### PR TITLE
chore(deps): bump rustls-webpki to 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
Unbreaks the `cargo audit` CI job on `main` (currently failing on sha `6f0144b`).

Two advisories against `rustls-webpki 0.103.10` were published 2026-04-14:

- [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098) — name constraints for URI names were incorrectly accepted
- [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099) — name constraints accepted for wildcard-asserting certificates

Both fixed in `rustls-webpki 0.103.12`. Pulled transitively via `reqwest` / `rustls` / `hickory` / `quinn` — a single `cargo update -p rustls-webpki` lifts the lockfile.

## Test plan
- [x] `cargo audit` — exits 0, no vulnerabilities (2 pre-existing allowed warnings remain: `rustls-pemfile` unmaintained, `rand` unsound)
- [x] `cargo check` — builds clean
- [x] Diff confined to `Cargo.lock` (2 lines: version + checksum)