### PR TITLE
fix: escape DNS label text per RFC 1035 §5.1 (closes #36)

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -84,6 +84,11 @@ impl BytePacketBuffer {
 
     /// Read a qname, handling label compression (pointer jumps).
     /// Converts wire format like [3]www[6]google[3]com[0] into "www.google.com".
+    ///
+    /// Label bytes are escaped per RFC 1035 §5.1:
+    /// - literal `.` within a label → `\.`
+    /// - literal `\` → `\\`
+    /// - bytes outside `0x21..=0x7E` (excluding `.` and `\`) → `\DDD` (3-digit decimal)
     pub fn read_qname(&mut self, outstr: &mut String) -> Result<()> {
         let mut pos = self.pos();
         let mut jumped = false;
@@ -121,7 +126,13 @@ impl BytePacketBuffer {
 
                 let str_buffer = self.get_range(pos, len as usize)?;
                 for &b in str_buffer {
-                    outstr.push(b.to_ascii_lowercase() as char);
+                    let c = b.to_ascii_lowercase();
+                    match c {
+                        b'.' => outstr.push_str("\\."),
+                        b'\\' => outstr.push_str("\\\\"),
+                        0x21..=0x7E => outstr.push(c as char),
+                        _ => outstr.push_str(&format!("\\{:03}", c)),
+                    }
                 }
 
                 delim = ".";
@@ -163,23 +174,23 @@ impl BytePacketBuffer {
         Ok(())
     }
 
+    /// Write a qname in wire format, parsing RFC 1035 §5.1 text escapes.
+    ///
+    /// Dots are label separators unless escaped as `\.`. `\\` yields a literal
+    /// backslash, and `\DDD` (three decimal digits) yields an arbitrary byte.
     pub fn write_qname(&mut self, qname: &str) -> Result<()> {
         if qname.is_empty() || qname == "." {
             self.write_u8(0)?;
             return Ok(());
         }
 
-        for label in qname.split('.') {
-            let len = label.len();
-            if len == 0 {
-                continue; // skip empty labels from trailing dot
-            }
-            if len > 0x3f {
+        let labels = parse_escaped_labels(qname)?;
+        for label in &labels {
+            if label.len() > 0x3f {
                 return Err("Single label exceeds 63 characters of length".into());
             }
-
-            self.write_u8(len as u8)?;
-            for b in label.as_bytes() {
+            self.write_u8(label.len() as u8)?;
+            for b in label {
                 self.write_u8(*b)?;
             }
         }
@@ -210,5 +221,182 @@ impl BytePacketBuffer {
         self.set(pos, (val >> 8) as u8)?;
         self.set(pos + 1, (val & 0xFF) as u8)?;
         Ok(())
+    }
+}
+
+fn parse_escaped_labels(qname: &str) -> Result<Vec<Vec<u8>>> {
+    let mut labels: Vec<Vec<u8>> = Vec::new();
+    let mut current: Vec<u8> = Vec::new();
+    let mut chars = qname.chars();
+
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some(d1) if d1.is_ascii_digit() => {
+                    let d2 = chars
+                        .next()
+                        .and_then(|c| c.to_digit(10))
+                        .ok_or("invalid \\DDD escape: expected 3 digits")?;
+                    let d3 = chars
+                        .next()
+                        .and_then(|c| c.to_digit(10))
+                        .ok_or("invalid \\DDD escape: expected 3 digits")?;
+                    let val = d1.to_digit(10).unwrap() * 100 + d2 * 10 + d3;
+                    if val > 255 {
+                        return Err(format!("\\DDD escape out of range: {}", val).into());
+                    }
+                    current.push(val as u8);
+                }
+                Some(other) => {
+                    let mut buf = [0u8; 4];
+                    current.extend_from_slice(other.encode_utf8(&mut buf).as_bytes());
+                }
+                None => return Err("trailing backslash in qname".into()),
+            }
+        } else if c == '.' {
+            if !current.is_empty() {
+                labels.push(std::mem::take(&mut current));
+            }
+        } else {
+            let mut buf = [0u8; 4];
+            current.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+        }
+    }
+    if !current.is_empty() {
+        labels.push(current);
+    }
+    Ok(labels)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(wire: &[u8]) -> String {
+        let mut buf = BytePacketBuffer::from_bytes(wire);
+        let mut out = String::new();
+        buf.read_qname(&mut out).unwrap();
+        out
+    }
+
+    fn write_then_read(text: &str) -> String {
+        let mut buf = BytePacketBuffer::new();
+        buf.write_qname(text).unwrap();
+        let wire_end = buf.pos();
+        buf.seek(0).unwrap();
+        let mut out = String::new();
+        buf.read_qname(&mut out).unwrap();
+        assert_eq!(
+            buf.pos(),
+            wire_end,
+            "reader should consume exactly what writer wrote"
+        );
+        out
+    }
+
+    #[test]
+    fn read_plain_domain() {
+        // [3]www[6]google[3]com[0]
+        let wire = b"\x03www\x06google\x03com\x00";
+        assert_eq!(roundtrip(wire), "www.google.com");
+    }
+
+    #[test]
+    fn read_label_with_literal_dot_is_escaped() {
+        // fanf2's example: [8]exa.mple[3]com[0] — two labels, first contains 0x2E
+        let wire = b"\x08exa.mple\x03com\x00";
+        assert_eq!(roundtrip(wire), "exa\\.mple.com");
+    }
+
+    #[test]
+    fn read_label_with_backslash_is_escaped() {
+        // [4]a\bc[3]com[0]
+        let wire = b"\x04a\\bc\x03com\x00";
+        assert_eq!(roundtrip(wire), "a\\\\bc.com");
+    }
+
+    #[test]
+    fn read_label_with_nonprintable_byte_uses_decimal_escape() {
+        // [4]\x00foo[3]com[0] — null byte at label start
+        let wire = b"\x04\x00foo\x03com\x00";
+        assert_eq!(roundtrip(wire), "\\000foo.com");
+    }
+
+    #[test]
+    fn read_label_with_space_uses_decimal_escape() {
+        // Space (0x20) is outside 0x21..=0x7E, so it must be decimal-escaped.
+        let wire = b"\x05a b c\x00";
+        assert_eq!(roundtrip(wire), "a\\032b\\032c");
+    }
+
+    #[test]
+    fn write_plain_domain() {
+        let mut buf = BytePacketBuffer::new();
+        buf.write_qname("www.google.com").unwrap();
+        assert_eq!(&buf.buf[..buf.pos], b"\x03www\x06google\x03com\x00");
+    }
+
+    #[test]
+    fn write_escaped_dot_does_not_split_label() {
+        let mut buf = BytePacketBuffer::new();
+        buf.write_qname("exa\\.mple.com").unwrap();
+        assert_eq!(&buf.buf[..buf.pos], b"\x08exa.mple\x03com\x00");
+    }
+
+    #[test]
+    fn write_escaped_backslash() {
+        let mut buf = BytePacketBuffer::new();
+        buf.write_qname("a\\\\bc.com").unwrap();
+        assert_eq!(&buf.buf[..buf.pos], b"\x04a\\bc\x03com\x00");
+    }
+
+    #[test]
+    fn write_decimal_escape_yields_raw_byte() {
+        let mut buf = BytePacketBuffer::new();
+        buf.write_qname("\\000foo.com").unwrap();
+        assert_eq!(&buf.buf[..buf.pos], b"\x04\x00foo\x03com\x00");
+    }
+
+    #[test]
+    fn write_rejects_out_of_range_decimal_escape() {
+        let mut buf = BytePacketBuffer::new();
+        assert!(buf.write_qname("\\999foo.com").is_err());
+    }
+
+    #[test]
+    fn write_rejects_trailing_backslash() {
+        let mut buf = BytePacketBuffer::new();
+        assert!(buf.write_qname("foo\\").is_err());
+    }
+
+    #[test]
+    fn write_rejects_short_decimal_escape() {
+        let mut buf = BytePacketBuffer::new();
+        assert!(buf.write_qname("\\1").is_err());
+    }
+
+    #[test]
+    fn roundtrip_preserves_dot_in_label() {
+        assert_eq!(write_then_read("exa\\.mple.com"), "exa\\.mple.com");
+    }
+
+    #[test]
+    fn roundtrip_preserves_backslash_in_label() {
+        assert_eq!(write_then_read("a\\\\b.com"), "a\\\\b.com");
+    }
+
+    #[test]
+    fn roundtrip_preserves_nonprintable_byte() {
+        assert_eq!(write_then_read("\\000foo.com"), "\\000foo.com");
+    }
+
+    #[test]
+    fn root_name_empty_and_dot_both_produce_single_zero() {
+        let mut a = BytePacketBuffer::new();
+        a.write_qname("").unwrap();
+        let mut b = BytePacketBuffer::new();
+        b.write_qname(".").unwrap();
+        assert_eq!(&a.buf[..a.pos], b"\x00");
+        assert_eq!(&b.buf[..b.pos], b"\x00");
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -180,13 +180,7 @@ impl BytePacketBuffer {
     }
 
     /// Write a qname in wire format, parsing RFC 1035 §5.1 text escapes.
-    ///
-    /// Dots are label separators unless escaped as `\.`. `\\` yields a literal
-    /// backslash, and `\DDD` (three decimal digits) yields an arbitrary byte.
-    ///
-    /// Streams directly into the buffer by reserving a length byte, writing
-    /// the label body, then backpatching the length. Zero intermediate
-    /// allocations on the common path.
+    /// See `read_qname` for the escape grammar.
     pub fn write_qname(&mut self, qname: &str) -> Result<()> {
         if qname.is_empty() || qname == "." {
             self.write_u8(0)?;
@@ -369,6 +363,19 @@ mod tests {
     }
 
     #[test]
+    fn write_skips_empty_labels() {
+        // Leading dot — first (empty) label is rolled back.
+        let mut buf = BytePacketBuffer::new();
+        buf.write_qname(".foo.com").unwrap();
+        assert_eq!(&buf.buf[..buf.pos], b"\x03foo\x03com\x00");
+
+        // Consecutive dots — middle empty label is rolled back.
+        let mut buf = BytePacketBuffer::new();
+        buf.write_qname("foo..com").unwrap();
+        assert_eq!(&buf.buf[..buf.pos], b"\x03foo\x03com\x00");
+    }
+
+    #[test]
     fn write_rejects_out_of_range_decimal_escape() {
         let mut buf = BytePacketBuffer::new();
         assert!(buf.write_qname("\\999foo.com").is_err());
@@ -384,6 +391,17 @@ mod tests {
     fn write_rejects_short_decimal_escape() {
         let mut buf = BytePacketBuffer::new();
         assert!(buf.write_qname("\\1").is_err());
+    }
+
+    #[test]
+    fn write_rejects_label_over_63_bytes() {
+        // 64 bytes exceeds the wire-format label cap.
+        let mut buf = BytePacketBuffer::new();
+        assert!(buf.write_qname(&"a".repeat(64)).is_err());
+
+        // 63 bytes is the maximum permitted label length.
+        let mut buf = BytePacketBuffer::new();
+        assert!(buf.write_qname(&"a".repeat(63)).is_ok());
     }
 
     #[test]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -131,7 +131,12 @@ impl BytePacketBuffer {
                         b'.' => outstr.push_str("\\."),
                         b'\\' => outstr.push_str("\\\\"),
                         0x21..=0x7E => outstr.push(c as char),
-                        _ => outstr.push_str(&format!("\\{:03}", c)),
+                        _ => {
+                            outstr.push('\\');
+                            outstr.push((b'0' + c / 100) as char);
+                            outstr.push((b'0' + (c / 10) % 10) as char);
+                            outstr.push((b'0' + c % 10) as char);
+                        }
                     }
                 }
 
@@ -178,20 +183,70 @@ impl BytePacketBuffer {
     ///
     /// Dots are label separators unless escaped as `\.`. `\\` yields a literal
     /// backslash, and `\DDD` (three decimal digits) yields an arbitrary byte.
+    ///
+    /// Streams directly into the buffer by reserving a length byte, writing
+    /// the label body, then backpatching the length. Zero intermediate
+    /// allocations on the common path.
     pub fn write_qname(&mut self, qname: &str) -> Result<()> {
         if qname.is_empty() || qname == "." {
             self.write_u8(0)?;
             return Ok(());
         }
 
-        let labels = parse_escaped_labels(qname)?;
-        for label in &labels {
-            if label.len() > 0x3f {
-                return Err("Single label exceeds 63 characters of length".into());
+        let bytes = qname.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            let len_pos = self.pos;
+            self.write_u8(0)?; // placeholder length byte, backpatched below
+            let body_start = self.pos;
+
+            while i < bytes.len() && bytes[i] != b'.' {
+                let b = bytes[i];
+                if b == b'\\' {
+                    i += 1;
+                    let c1 = *bytes.get(i).ok_or("trailing backslash in qname")?;
+                    if c1.is_ascii_digit() {
+                        let c2 = *bytes
+                            .get(i + 1)
+                            .ok_or("invalid \\DDD escape: expected 3 digits")?;
+                        let c3 = *bytes
+                            .get(i + 2)
+                            .ok_or("invalid \\DDD escape: expected 3 digits")?;
+                        if !c2.is_ascii_digit() || !c3.is_ascii_digit() {
+                            return Err("invalid \\DDD escape: expected 3 digits".into());
+                        }
+                        let val =
+                            (c1 - b'0') as u16 * 100 + (c2 - b'0') as u16 * 10 + (c3 - b'0') as u16;
+                        if val > 255 {
+                            return Err(format!("\\DDD escape out of range: {}", val).into());
+                        }
+                        self.write_u8(val as u8)?;
+                        i += 3;
+                    } else {
+                        // \. \\ and any other \X → literal next byte
+                        self.write_u8(c1)?;
+                        i += 1;
+                    }
+                } else {
+                    self.write_u8(b)?;
+                    i += 1;
+                }
+
+                if self.pos - body_start > 0x3f {
+                    return Err("Single label exceeds 63 characters of length".into());
+                }
             }
-            self.write_u8(label.len() as u8)?;
-            for b in label {
-                self.write_u8(*b)?;
+
+            let label_len = self.pos - body_start;
+            if label_len == 0 && i < bytes.len() {
+                // Empty label from leading/consecutive dots — roll back the placeholder.
+                self.pos = len_pos;
+            } else {
+                self.set(len_pos, label_len as u8)?;
+            }
+
+            if i < bytes.len() && bytes[i] == b'.' {
+                i += 1;
             }
         }
 
@@ -222,50 +277,6 @@ impl BytePacketBuffer {
         self.set(pos + 1, (val & 0xFF) as u8)?;
         Ok(())
     }
-}
-
-fn parse_escaped_labels(qname: &str) -> Result<Vec<Vec<u8>>> {
-    let mut labels: Vec<Vec<u8>> = Vec::new();
-    let mut current: Vec<u8> = Vec::new();
-    let mut chars = qname.chars();
-
-    while let Some(c) = chars.next() {
-        if c == '\\' {
-            match chars.next() {
-                Some(d1) if d1.is_ascii_digit() => {
-                    let d2 = chars
-                        .next()
-                        .and_then(|c| c.to_digit(10))
-                        .ok_or("invalid \\DDD escape: expected 3 digits")?;
-                    let d3 = chars
-                        .next()
-                        .and_then(|c| c.to_digit(10))
-                        .ok_or("invalid \\DDD escape: expected 3 digits")?;
-                    let val = d1.to_digit(10).unwrap() * 100 + d2 * 10 + d3;
-                    if val > 255 {
-                        return Err(format!("\\DDD escape out of range: {}", val).into());
-                    }
-                    current.push(val as u8);
-                }
-                Some(other) => {
-                    let mut buf = [0u8; 4];
-                    current.extend_from_slice(other.encode_utf8(&mut buf).as_bytes());
-                }
-                None => return Err("trailing backslash in qname".into()),
-            }
-        } else if c == '.' {
-            if !current.is_empty() {
-                labels.push(std::mem::take(&mut current));
-            }
-        } else {
-            let mut buf = [0u8; 4];
-            current.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
-        }
-    }
-    if !current.is_empty() {
-        labels.push(current);
-    }
-    Ok(labels)
 }
 
 #[cfg(test)]

--- a/src/dnssec.rs
+++ b/src/dnssec.rs
@@ -722,14 +722,10 @@ pub fn verify_ds(ds: &DnsRecord, dnskey: &DnsRecord, owner: &str) -> bool {
 // -- Canonical wire format --
 
 /// Encode a DNS name in canonical wire form per RFC 4034 §6.2:
-/// uncompressed, with all ASCII letters lowercased.
+/// uncompressed, with ASCII letters lowercased.
 ///
-/// Label parsing and RFC 1035 §5.1 escape handling live in
-/// `BytePacketBuffer::write_qname`; this function then walks the emitted
-/// wire bytes once to lowercase label bodies (length bytes stay untouched).
-/// Lowercasing has to happen post-escape-resolution because a decimal
-/// escape like `\065` yields `'A'`, which canonical form must convert
-/// to `'a'`.
+/// Lowercasing happens *after* escape resolution because `\065` yields
+/// `'A'`, which canonical form must convert to `'a'`.
 pub fn name_to_wire(name: &str) -> Vec<u8> {
     let mut buf = BytePacketBuffer::new();
     buf.write_qname(name)

--- a/src/dnssec.rs
+++ b/src/dnssec.rs
@@ -5,6 +5,7 @@ use log::{debug, trace};
 use ring::digest;
 use ring::signature;
 
+use crate::buffer::BytePacketBuffer;
 use crate::cache::{DnsCache, DnssecStatus};
 use crate::packet::DnsPacket;
 use crate::question::QueryType;
@@ -720,22 +721,33 @@ pub fn verify_ds(ds: &DnsRecord, dnskey: &DnsRecord, owner: &str) -> bool {
 
 // -- Canonical wire format --
 
+/// Encode a DNS name in canonical wire form per RFC 4034 §6.2:
+/// uncompressed, with all ASCII letters lowercased.
+///
+/// Delegates label parsing and RFC 1035 §5.1 escape handling to
+/// `BytePacketBuffer::write_qname`, then post-processes the emitted bytes
+/// to lowercase label bodies (length bytes stay untouched). This keeps
+/// the escape logic in exactly one place — see #55.
 pub fn name_to_wire(name: &str) -> Vec<u8> {
-    let mut wire = Vec::with_capacity(name.len() + 2);
-    if name == "." || name.is_empty() {
-        wire.push(0);
-        return wire;
-    }
-    for label in name.split('.') {
-        if label.is_empty() {
-            continue;
+    let mut buf = BytePacketBuffer::new();
+    buf.write_qname(name)
+        .expect("DNSSEC canonical form: name must be a well-formed DNS name");
+    let mut wire = buf.filled().to_vec();
+
+    let mut i = 0;
+    while i < wire.len() {
+        let label_len = wire[i] as usize;
+        if label_len == 0 {
+            break;
         }
-        wire.push(label.len() as u8);
-        for &b in label.as_bytes() {
-            wire.push(b.to_ascii_lowercase());
+        i += 1;
+        let end = i + label_len;
+        for b in &mut wire[i..end] {
+            *b = b.to_ascii_lowercase();
         }
+        i = end;
     }
-    wire.push(0);
+
     wire
 }
 
@@ -1473,6 +1485,23 @@ mod tests {
             wire,
             vec![7, b'e', b'x', b'a', b'm', b'p', b'l', b'e', 3, b'c', b'o', b'm', 0]
         );
+    }
+
+    #[test]
+    fn name_to_wire_escaped_dot_in_label_is_not_a_separator() {
+        // `exa\.mple.com` is two labels: `exa.mple` (8 bytes including the 0x2E) and `com`.
+        let wire = name_to_wire("exa\\.mple.com");
+        assert_eq!(
+            wire,
+            vec![8, b'e', b'x', b'a', b'.', b'm', b'p', b'l', b'e', 3, b'c', b'o', b'm', 0]
+        );
+    }
+
+    #[test]
+    fn name_to_wire_decimal_escape_is_lowercased() {
+        // `\065` is the byte 0x41 ('A'), which canonical form must lowercase to 'a'.
+        let wire = name_to_wire("\\065bc.com");
+        assert_eq!(wire, vec![3, b'a', b'b', b'c', 3, b'c', b'o', b'm', 0]);
     }
 
     #[test]

--- a/src/dnssec.rs
+++ b/src/dnssec.rs
@@ -724,14 +724,16 @@ pub fn verify_ds(ds: &DnsRecord, dnskey: &DnsRecord, owner: &str) -> bool {
 /// Encode a DNS name in canonical wire form per RFC 4034 §6.2:
 /// uncompressed, with all ASCII letters lowercased.
 ///
-/// Delegates label parsing and RFC 1035 §5.1 escape handling to
-/// `BytePacketBuffer::write_qname`, then post-processes the emitted bytes
-/// to lowercase label bodies (length bytes stay untouched). This keeps
-/// the escape logic in exactly one place — see #55.
+/// Label parsing and RFC 1035 §5.1 escape handling live in
+/// `BytePacketBuffer::write_qname`; this function then walks the emitted
+/// wire bytes once to lowercase label bodies (length bytes stay untouched).
+/// Lowercasing has to happen post-escape-resolution because a decimal
+/// escape like `\065` yields `'A'`, which canonical form must convert
+/// to `'a'`.
 pub fn name_to_wire(name: &str) -> Vec<u8> {
     let mut buf = BytePacketBuffer::new();
     buf.write_qname(name)
-        .expect("DNSSEC canonical form: name must be a well-formed DNS name");
+        .expect("name_to_wire: input must parse as a valid DNS name");
     let mut wire = buf.filled().to_vec();
 
     let mut i = 0;
@@ -742,9 +744,7 @@ pub fn name_to_wire(name: &str) -> Vec<u8> {
         }
         i += 1;
         let end = i + label_len;
-        for b in &mut wire[i..end] {
-            *b = b.to_ascii_lowercase();
-        }
+        wire[i..end].make_ascii_lowercase();
         i = end;
     }
 
@@ -1499,7 +1499,7 @@ mod tests {
 
     #[test]
     fn name_to_wire_decimal_escape_is_lowercased() {
-        // `\065` is the byte 0x41 ('A'), which canonical form must lowercase to 'a'.
+        // \065 = 'A', must become 'a' in canonical form.
         let wire = name_to_wire("\\065bc.com");
         assert_eq!(wire, vec![3, b'a', b'b', b'c', 3, b'c', b'o', b'm', 0]);
     }


### PR DESCRIPTION
Closes #36.
Closes #55.

## Bug

`read_qname` pushed raw label bytes directly into the output string, producing ambiguous text for labels containing dots, backslashes, or non-printable bytes. fanf2 [spotted this on HN](https://news.ycombinator.com/item?id=47612321):

> Wire format `[8]exa.mple[3]com[0]` (two labels, first containing a literal `0x2E`) was rendered as `exa.mple.com`, indistinguishable from three labels.

Code review of the first fix cut also surfaced that `src/dnssec.rs::name_to_wire` was a parallel implementation of the old `write_qname` splitting loop — it predated and duplicated the buffer.rs logic, and was similarly broken for escaped labels. Both sides of the DNSSEC canonical form pipeline were silently wrong in the same way; making `read_qname` correct exposed the divergence, so it's fixed here in the same PR (#55).

## Fix

Both sides of the text representation now follow RFC 1035 §5.1, and DNSSEC canonical form delegates to the same code path.

### `read_qname` — rendering wire bytes to text

- literal `.` within a label → `\.`
- literal `\` → `\\`
- bytes outside `0x21..=0x7E` → `\DDD` (3-digit decimal)
- printable ASCII passes through unchanged (fast path, no regression)

### `write_qname` — parsing text back to wire

- `\.` produces a literal `0x2E` inside the current label (not a separator)
- `\\` produces a literal `0x5C`
- `\DDD` produces the byte with that decimal value (`0..=255`)
- unescaped `.` still separates labels; empty labels (leading/trailing/consecutive dots) still skipped
- rejects trailing `\`, short `\DD`, and `\DDD > 255`
- 63-byte label cap checked incrementally so oversized labels fail fast

Implementation is a **streaming byte-level pass**: reserve a length byte, write the label body directly into the buffer, backpatch the length via `set()`. Zero intermediate allocations on the common path. Byte-level scanning is safe for UTF-8 input because continuation bytes (`0x80..=0xBF`) never collide with ASCII `.` (0x2E) or `\` (0x5C).

`read_qname`'s `\DDD` rendering also inlines the decimal digits to avoid a per-byte `format!` allocation on non-printable input.

### `dnssec::name_to_wire` — DNSSEC canonical form

Reimplemented on top of `BytePacketBuffer::write_qname`: scratch buffer → `write_qname` → copy filled bytes → post-walk to lowercase label bodies (length bytes untouched). Lowercasing has to happen post-escape-resolution because a decimal escape like `\065` yields `0x41` (`'A'`) which must become `'a'` in canonical form per RFC 4034 §6.2.

Call sites in `build_signed_data`, `record_to_canonical_wire`, `record_rdata_canonical`, and `nsec3_hash` are unchanged — `name_to_wire`'s public signature stays the same, infallible `Vec<u8>` return.

## Impact

Low in practice — real-world domains don't contain dots in labels — but this is a correctness bug in the wire format parser and the DNSSEC canonical form builder, which is the core of the project. Correctness bugs take priority over practical impact.

Performance: streaming implementation means **zero allocations on the common `write_qname` path**, matching `main`. The first iteration of this PR went via a `Vec<Vec<u8>>` helper; code review caught that `bench_buffer_serialize` calls `write_qname` ~6 times per response, so that approach would have added ~24 extra allocations per response. The streaming rewrite (commit 2) fixes that.

## Tests

18 new unit tests across `src/buffer.rs` (16) and `src/dnssec.rs` (2). `buffer.rs` had no tests before this PR.

**Buffer — read side**
- `read_plain_domain`
- `read_label_with_literal_dot_is_escaped` — fanf2's exact example
- `read_label_with_backslash_is_escaped`
- `read_label_with_nonprintable_byte_uses_decimal_escape`
- `read_label_with_space_uses_decimal_escape`

**Buffer — write side**
- `write_plain_domain`
- `write_escaped_dot_does_not_split_label`
- `write_escaped_backslash`
- `write_decimal_escape_yields_raw_byte`
- `write_rejects_out_of_range_decimal_escape` (`\999`)
- `write_rejects_trailing_backslash`
- `write_rejects_short_decimal_escape` (`\1`)

**Buffer — round-trip**
- `roundtrip_preserves_dot_in_label`
- `roundtrip_preserves_backslash_in_label`
- `roundtrip_preserves_nonprintable_byte`
- `root_name_empty_and_dot_both_produce_single_zero`

**DNSSEC canonical form**
- `name_to_wire_escaped_dot_in_label_is_not_a_separator`
- `name_to_wire_decimal_escape_is_lowercased` — verifies post-escape-resolution lowercasing

Existing `name_to_wire_root`, `name_to_wire_domain`, and `ds_verification` tests continue to pass unchanged.

Total test count: 142 → 160.

## Test plan

- [x] `cargo test --lib` — 160 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] CI green on all three platforms

## Commits

1. `fix: escape DNS label text per RFC 1035 §5.1` — initial fix in `buffer.rs`
2. `refactor: stream label writes directly into buffer` — addresses review feedback on allocation overhead in `write_qname`
3. `fix: route dnssec::name_to_wire through write_qname for escape handling` — addresses #55 (surfaced by the review)

## Credit

[fanf2](https://news.ycombinator.com/item?id=47612321) on HN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)