### PR TITLE
docs(config): fix ODoH relay path in numa.toml example

### DIFF
--- a/numa.toml
+++ b/numa.toml
@@ -43,7 +43,7 @@ api_port = 5380
 # refuses same-operator relay+target configs by default (eTLD+1 check).
 # [upstream]
 # mode = "odoh"
-# relay = "https://odoh-relay.numa.rs/proxy"
+# relay = "https://odoh-relay.numa.rs/relay"
 # target = "https://odoh.cloudflare-dns.com/dns-query"
 # strict = true                                 # default: refuse to downgrade to `fallback`
 #                                                # on relay failure. Set false to allow a


### PR DESCRIPTION
## Summary

- `numa.toml` line 46 advertised the ODoH relay at `https://odoh-relay.numa.rs/proxy`, but the live server only serves `/relay` (returns 404 on `/proxy`, 405 on `GET /relay` as expected for an ODoH POST endpoint).
- Every other reference in the tree already uses `/relay` — `src/config.rs` rustdoc + tests, `packaging/client/numa.toml` — so this was an isolated typo introduced in 2e461cc ("docs(config): add ODoH upstream examples…"), shipped in 0.14.2.
- One-line fix. Users who copied the example verbatim saw `UPSTREAM ERROR | ODoH relay returned 404 Not Found` → SERVFAIL on every query.

Reported by @bcookatpcsd in #138. Their workaround (swapping in `odoh-relay.edgecompute.app`) confirmed the relay choice wasn't at fault — only the path.

## Test plan

- [x] `curl -I https://odoh-relay.numa.rs/relay` → 405 (method not allowed on GET, correct)
- [x] `curl -I https://odoh-relay.numa.rs/proxy` → 404