### PR TITLE
fix: title alignment

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -342,12 +342,13 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     };
 
     // Title row: center within the box
+    let tag_line = "DNS that governs itself";
     let title = format!(
-        "{b}NUMA{r}  {it}DNS that governs itself{r}  {d}v{}{r}",
+        "{b}NUMA{r}  {it}{tag_line}{r}  {d}v{}{r}",
         env!("CARGO_PKG_VERSION")
     );
     // The title contains ANSI codes; visible length is ~38 chars. Pad to fill the box.
-    let title_visible_len = 4 + 2 + 24 + 2 + 1 + env!("CARGO_PKG_VERSION").len() + 1;
+    let title_visible_len = 4 + 2 + tag_line.len() + 2 + 1 + env!("CARGO_PKG_VERSION").len() + 1;
     let title_pad = w.saturating_sub(title_visible_len);
     eprintln!("\n{o}  ╔{bar_top}╗{r}");
     eprint!("{o}  ║{r} {title}");


### PR DESCRIPTION
The box drawing for the title line in console output is not aligned well. This should fix the issue.

Before:
<img width="1150" height="664" alt="image" src="https://github.com/user-attachments/assets/a84cfb98-dbf1-4ca8-8cbd-1b7dc85656a2" />
After:
<img width="611" height="385" alt="image" src="https://github.com/user-attachments/assets/1f4d33c0-40e6-459b-ab95-84236e3f2e9d" />
