### PR TITLE
[Feature] Add GitHub Dependabot scanning (runs once a month)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,34 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "monthly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Dependabot is GitHub’s built-in dependency update service. It monitors the dependency files in a repository, checks for newer or insecure versions, and opens pull requests to update them automatically.

It should be enabled because it reduces dependency drift, catches known vulnerable packages earlier, and keeps maintenance work small and routine instead of sporadic and risky. 

For this repo specifically, it can keep Rust crates, GitHub Actions, and Docker base images current with low overhead, while the existing CI validates whether an update is safe to merge.

**How to enable Dependabot:**

- Merge this PR into `main`
- In the repo, go to Settings → Advanced Security.
- Under Dependabot, enable all settings
- Once the config file is on `main`, Dependabot should run immediately and then continue on its monthly schedule.

After enabled, view:
- https://github.com/razvandimescu/numa/network/updates

Sample output:
- https://github.com/CaseyLabs/numa-fork/pulls