### PR TITLE
feat: cache warming for configured domains

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -82,6 +82,29 @@ impl DnsCache {
         Some((packet, entry.dnssec_status))
     }
 
+    pub fn ttl_remaining(&self, domain: &str, qtype: QueryType) -> Option<(u32, u32)> {
+        let type_map = self.entries.get(domain)?;
+        let entry = type_map.get(&qtype)?;
+        let elapsed = entry.inserted_at.elapsed();
+        if elapsed >= entry.ttl {
+            return None;
+        }
+        let total = entry.ttl.as_secs() as u32;
+        let remaining = (entry.ttl - elapsed).as_secs() as u32;
+        Some((remaining, total))
+    }
+
+    pub fn needs_warm(&self, domain: &str) -> bool {
+        for qtype in [QueryType::A, QueryType::AAAA] {
+            match self.ttl_remaining(domain, qtype) {
+                None => return true,
+                Some((remaining, total)) if remaining < total / 4 => return true,
+                _ => {}
+            }
+        }
+        false
+    }
+
     pub fn insert(&mut self, domain: &str, qtype: QueryType, packet: &DnsPacket) {
         self.insert_with_status(domain, qtype, packet, DnssecStatus::Indeterminate);
     }
@@ -232,5 +255,67 @@ mod tests {
         });
         cache.insert("example.com", QueryType::A, &pkt);
         assert!(cache.heap_bytes() > empty);
