### PR TITLE
bench: add --vs-adguard comparison mode

### DIFF
--- a/benches/recursive_compare.rs
+++ b/benches/recursive_compare.rs
@@ -8,6 +8,7 @@
 //!   --hedge-5x      Hedging: single vs hedge-same vs hedge-dual vs Hickory (5 iterations)
 //!   --vs-unbound    Server-to-server: Numa vs Unbound (plain UDP, caching)
 //!   --vs-unbound-cold  Cold: Numa vs Unbound (unique subdomains, no cache hits)
+//!   --vs-adguard    Server-to-server: Numa vs AdGuard Home (plain UDP, caching)
 //!   --vs-nextdns    Server-to-cloud: Numa (local cache) vs NextDNS (remote, 45.90.28.0)
 //!   --vs-dot        DoT server: Numa vs Unbound
 //!   --vs-doh-servers DoH server: Numa vs Unbound (DoT upstream)
@@ -157,6 +158,10 @@ fn main() {
     if arg("--vs-dnscrypt") {
         check_numa_mode(&rt, "forward");
         return run_server_comparison(&rt, "dnscrypt-proxy", "127.0.0.1:5455", 5, false);
+    }
+    if arg("--vs-adguard") {
+        check_numa_mode(&rt, "forward");
+        return run_server_comparison(&rt, "AdGuard Home", "127.0.0.1:5457", 5, false);
     }
     if arg("--vs-nextdns") {
         check_numa_mode(&rt, "forward");


### PR DESCRIPTION
## Summary

- Add `--vs-adguard` benchmark mode: Numa vs AdGuard Home (127.0.0.1:5457), both DoH forwarding
- Results: cached queries tied at 0.1ms; without hedging, identical on all metrics

## Setup

```bash
# Download AdGuard Home
curl -sLO https://github.com/AdguardTeam/AdGuardHome/releases/latest/download/AdGuardHome_darwin_arm64.zip
unzip AdGuardHome_darwin_arm64.zip

# Start on port 5457 with DoH upstream
./AdGuardHome/AdGuardHome -w /tmp/adguard-bench-workdir

# Run benchmark
cargo bench --bench recursive_compare -- --vs-adguard
```

## Test plan

- [x] 272 tests pass, clippy clean