### PR TITLE
fix(zones): accept PTR records in [[zones]] config (#154)

### DIFF
--- a/numa.toml
+++ b/numa.toml
@@ -144,6 +144,13 @@ tld = "numa"
 # value = "127.0.0.1"
 # ttl = 60
 
+# Reverse-DNS (PTR) for LAN hosts — makes tcpdump/access logs readable
+# [[zones]]
+# domain = "1.0.168.192.in-addr.arpa"   # 192.168.0.1 reversed + .in-addr.arpa
+# record_type = "PTR"
+# value = "router.lan"
+# ttl = 300
+
 # DNSSEC signature validation (requires mode = "recursive")
 # [dnssec]
 # enabled = false             # opt-in: verify chain of trust from root KSK

--- a/src/config.rs
+++ b/src/config.rs
@@ -724,6 +724,28 @@ mod tests {
     }
 
     #[test]
+    fn build_zone_map_accepts_ptr() {
+        let zones = vec![ZoneRecord {
+            domain: "1.0.168.192.in-addr.arpa".into(),
+            record_type: "PTR".into(),
+            value: "router.lan".into(),
+            ttl: 300,
+        }];
+        let map = build_zone_map(&zones).expect("PTR must load");
+        let records = map
+            .get("1.0.168.192.in-addr.arpa")
+            .and_then(|m| m.get(&QueryType::PTR))
+            .expect("PTR record present");
+        match &records[0] {
+            DnsRecord::PTR { host, ttl, .. } => {
+                assert_eq!(host, "router.lan");
+                assert_eq!(*ttl, 300);
+            }
+            other => panic!("expected PTR, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn api_binds_localhost_by_default() {
         assert_eq!(ServerConfig::default().api_bind_addr, "127.0.0.1");
     }
@@ -1381,6 +1403,14 @@ pub fn build_zone_map(zones: &[ZoneRecord]) -> Result<ZoneMap> {
             "CNAME" => (
                 QueryType::CNAME,
                 DnsRecord::CNAME {
+                    domain: domain.clone(),
+                    host: zone.value.clone(),
+                    ttl: zone.ttl,
+                },
+            ),
+            "PTR" => (
+                QueryType::PTR,
+                DnsRecord::PTR {
                     domain: domain.clone(),
                     host: zone.value.clone(),
                     ttl: zone.ttl,

--- a/src/dnssec.rs
+++ b/src/dnssec.rs
@@ -814,8 +814,9 @@ fn record_rdata_canonical(record: &DnsRecord) -> Vec<u8> {
     match record {
         DnsRecord::A { addr, .. } => addr.octets().to_vec(),
         DnsRecord::AAAA { addr, .. } => addr.octets().to_vec(),
-        DnsRecord::NS { host, .. } => name_to_wire(host),
-        DnsRecord::CNAME { host, .. } => name_to_wire(host),
+        DnsRecord::NS { host, .. }
+        | DnsRecord::CNAME { host, .. }
+        | DnsRecord::PTR { host, .. } => name_to_wire(host),
         DnsRecord::MX { priority, host, .. } => {
             let mut rdata = Vec::with_capacity(2 + host.len() + 2);
             rdata.extend(&priority.to_be_bytes());

--- a/src/record.rs
+++ b/src/record.rs
@@ -40,6 +40,11 @@ pub enum DnsRecord {
         host: String,
         ttl: u32,
     },
+    PTR {
+        domain: String,
+        host: String,
+        ttl: u32,
+    },
     MX {
         domain: String,
         priority: u16,
@@ -104,6 +109,7 @@ impl DnsRecord {
             DnsRecord::A { domain, .. }
             | DnsRecord::NS { domain, .. }
             | DnsRecord::CNAME { domain, .. }
+            | DnsRecord::PTR { domain, .. }
             | DnsRecord::MX { domain, .. }
             | DnsRecord::AAAA { domain, .. }
             | DnsRecord::DNSKEY { domain, .. }
@@ -122,6 +128,7 @@ impl DnsRecord {
             DnsRecord::AAAA { .. } => QueryType::AAAA,
             DnsRecord::NS { .. } => QueryType::NS,
             DnsRecord::CNAME { .. } => QueryType::CNAME,
+            DnsRecord::PTR { .. } => QueryType::PTR,
             DnsRecord::MX { .. } => QueryType::MX,
             DnsRecord::SOA { .. } => QueryType::SOA,
             DnsRecord::DNSKEY { .. } => QueryType::DNSKEY,
@@ -138,6 +145,7 @@ impl DnsRecord {
             DnsRecord::A { ttl, .. }
             | DnsRecord::NS { ttl, .. }
             | DnsRecord::CNAME { ttl, .. }
+            | DnsRecord::PTR { ttl, .. }
             | DnsRecord::MX { ttl, .. }
             | DnsRecord::AAAA { ttl, .. }
             | DnsRecord::DNSKEY { ttl, .. }
@@ -153,9 +161,9 @@ impl DnsRecord {
     pub fn heap_bytes(&self) -> usize {
         match self {
             DnsRecord::A { domain, .. } => domain.capacity(),
-            DnsRecord::NS { domain, host, .. } | DnsRecord::CNAME { domain, host, .. } => {
-                domain.capacity() + host.capacity()
-            }
+            DnsRecord::NS { domain, host, .. }
+            | DnsRecord::CNAME { domain, host, .. }
+            | DnsRecord::PTR { domain, host, .. } => domain.capacity() + host.capacity(),
             DnsRecord::MX { domain, host, .. } => domain.capacity() + host.capacity(),
             DnsRecord::AAAA { domain, .. } => domain.capacity(),
             DnsRecord::DNSKEY {
@@ -201,6 +209,7 @@ impl DnsRecord {
             DnsRecord::A { ttl, .. }
             | DnsRecord::NS { ttl, .. }
             | DnsRecord::CNAME { ttl, .. }
+            | DnsRecord::PTR { ttl, .. }
             | DnsRecord::MX { ttl, .. }
             | DnsRecord::AAAA { ttl, .. }
             | DnsRecord::DNSKEY { ttl, .. }
@@ -267,6 +276,15 @@ impl DnsRecord {
                 Ok(DnsRecord::CNAME {
                     domain,
                     host: cname,
+                    ttl,
+                })
+            }
+            QueryType::PTR => {
+                let mut ptr = String::with_capacity(64);
+                buffer.read_qname(&mut ptr)?;
+                Ok(DnsRecord::PTR {
+                    domain,
+                    host: ptr,
                     ttl,
                 })
             }
@@ -460,6 +478,18 @@ impl DnsRecord {
                 let size = buffer.pos() - (pos + 2);
                 buffer.set_u16(pos, size as u16)?;
             }
+            DnsRecord::PTR {
+                ref domain,
+                ref host,
+                ttl,
+            } => {
+                write_header(buffer, domain, QueryType::PTR.to_num(), ttl)?;
+                let pos = buffer.pos();
+                buffer.write_u16(0)?;
+                buffer.write_qname(host)?;
+                let size = buffer.pos() - (pos + 2);
+                buffer.set_u16(pos, size as u16)?;
+            }
             DnsRecord::MX {
                 ref domain,
                 priority,
@@ -637,6 +667,18 @@ mod tests {
         record.write(&mut buf).unwrap();
         buf.seek(0).unwrap();
         DnsRecord::read(&mut buf).unwrap()
+    }
+
+    #[test]
+    fn ptr_round_trip() {
+        let rec = DnsRecord::PTR {
+            domain: "9.9.9.9.in-addr.arpa".into(),
+            host: "dns.quad9.net".into(),
+            ttl: 3600,
+        };
+        let parsed = round_trip(&rec);
+        assert_eq!(rec, parsed);
+        assert_eq!(parsed.query_type(), QueryType::PTR);
     }
 
     #[test]

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -364,6 +364,12 @@ domain = "mail.local"
 record_type = "MX"
 value = "10 smtp.local"
 ttl = 60
+
+[[zones]]
+domain = "1.0.168.192.in-addr.arpa"
+record_type = "PTR"
+value = "router.lan"
+ttl = 60
 CONF
 
 RUST_LOG=info "$BINARY" "$CONFIG" > "$LOG" 2>&1 &
@@ -380,6 +386,11 @@ check "Local A record (test.local)" \
 check "Local MX record (mail.local)" \
     "smtp.local" \
     "$($DIG mail.local MX +short)"
+
+# PTR in 192.168/16 — proves zone_map beats RFC 6303 NXDOMAIN shortcut
+check "Local PTR record (192.168.0.1 → router.lan)" \
+    "router.lan" \
+    "$($DIG -x 192.168.0.1 +short)"
 
 check "Non-local domain still resolves" \
     "." \


### PR DESCRIPTION
## Summary

- Adds `DnsRecord::PTR { domain, host, ttl }` — wire shape mirrors CNAME (qname-only RDATA per RFC 1035 §3.3.12)
- Accepts `record_type = "PTR"` in `[[zones]]`; previously hit the `unsupported record type` fallback
- Local PTR answers take precedence over the RFC 6303 private-range NXDOMAIN shortcut (zone-map check runs before `is_special_use_domain` in the pipeline)
- Adds the canonical RDATA encoding for DNSSEC validation of signed PTR zones

Fixes #154.

### Example config

```toml
[[zones]]
domain = "1.0.168.192.in-addr.arpa"
record_type = "PTR"
value = "router.lan"
ttl = 300
```

Reverse lookups for `192.168.0.1` now return `router.lan` locally — useful for cleaning up `tcpdump`/access-log output for LAN hosts.

## Test plan

- [x] `record::tests::ptr_round_trip` — wire round-trip + `query_type()`
- [x] `config::tests::build_zone_map_accepts_ptr` — config loader accepts PTR
- [x] Existing `special_use_private_ptr_returns_nxdomain` still passes (no regression on the RFC 6303 path)
- [x] `make all` green (fmt, clippy, audit, 358 unit + 1 integration test)