### PR TITLE
fix(ci): skip prepare() in publish-aur metadata container

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -132,7 +132,10 @@ jobs:
             cd /pkg
             sudo -u builduser git config --global --add safe.directory '*'
             # makepkg -od fetches the source first so pkgver() can calculate the version.
-            sudo -u builduser makepkg -od && sudo -u builduser makepkg --printsrcinfo > .SRCINFO
+            # --noprepare skips the prepare() function, which invokes cargo and would
+            # otherwise require a full rust toolchain in this metadata-only container.
+            # pkgver() runs before prepare(), so .SRCINFO still gets the correct version.
+            sudo -u builduser makepkg -od --noprepare && sudo -u builduser makepkg --printsrcinfo > .SRCINFO
           "
 
           # Reclaim ownership: the in-container 'chown -R builduser:builduser /pkg'


### PR DESCRIPTION
## Summary
Third in a chain of fixes after #49 and #50. With ownership and quoting resolved, the next run ([24199871832](https://github.com/razvandimescu/numa/actions/runs/24199871832)) got all the way to \`makepkg\` and failed with:

\`\`\`
/pkg/PKGBUILD: line 34: cargo: command not found
==> ERROR: A failure occurred in prepare().
\`\`\`

## Root cause
The publish job's container only installs \`binutils git sudo\` because its only purpose is to regenerate \`.SRCINFO\`. But \`makepkg -od\` still runs \`prepare()\`, which invokes \`cargo\`. The sibling \`validate\` job sidesteps this with \`--noprepare\` (and installs \`rust\` anyway).

## Fix
Add \`--noprepare\` to the metadata-generation invocation. In makepkg's pipeline, \`pkgver()\` runs **before** \`prepare()\`, so \`.SRCINFO\` still captures the computed version — and we avoid dragging a ~100 MB rust toolchain into a container that only needs to parse PKGBUILD metadata.

## Test plan
- [ ] Merge and confirm \`Publish to AUR\` reaches \`git push origin master\` successfully.
- [ ] Confirm the published \`.SRCINFO\` on the AUR repo has a correctly computed \`pkgver\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)