### PR TITLE
feat(dashboard): version in header, restructure footer

### DIFF
--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -552,7 +552,11 @@ body {
 @media (max-width: 700px) {
   .stats-row { grid-template-columns: repeat(2, 1fr); }
   .dashboard { padding: 1rem; }
-  .header { padding: 1rem; }
+  .header { padding: 0.8rem 1rem; }
+  .logo { font-size: 1.4rem; }
+  .tagline { display: none; }
+  #headerVersion { display: none; }
+  #phoneSetup { display: none; }
 }
 </style>
 </head>

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -561,6 +561,7 @@ body {
 <div class="header">
   <div class="header-left">
     <div class="logo">Numa</div>
+    <span id="headerVersion" style="font-family:var(--font-mono);font-size:0.68rem;color:var(--text-dim);"></span>
     <div class="tagline">DNS that governs itself</div>
   </div>
   <div style="display:flex;align-items:center;gap:1.2rem;">
@@ -1136,16 +1137,20 @@ async function refresh() {
     document.getElementById('totalQueries').textContent = formatNumber(q.total);
     document.getElementById('uptime').textContent = formatUptime(stats.uptime_secs);
     document.getElementById('uptimeSub').textContent = formatUptimeSub(stats.uptime_secs);
+    document.getElementById('headerVersion').textContent = stats.version ? 'v' + stats.version : '';
     document.getElementById('footerUpstream').textContent = stats.upstream || '';
     document.getElementById('footerConfig').textContent = stats.config_path || '';
     document.getElementById('footerData').textContent = stats.data_dir || '';
-    const modeEl = document.getElementById('footerMode');
-    modeEl.textContent = stats.mode || '—';
-    modeEl.style.color = stats.mode === 'recursive' ? 'var(--emerald)' : 'var(--amber)';
     document.getElementById('footerDnssec').textContent = stats.dnssec ? 'on' : 'off';
     document.getElementById('footerDnssec').style.color = stats.dnssec ? 'var(--emerald)' : 'var(--text-dim)';
     document.getElementById('footerSrtt').textContent = stats.srtt ? 'on' : 'off';
     document.getElementById('footerSrtt').style.color = stats.srtt ? 'var(--emerald)' : 'var(--text-dim)';
+    if (!document.getElementById('footerLogs').textContent) {
+      const isMac = stats.data_dir && stats.data_dir.includes('/usr/local/');
+      document.getElementById('footerLogs').textContent = isMac
+        ? '/usr/local/var/log/numa.log'
+        : 'journalctl -u numa -f';
+    }
 
     // LAN status indicator
     const lanEl = document.getElementById('lanToggle');
@@ -1504,14 +1509,14 @@ refresh();
 setInterval(refresh, 2000);
 </script>
 
-<div style="text-align:center;padding:0.8rem;font-family:var(--font-mono);font-size:0.68rem;color:var(--text-dim);">
+<div style="text-align:center;padding:0.8rem 0.8rem 0.4rem;font-family:var(--font-mono);font-size:0.68rem;color:var(--text-dim);line-height:1.8;">
   Config: <span id="footerConfig" style="user-select:all;color:var(--emerald);"></span>
   · Data: <span id="footerData" style="user-select:all;color:var(--emerald);"></span>
-  · Upstream: <span id="footerUpstream" style="user-select:all;color:var(--emerald);"></span>
-  · Mode: <span id="footerMode" style="color:var(--text-dim);">—</span>
+  · Logs: <span id="footerLogs" style="user-select:all;color:var(--emerald);"></span>
+  <br>
+  Upstream: <span id="footerUpstream" style="user-select:all;color:var(--emerald);"></span>
   · DNSSEC: <span id="footerDnssec" style="color:var(--text-dim);">—</span>
   · SRTT: <span id="footerSrtt" style="color:var(--text-dim);">—</span>
-  · Logs: <span style="user-select:all;color:var(--emerald);">macOS: /usr/local/var/log/numa.log · Linux: journalctl -u numa -f</span>
   · <a href="https://github.com/razvandimescu/numa" target="_blank" rel="noopener" style="color:var(--amber);text-decoration:none;">GitHub</a>
 </div>
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -160,6 +160,7 @@ struct QueryLogResponse {
 
 #[derive(Serialize)]
 struct StatsResponse {
+    version: &'static str,
     uptime_secs: u64,
     upstream: String,
     mode: &'static str, // "recursive" or "forward" — never "auto" at runtime
@@ -539,6 +540,7 @@ async fn stats(State(ctx): State<Arc<ServerCtx>>) -> Json<StatsResponse> {
     };
 
     Json(StatsResponse {
+        version: env!("CARGO_PKG_VERSION"),
         uptime_secs: snap.uptime_secs,
         upstream,
         mode: ctx.upstream_mode.as_str(),


### PR DESCRIPTION
## Summary
Closes #108.

- Adds `version` field to `/stats` endpoint (from `CARGO_PKG_VERSION`), so the dashboard can read it without a second fetch to `/health`.
- Shows `v0.13.1` next to the Numa wordmark in the dashboard header — matches the universal convention (Grafana, Pi-hole, Portainer all put version near the product name).
- Restructures the footer into two semantic rows for reduced density:
  - **Row 1 (paths):** Config · Data · Logs — the things you'd paste into a bug report
  - **Row 2 (runtime):** Upstream · DNSSEC · SRTT · GitHub — the things you'd check at a glance
- Drops `Mode` from the footer (redundant — the Upstream label already reads "forward" vs "recursive (root hints)").
- Detects platform from `data_dir` path and shows only the matching log location (macOS → `/usr/local/var/log/numa.log`, Linux → `journalctl -u numa -f`) instead of listing both unconditionally.

## Test plan
- [x] `make all` — fmt + clippy + audit + 285 tests pass
- [x] Visual: deploy locally, open dashboard, confirm version badge in header and two-row footer render correctly
- [x] `/stats` JSON includes `"version": "0.13.1"` as the first field