### PR TITLE
fix(dashboard): pass missing args to encryptionPct in refresh()

### DIFF
--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1244,7 +1244,7 @@ async function refresh() {
 
     // QPS calculation
     const now = Date.now();
-    const encPct = encryptionPct(stats.transport);
+    const encPct = encryptionPct(stats.transport, ['dot', 'doh'], ['udp', 'tcp', 'dot', 'doh']);
     if (prevTotal !== null && prevTime !== null) {
       const dt = (now - prevTime) / 1000;
       const dq = q.total - prevTotal;
@@ -1273,6 +1273,7 @@ async function refresh() {
     renderMemory(stats.memory, stats);
 
   } catch (err) {
+    console.error('[numa dashboard] render failed:', err);
     document.getElementById('statusDot').className = 'status-dot error';
     document.getElementById('statusText').textContent = 'disconnected';
   }


### PR DESCRIPTION
## Summary

- Commit `eb5ea3b` generalised `encryptionPct` from `(transport)` to `(data, encryptedKeys, allKeys)` and updated `renderTransport` + `renderUpstreamWire`, but missed the call inside `render()` that computes the inline `~N/s · M% enc` QPS tag.
- With `allKeys` undefined, the first `.reduce()` threw `TypeError`. The render `try/catch` silently downgraded the whole dashboard to "disconnected" — every panel left empty even though `/stats` returned real data.
- Also: `console.error(err)` inside the catch so the next silent-failure regression lands in DevTools instead of behind a source dive.

## Test plan

- [x] `cargo fmt --check` / `cargo clippy -D warnings` / `cargo audit` / `cargo test` (344 pass)
- [ ] Manual: reload dashboard, confirm panels populate and QPS tag renders with no console errors
- [ ] Manual: temporarily break a render function, verify the error lands in DevTools console

Diff is two lines: the call-site fix and the `console.error` line.