### PR TITLE
fix(dashboard): allowlist input erased by polling refresh

### DIFF
--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1354,6 +1354,7 @@ function renderBlockingInfo(info) {
 }
 
 function renderAllowlist(entries) {
+  if (document.activeElement && document.activeElement.id === 'allowDomainInput') return;
   const el = document.getElementById('blockingAllowlist');
   const count = entries.length;
   el.innerHTML = `


### PR DESCRIPTION
## Summary
Fixes #106.

- The allowlist panel's `renderAllowlist()` replaced the entire section's `innerHTML` every 2 seconds (polling loop), including the `<form>` and `<input>`. If the user was mid-typing when the refresh fired, their text vanished — reported as "it would 'time out' and erase the entered text."
- Fix: skip the re-render when `allowDomainInput` has focus. The list updates on the next refresh after the user submits or clicks away.
- Note for the reporter: `numa.toml` already supports config-based allowlists under `[blocking]`: `allowlist = ["tailscale.com"]`. This pre-loads entries at startup without needing the dashboard.

## Test plan
- [x] `make all` — fmt + clippy + audit + 285 tests pass
- [x] Open dashboard, start typing in allowlist input, wait >2s — text should persist
- [x] Submit a domain via the input — allowlist updates on next refresh cycle
- [x] Verify the existing polling refresh still updates the allowlist when the input is not focused