### PR TITLE
chore(deps): bump rcgen from 0.13 to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -103,15 +103,15 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror",
  "time",
 ]
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -449,9 +449,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -1162,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]
@@ -1309,7 +1309,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -1330,7 +1330,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1416,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
  "pem",
  "ring",
@@ -1747,31 +1747,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2383,9 +2363,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs",
  "data-encoding",
@@ -2395,7 +2375,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
 http-body-util = "0.1"
 futures = "0.3"
 socket2 = { version = "0.6", features = ["all"] }
-rcgen = { version = "0.13", features = ["pem", "x509-parser"] }
+rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
 time = "0.3"
 rustls = "0.23"
 tokio-rustls = "0.26"

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use log::{info, warn};
 
 use crate::ctx::ServerCtx;
-use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose, SanType};
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType,
+};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::ServerConfig;
 use time::{Duration, OffsetDateTime};
@@ -87,8 +89,8 @@ pub fn build_tls_config(
     alpn: Vec<Vec<u8>>,
     data_dir: &Path,
 ) -> crate::Result<Arc<ServerConfig>> {
-    let (ca_cert, ca_key) = ensure_ca(data_dir)?;
-    let (cert_chain, key) = generate_service_cert(&ca_cert, &ca_key, tld, service_names)?;
+    let (ca_der, issuer) = ensure_ca(data_dir)?;
+    let (cert_chain, key) = generate_service_cert(&ca_der, &issuer, tld, service_names)?;
 
     // Ensure a crypto provider is installed (rustls needs one)
     let _ = rustls::crypto::ring::default_provider().install_default();
@@ -106,7 +108,7 @@ pub fn build_tls_config(
     Ok(Arc::new(config))
 }
 
-fn ensure_ca(dir: &Path) -> crate::Result<(rcgen::Certificate, KeyPair)> {
+fn ensure_ca(dir: &Path) -> crate::Result<(CertificateDer<'static>, Issuer<'static, KeyPair>)> {
     let ca_key_path = dir.join("ca.key");
     let ca_cert_path = dir.join(CA_FILE_NAME);
 
@@ -114,10 +116,12 @@ fn ensure_ca(dir: &Path) -> crate::Result<(rcgen::Certificate, KeyPair)> {
         let key_pem = std::fs::read_to_string(&ca_key_path)?;
         let cert_pem = std::fs::read_to_string(&ca_cert_path)?;
         let key_pair = KeyPair::from_pem(&key_pem)?;
-        let params = CertificateParams::from_ca_cert_pem(&cert_pem)?;
-        let cert = params.self_signed(&key_pair)?;
+        let ca_der = rustls_pemfile::certs(&mut cert_pem.as_bytes())
+            .next()
+            .ok_or("empty CA PEM file")??;
+        let issuer = Issuer::from_ca_cert_der(&ca_der, key_pair)?;
         info!("loaded CA from {:?}", ca_cert_path);
-        return Ok((cert, key_pair));
+        return Ok((ca_der, issuer));
     }
 
     // Generate new CA
@@ -145,14 +149,16 @@ fn ensure_ca(dir: &Path) -> crate::Result<(rcgen::Certificate, KeyPair)> {
     }
 
     info!("generated CA at {:?}", ca_cert_path);
-    Ok((cert, key_pair))
+    let ca_der = cert.der().clone();
+    let issuer = Issuer::new(params, key_pair);
+    Ok((ca_der, issuer))
 }
 
 /// Generate a cert with explicit SANs for each service name.
 /// Always regenerated at startup (~5ms) — no disk caching needed.
 fn generate_service_cert(
-    ca_cert: &rcgen::Certificate,
-    ca_key: &KeyPair,
+    ca_der: &CertificateDer<'static>,
+    issuer: &Issuer<'_, KeyPair>,
     tld: &str,
     service_names: &[String],
 ) -> crate::Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
@@ -187,7 +193,7 @@ fn generate_service_cert(
     params.not_before = OffsetDateTime::now_utc();
     params.not_after = OffsetDateTime::now_utc() + Duration::days(CERT_VALIDITY_DAYS);
 
-    let cert = params.signed_by(&key_pair, ca_cert, ca_key)?;
+    let cert = params.signed_by(&key_pair, issuer)?;
 
     info!(
         "generated TLS cert for: {}",
@@ -198,11 +204,11 @@ fn generate_service_cert(
             .join(", ")
     );
 
-    let cert_der = CertificateDer::from(cert.der().to_vec());
-    let ca_der = CertificateDer::from(ca_cert.der().to_vec());
+    let cert_der = cert.der().clone();
+    let ca_cert_der = ca_der.clone();
     let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
 
-    Ok((vec![cert_der, ca_der], key_der))
+    Ok((vec![cert_der, ca_cert_der], key_der))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Bumps `rcgen` from 0.13.2 to 0.14.7 — closes #66 (Dependabot couldn't merge due to breaking API changes)
- Migrates `src/tls.rs` to the new `Issuer` API: `Certificate` + `KeyPair` args → unified `Issuer` type
- Load path uses `Issuer::from_ca_cert_der` (eliminates the old self-signed re-signing round-trip)
- Generate path uses `Issuer::new(params, key_pair)` (constructs directly, no DER re-parse)
- Drops `thiserror v1` from the dependency tree (rcgen 0.14 uses v2, already pulled by other deps)

## Test plan

- [x] `cargo test --lib` — 142 passed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] CI green on all three platforms
- [x] Smoke test: `numa` starts, generates CA cert, serves `.numa` domains over HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)