### PR TITLE
chore: bump version to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "numa"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numa"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["razvandimescu <razvan@dimescu.com>"]
 edition = "2021"
 description = "Portable DNS resolver in Rust — .numa local domains, ad blocking, developer overrides, DNS-over-HTTPS"


### PR DESCRIPTION
## Summary

- Version bump to 0.9.1

Includes fixes since v0.9.0:
- **Forwarding rules in recursive mode** (#29) — Tailscale/VPN split DNS was ignored when `mode = "recursive"`
- **Browser search domain** — add `numa` as search domain on install so browsers resolve `.numa` without trailing slash

## Test plan

- [x] `cargo check` passes
- [x] Both fixes verified on macOS with Tailscale

🤖 Generated with [Claude Code](https://claude.com/claude-code)