### PR TITLE
chore: bump rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- RustSec advisory [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) (published 2026-04-22): reachable panic in certificate revocation list parsing.
- Transitive via `rustls 0.23.37 → rustls-webpki 0.103.12`; fix is a lockfile-only bump to `0.103.13`.
- Unblocks `cargo audit` in CI; all open PRs (#129–#132) will go green after rerun once this lands.

## Test plan
- [ ] `cargo check` clean on all platforms.
- [ ] `cargo audit` reports no errors (two pre-existing `allowed` warnings — `rand` unsound w/ custom logger, `rustls-pemfile` unmaintained — remain, same as main today).
- [ ] CI `check` job (which runs `cargo audit`) goes from red to green.