### PR TITLE
ci: use pandoc/actions/setup instead of apt-get

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pandoc
-        run: sudo apt-get install -y pandoc
+        uses: pandoc/actions/setup@v1
       - name: Generate blog HTML
         run: make blog
       - name: Setup Pages


### PR DESCRIPTION
## Summary
- Replace `sudo apt-get install -y pandoc` with `pandoc/actions/setup@v1`
- apt index refresh was taking ~27 minutes; prebuilt binary completes in seconds

## Test plan
- [x] Pages deploy workflow completes in under 2 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)