### PR TITLE
ci(aur): attach to master after clone to avoid detached HEAD

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -126,6 +126,10 @@ jobs:
           # ssh://aur@aur.archlinux.org/<package-name>.git
           git clone ssh://aur@aur.archlinux.org/$AUR_PKGNAME.git aur-repo
 
+          # AUR's git server no longer advertises HEAD's symref, so clone
+          # lands in detached HEAD. Attach to master before committing.
+          git -C aur-repo checkout master
+
           cp PKGBUILD aur-repo/
           cd aur-repo
 


### PR DESCRIPTION
## Summary
- The AUR publish workflow has been failing on every push to `main` since 2026-04-23 05:58 UTC (first failure after a successful run ~9h earlier), with:
  ```
  error: src refspec master does not match any
  error: failed to push some refs to 'ssh://aur.archlinux.org/***.git'
  ```
- Root cause: `aur.archlinux.org`'s git server stopped advertising the HEAD symref. Probe:
  ```
  $ git ls-remote --symref https://aur.archlinux.org/numa-git.git
  9622dc47…  HEAD            ← no 'ref: refs/heads/master HEAD' line
  9622dc47…  HEAD
  f23f4532…  refs/heads/master
  ```
  A normal git server would prefix HEAD with `ref: refs/heads/master`. Without that, `git clone` falls back to checking out HEAD as a detached SHA. The run log confirms: *"You are in 'detached HEAD' state"* immediately after `Cloning into 'aur-repo'...`. The subsequent `git commit` then lands on that detached HEAD, and `git push origin master` has nothing to push.
- Fix: after `git clone`, explicitly `git checkout master`. The branch still exists on the remote (as shown in `ls-remote`), so this just reattaches the working copy.

## Test plan
- [x] `git diff` — 4 added lines, workflow-only change
- [ ] Merge, wait for next push to `main`, confirm the `publish-aur.yml` run succeeds through the final `git push`
- [ ] Verify the AUR `numa-git` package tip advances to the merge commit

Unblocks: every AUR publish since #139.