### PR TITLE
fix(ci): repair broken quoting in publish-aur docker heredoc

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -131,7 +131,7 @@ jobs:
             chown -R builduser:builduser /pkg
             cd /pkg
             sudo -u builduser git config --global --add safe.directory '*'
-            # "makepkg -od" fetches the source first so pkgver() can calculate the version.
+            # makepkg -od fetches the source first so pkgver() can calculate the version.
             sudo -u builduser makepkg -od && sudo -u builduser makepkg --printsrcinfo > .SRCINFO
           "
 


### PR DESCRIPTION
## Summary
Follow-up to #49. With the ownership bug fixed, the next run ([24198410915](https://github.com/razvandimescu/numa/actions/runs/24198410915)) failed with:

```
fatal: pathspec '.SRCINFO' did not match any files
```

## Root cause
The docker block is wrapped in `/bin/bash -c "<multi-line script>"`. A comment inside the script contained embedded double quotes:

```
# "makepkg -od" fetches the source first so pkgver() can calculate the version.
```

The first embedded `"` prematurely closes the outer string. Bash then parses the remainder of the line into a **second argument** to `bash -c`, which becomes `$0` inside the container and is silently discarded. Net effect: the in-container script stops at `git config --add safe.directory '*'`, and neither `makepkg -od` nor `makepkg --printsrcinfo > .SRCINFO` ever runs.

This bug predates #49 but was masked by the ownership error firing first.

## Fix
Drop the embedded double quotes from the comment.

## Test plan
- [ ] Merge and confirm `Publish to AUR` runs `makepkg --printsrcinfo > .SRCINFO` and reaches `git push origin master` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)