### PR TITLE
chore: gitignore .claude/ harness state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 /build-dir
 CLAUDE.md
+.claude/
 docs/
 site/blog/posts/
 ios/


### PR DESCRIPTION
## Summary
- Adds `.claude/` to `.gitignore` so Claude Code's per-session state (`settings.local.json`, task locks, worktree metadata) can't accidentally be committed.

## Test plan
- [ ] `git check-ignore -v .claude/settings.local.json` points at the new `.gitignore` line.
- [ ] `git status` on a fresh clone with a populated `.claude/` shows nothing.