### PR TITLE
fix(api): Cache-Control: no-cache on dashboard HTML

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -83,8 +83,13 @@ pub fn router(ctx: Arc<ServerCtx>) -> Router {
 }
 
 async fn dashboard() -> impl IntoResponse {
+    // Revalidate each load so browsers don't keep serving a stale
+    // dashboard across numa upgrades.
     (
-        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        [
+            (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
         DASHBOARD_HTML,
     )
 }
@@ -1244,6 +1249,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), 200);
+        assert_eq!(
+            resp.headers()
+                .get(header::CACHE_CONTROL)
+                .map(|v| v.to_str().unwrap()),
+            Some("no-cache"),
+            "dashboard must revalidate to avoid stale HTML across upgrades"
+        );
         let body = axum::body::to_bytes(resp.into_body(), 100000)
             .await
             .unwrap();


### PR DESCRIPTION
## Summary
- The dashboard route (`GET /`) returned the embedded HTML with no `Cache-Control` header. With no `Last-Modified` either, browsers fall back to heuristic caching and may serve the stale copy for a long time after a numa upgrade.
- This is what the reporter in #144 was seeing: binary was v0.14.2 (confirmed via `numa --version` and the `queries.upstream` key in `/stats`), but the rendered dashboard still matched a pre-v0.14.0 build — no Upstream row in Resolution Paths, and the zero-count filter wasn't kicking in. Both were dashboard changes that shipped weeks ago.
- Fix: send `Cache-Control: no-cache` on the dashboard response. Browsers will revalidate on every load; since there's no ETag the response is always re-delivered, but it's ~60KB served locally and only on page load (data refresh stays on `/stats`), so the cost is negligible.

## Test plan
- [x] `cargo test api::tests::dashboard_returns_html` — existing test now also asserts the header
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib -- -D warnings`
- [ ] Manual: upgrade a running numa, hit `http://127.0.0.1:5380/` in a browser that previously had the page open, confirm the new dashboard renders without a hard reload

Closes #144.