### PR TITLE
fix: replace truecolor ANSI codes with 256-color for consistent termi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ site/blog/posts/
 ios/
 drafts/
 site/blog/index.html
+.DS_Store

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,16 +31,16 @@ fn main() -> numa::Result<()> {
 
     match arg1.as_str() {
         "install" => {
-            eprintln!("\x1b[1;38;2;192;98;58mNuma\x1b[0m — installing\n");
+            eprintln!("\x1b[1;38;5;166mNuma\x1b[0m — installing\n");
             return install_service().map_err(|e| e.into());
         }
         "uninstall" => {
-            eprintln!("\x1b[1;38;2;192;98;58mNuma\x1b[0m — uninstalling\n");
+            eprintln!("\x1b[1;38;5;166mNuma\x1b[0m — uninstalling\n");
             return uninstall_service().map_err(|e| e.into());
         }
         "service" => {
             let sub = std::env::args().nth(2).unwrap_or_default();
-            eprintln!("\x1b[1;38;2;192;98;58mNuma\x1b[0m — service management\n");
+            eprintln!("\x1b[1;38;5;166mNuma\x1b[0m — service management\n");
             return match sub.as_str() {
                 "start" => start_service().map_err(|e| e.into()),
                 "stop" => stop_service().map_err(|e| e.into()),
@@ -105,7 +105,7 @@ fn main() -> numa::Result<()> {
                 && !arg1.ends_with(".toml")
             {
                 eprintln!(
-                    "\x1b[1;38;2;192;98;58mNuma\x1b[0m — unknown command: \x1b[1m{}\x1b[0m\n",
+                    "\x1b[1;38;5;166mNuma\x1b[0m — unknown command: \x1b[1m{}\x1b[0m\n",
                     arg1
                 );
                 eprintln!("Run \x1b[1mnuma help\x1b[0m for a list of commands.");
@@ -185,7 +185,7 @@ fn print_lan_status(enabled: bool) {
     let label = if enabled { "enabled" } else { "disabled" };
     let color = if enabled { "32" } else { "33" };
     eprintln!(
-        "\x1b[1;38;2;192;98;58mNuma\x1b[0m — LAN discovery \x1b[{}m{}\x1b[0m",
+        "\x1b[1;38;5;166mNuma\x1b[0m — LAN discovery \x1b[{}m{}\x1b[0m",
         color, label
     );
     if enabled {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -275,12 +275,12 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     .unwrap_or(30);
     let w = (val_w + 12).max(42); // 10 label + 2 padding, min 42 for title
 
-    let o = "\x1b[38;2;192;98;58m"; // orange
-    let g = "\x1b[38;2;107;124;78m"; // green
-    let d = "\x1b[38;2;163;152;136m"; // dim
+    let o = "\x1b[38;5;166m"; // orange borders (256-color, ~192,98,58)
+    let g = "\x1b[38;5;101m"; // khaki/olive labels (256-color, ~107,124,78)
+    let d = "\x1b[38;5;138m"; // warm grey labels (256-color, ~163,152,136)
     let r = "\x1b[0m"; // reset
-    let b = "\x1b[1;38;2;192;98;58m"; // bold orange
-    let it = "\x1b[3;38;2;163;152;136m"; // italic dim
+    let b = "\x1b[1;38;5;166m"; // bold orange title (256-color)
+    let it = "\x1b[3;38;5;138m"; // italic warm grey subtitle
 
     let bar_top = "═".repeat(w);
     let bar_mid = "─".repeat(w);
@@ -338,7 +338,7 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     if let Some(ref label) = proxy_label {
         row("Proxy", g, label);
         if config.proxy.bind_addr == "127.0.0.1" {
-            let y = "\x1b[38;2;204;176;59m"; // yellow
+            let y = "\x1b[33m"; // yellow
             row(
                 "",
                 y,

--- a/src/setup_phone.rs
+++ b/src/setup_phone.rs
@@ -60,7 +60,7 @@ pub async fn run() -> Result<(), String> {
     if !api_reachable {
         eprintln!();
         eprintln!(
-            "  \x1b[1;38;2;192;98;58mNuma\x1b[0m — mobile API is not reachable on port {}.",
+            "  \x1b[1;38;5;166mNuma\x1b[0m — mobile API is not reachable on port {}.",
             SETUP_PORT
         );
         eprintln!();
@@ -77,7 +77,7 @@ pub async fn run() -> Result<(), String> {
     let qr = render_qr(&url)?;
 
     eprintln!();
-    eprintln!("  \x1b[1;38;2;192;98;58mNuma Phone Setup\x1b[0m");
+    eprintln!("  \x1b[1;38;5;166mNuma Phone Setup\x1b[0m");
     eprintln!();
     eprintln!("  Profile URL: \x1b[36m{}\x1b[0m", url);
     eprintln!();

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -89,7 +89,7 @@ pub fn try_port53_advisory(bind_addr: &str, err: &std::io::Error) -> Option<Stri
         ),
         _ => return None,
     };
-    let o = "\x1b[1;38;2;192;98;58m"; // bold orange
+    let o = "\x1b[1;38;5;166m"; // bold orange
     let r = "\x1b[0m";
     Some(format!(
         "

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -49,7 +49,7 @@ pub fn try_data_dir_advisory(err: &crate::Error, data_dir: &Path) -> Option<Stri
     if io_err.kind() != std::io::ErrorKind::PermissionDenied {
         return None;
     }
-    let o = "\x1b[1;38;2;192;98;58m";
+    let o = "\x1b[1;38;5;166m";
     let r = "\x1b[0m";
     Some(format!(
         "


### PR DESCRIPTION
PR target is to consistently display this CLI table across all operating systems using the same color palette:
<img width="444" height="269" alt="Screenshot 2026-04-17 at 12 10 53" src="https://github.com/user-attachments/assets/20e110a8-5f78-4d03-a5e4-2af7ffee690c" />