+    }
+
+    #[test]
+    fn ttl_remaining_returns_values_for_fresh_entry() {
+        let mut cache = DnsCache::new(100, 60, 3600);
+        let mut pkt = DnsPacket::new();
+        pkt.answers.push(DnsRecord::A {
+            domain: "example.com".into(),
+            addr: "1.2.3.4".parse().unwrap(),
+            ttl: 300,
+        });
+        cache.insert("example.com", QueryType::A, &pkt);
+        let (remaining, total) = cache.ttl_remaining("example.com", QueryType::A).unwrap();
+        assert_eq!(total, 300);
+        assert!(remaining <= 300);
+        assert!(remaining > 0);
+    }
+
+    #[test]
+    fn ttl_remaining_none_for_missing() {
+        let cache = DnsCache::new(100, 1, 3600);
+        assert!(cache.ttl_remaining("missing.com", QueryType::A).is_none());
+    }
+
+    #[test]
+    fn needs_warm_true_when_missing() {
+        let cache = DnsCache::new(100, 1, 3600);
+        assert!(cache.needs_warm("missing.com"));
+    }
+
+    #[test]
+    fn needs_warm_false_when_fresh() {
+        let mut cache = DnsCache::new(100, 1, 3600);
+        let mut pkt_a = DnsPacket::new();
+        pkt_a.answers.push(DnsRecord::A {
+            domain: "example.com".into(),
+            addr: "1.2.3.4".parse().unwrap(),
+            ttl: 300,
+        });
+        let mut pkt_aaaa = DnsPacket::new();
+        pkt_aaaa.answers.push(DnsRecord::AAAA {
+            domain: "example.com".into(),
+            addr: "::1".parse().unwrap(),
+            ttl: 300,
+        });
+        cache.insert("example.com", QueryType::A, &pkt_a);
+        cache.insert("example.com", QueryType::AAAA, &pkt_aaaa);
+        assert!(!cache.needs_warm("example.com"));
+    }
+
+    #[test]
+    fn needs_warm_true_when_only_a_cached() {
+        let mut cache = DnsCache::new(100, 1, 3600);
+        let mut pkt = DnsPacket::new();
+        pkt.answers.push(DnsRecord::A {
+            domain: "example.com".into(),
+            addr: "1.2.3.4".parse().unwrap(),
+            ttl: 300,
+        });
+        cache.insert("example.com", QueryType::A, &pkt);
+        // AAAA missing → needs warm
+        assert!(cache.needs_warm("example.com"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -247,6 +247,8 @@ pub struct CacheConfig {
     pub min_ttl: u32,
     #[serde(default = "default_max_ttl")]
     pub max_ttl: u32,
+    #[serde(default)]
+    pub warm: Vec<String>,
 }
 
 impl Default for CacheConfig {
@@ -255,6 +257,7 @@ impl Default for CacheConfig {
             max_entries: default_max_entries(),
             min_ttl: default_min_ttl(),
             max_ttl: default_max_ttl(),
+            warm: Vec::new(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -402,6 +402,9 @@ async fn main() -> numa::Result<()> {
         g,
         &format!("max {} entries", config.cache.max_entries),
     );
+    if !config.cache.warm.is_empty() {
+        row("Warm", g, &format!("{} domains", config.cache.warm.len()));
+    }
     row(
         "Blocking",
         g,
@@ -481,6 +484,15 @@ async fn main() -> numa::Result<()> {
                 &prime_ctx.srtt,
             )
             .await;
+        });
+    }
+
+    // Spawn cache warming for user-configured domains
+    if !config.cache.warm.is_empty() {
+        let warm_ctx = Arc::clone(&ctx);
+        let warm_domains = config.cache.warm.clone();
+        tokio::spawn(async move {
+            cache_warm_loop(warm_ctx, warm_domains).await;
         });
     }
 
@@ -719,4 +731,54 @@ async fn load_blocklists(ctx: &ServerCtx, lists: &[String]) {
         total,
         downloaded.len()
     );
+}
+
+async fn warm_domain(ctx: &ServerCtx, domain: &str) {
+    use numa::question::QueryType;
+
+    for qtype in [QueryType::A, QueryType::AAAA] {
+        let query = numa::packet::DnsPacket::query(0, domain, qtype);
+        let result = if ctx.upstream_mode == numa::config::UpstreamMode::Recursive {
+            numa::recursive::resolve_recursive(
+                domain,
+                qtype,
+                &ctx.cache,
+                &query,
+                &ctx.root_hints,
+                &ctx.srtt,
+            )
+            .await
+        } else {
+            let pool = ctx.upstream_pool.lock().unwrap().clone();
+            numa::forward::forward_with_failover(&query, &pool, &ctx.srtt, ctx.timeout).await
+        };
+        match result {
+            Ok(resp) => {
+                ctx.cache.write().unwrap().insert(domain, qtype, &resp);
+                log::debug!("cache warm: {} {:?}", domain, qtype);
+            }
+            Err(e) => log::warn!("cache warm: {} {:?} failed: {}", domain, qtype, e),
+        }
+    }
+}
+
+async fn cache_warm_loop(ctx: Arc<ServerCtx>, domains: Vec<String>) {
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    for domain in &domains {
+        warm_domain(&ctx, domain).await;
+    }
+    info!("cache warm: {} domains resolved at startup", domains.len());
+
+    let mut interval = tokio::time::interval(Duration::from_secs(30));
+    interval.tick().await;
+    loop {
+        interval.tick().await;
+        for domain in &domains {
+            let refresh = ctx.cache.read().unwrap().needs_warm(domain);
+            if refresh {
+                warm_domain(&ctx, domain).await;
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- New `[cache] warm` config field: list domains to keep hot in cache
- Resolves A + AAAA at startup, re-resolves proactively before TTL expiry (at 75% elapsed)
- `DnsCache::ttl_remaining()` and `needs_warm()` methods for threshold checks
- Banner row shows warm domain count at startup
- 5 new tests (200 total): TTL remaining, needs_warm logic

```toml
[cache]
warm = ["google.com", "github.com"]
```

Closes #34 (item 4)

## Test plan
- [x] `make all` passes (200 tests, clippy, fmt, audit)
- [x] `needs_warm` returns true for missing domains
- [x] `needs_warm` returns false for freshly cached A + AAAA
- [x] `needs_warm` returns true when only one record type is cached
- [x] `ttl_remaining` returns correct values for cached entries
- [x] `ttl_remaining` returns None for missing entries
- [x] Manual: startup log shows "cache warm: 2 domains resolved at startup"

🤖 Generated with [Claude Code](https://claude.com/claude-code)