### PR TITLE
fix: drop include:scope from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
     groups:
       minor-and-patch:
         patterns: ["*"]
@@ -18,7 +17,6 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
     groups:
       minor-and-patch:
         patterns: ["*"]
@@ -30,7 +28,6 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
     groups:
       minor-and-patch:
         patterns: ["*"]


### PR DESCRIPTION
## Summary
- Removes `include: "scope"` from all three dependabot ecosystems
- Fixes `chore(deps)(deps):` double-scope in commit messages → now `chore(deps):`

## Context
Introduced in #46. The `prefix: "chore(deps)"` already contains the scope; adding `include: "scope"` caused Dependabot to append a second `(deps)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)