### PR TITLE
chore(site): live-reload dev server

### DIFF
--- a/scripts/serve-site.sh
+++ b/scripts/serve-site.sh
@@ -1,14 +1,41 @@
 #!/usr/bin/env bash
+# Dev server for site/: regenerates drafts on each MD change, reloads the
+# browser on each rendered HTML/CSS/JS change. Port is the first numeric arg
+# (default 9000); any other args are ignored for back-compat.
+#
+# First run downloads chokidar-cli + browser-sync into the npm cache — slow
+# once, instant after that.
+
 set -euo pipefail
 
-PORT="${1:-9000}"
+PORT=9000
+for arg in "$@"; do
+  if [[ "$arg" =~ ^[0-9]+$ ]]; then
+    PORT="$arg"
+    break
+  fi
+done
 
-if [[ "${1:-}" == "--drafts" ]] || [[ "${2:-}" == "--drafts" ]]; then
-  PORT="${PORT//--drafts/9000}"  # default port if --drafts was first arg
-  make blog-drafts
-else
-  make blog
-fi
+command -v npx >/dev/null || { echo "npx not found. Install Node.js: https://nodejs.org" >&2; exit 1; }
+command -v pandoc >/dev/null || { echo "pandoc not found (required by 'make blog-drafts')." >&2; exit 1; }
 
-echo "Serving site at http://localhost:$PORT"
-cd site && python3 -m http.server "$PORT"
+# Initial render so the first page load has everything.
+make blog-drafts
+
+echo "Serving site at http://localhost:$PORT (drafts included, live reload)"
+
+# Kill child processes on exit so re-runs don't leave orphaned watchers.
+trap 'kill $(jobs -p) 2>/dev/null' EXIT INT TERM
+
+# Regenerate HTML when MD sources or the blog template change.
+npx --yes chokidar-cli \
+  "drafts/*.md" "blog/*.md" "site/blog-template.html" \
+  -c "make blog-drafts" &
+
+# Serve + reload on rendered-asset changes.
+cd site && exec npx --yes browser-sync start \
+  --server . \
+  --port "$PORT" \
+  --files "**/*.html,**/*.css,**/*.js" \
+  --no-open \
+  --no-notify


### PR DESCRIPTION
## Summary
- `scripts/serve-site.sh` now uses `chokidar-cli` + `browser-sync` instead of plain `python3 -m http.server`: MD edits regenerate HTML, browser reloads on rendered-asset changes.
- First run pulls both via `npx` (slow once, instant after).
- Preflight checks for `npx` and `pandoc`.
- Cleanup trap kills watcher + server on exit so re-runs don't leave orphans.
- Port arg parsing tolerates legacy `--drafts` flag ordering; drafts are always included now (that's what the dev loop actually wants).

CI is intentionally skipped for `scripts/serve-site.sh` via `paths-ignore` in `.github/workflows/ci.yml` — no Rust surface to test.

## Test plan
- [x] `bash -n scripts/serve-site.sh` clean (syntax valid).
- [ ] `scripts/serve-site.sh 9000` serves at `http://localhost:9000`.
- [ ] Editing a `drafts/*.md` file regenerates HTML; browser tab reloads automatically.
- [ ] Ctrl-C leaves no orphaned `chokidar` / `browser-sync` processes (`pgrep -f chokidar` empty).
- [ ] Missing `pandoc` or `npx` produces a clear install-pointer error.