### PR TITLE
fix(ci): reclaim aur-repo ownership after docker chown

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -135,6 +135,12 @@ jobs:
             sudo -u builduser makepkg -od && sudo -u builduser makepkg --printsrcinfo > .SRCINFO
           "
 
+          # Reclaim ownership: the in-container 'chown -R builduser:builduser /pkg'
+          # propagates through the bind mount, leaving .git/ owned by the container's
+          # builduser UID. Without this, subsequent 'git config' on the host fails with
+          # "could not lock config file .git/config: Permission denied".
+          sudo chown -R "$(id -u):$(id -g)" .
+
           # Set the commit identity using secrets for security and auditability.
           git config user.name "$AUR_USER"
           git config user.email "$AUR_EMAIL"


### PR DESCRIPTION
## Summary
- Fixes the `Push to AUR` step in `publish-aur.yml` failing with `error: could not lock config file .git/config: Permission denied` (e.g. run [24195384571](https://github.com/razvandimescu/numa/actions/runs/24195384571)).
- Root cause: inside the docker block we `chown -R builduser:builduser /pkg`, which propagates through the bind mount and transfers ownership of the host's `aur-repo/` (including `.git/`) to the container's builduser UID. When control returns to the runner user, `git config user.name` can no longer write `.git/config` and the step exits 255.
- Fix: `sudo chown -R "$(id -u):$(id -g)" .` immediately after the docker block, before any host-side git ops.

## Test plan
- [ ] Merge to `main` and confirm the `Publish to AUR` job reaches `git push origin master` without a permission error.
- [ ] Confirm `.SRCINFO` and `PKGBUILD` land on the AUR repo as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)