### PR TITLE
feat(proxy): PROXY protocol v2 inbound on DoT, DoH, and plain TCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -1560,8 +1563,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "ipnet",
  "log",
  "odoh-rs",
+ "proxy-header",
  "psl",
  "qrcode",
  "rand_core 0.9.5",
@@ -1801,6 +1806,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proxy-header"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1493f63ddddfba840c3169e997c2905d09538ace72d64e84af6324c6e0e065"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ rand_core = { version = "0.9", features = ["os_rng"] }
 rustls-pemfile = "2.2.0"
 qrcode = { version = "0.14", default-features = false, features = ["svg"] }
 webpki-roots = "1"
+proxy-header = { version = "0.1", features = ["tokio"] }
+ipnet = { version = "2", features = ["serde"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.7"

--- a/numa.toml
+++ b/numa.toml
@@ -122,6 +122,17 @@ tls_port = 443
 tld = "numa"
 # bind_addr = "127.0.0.1"  # default; set to "0.0.0.0" for LAN access to .numa services
 
+# PROXY protocol v2 — preserves the real client IP when numa runs behind an
+# L4 front-end (dnsdist, HAProxy, nginx-stream, AWS NLB, GCP TCP LB). Empty
+# `from` allowlist (or omitted section) leaves the feature disabled.
+# A non-empty list puts the listener in PROXY-required mode: connections from
+# listed senders that omit the header are dropped, and connections from
+# non-listed senders are dropped before any read.
+# [proxy.proxy_protocol]
+# from = ["10.0.0.0/8", "127.0.0.1"]  # CIDR allowlist of trusted L4 front-ends
+# max_size = 512                       # bytes; cap on the PROXY v2 header
+# header_timeout_ms = 5000             # ms; kill stalled-header connections fast
+
 # Pre-configured services (numa.numa is always added automatically)
 # [[services]]
 # name = "frontend"
@@ -163,6 +174,12 @@ tld = "numa"
 # bind_addr = "0.0.0.0"       # IPv4 or IPv6; unspecified binds all interfaces
 # cert_path = "/etc/numa/dot.crt"  # PEM cert; omit to use self-signed (proxy CA if available)
 # key_path = "/etc/numa/dot.key"   # PEM private key; must be set together with cert_path
+
+# PROXY v2 also attaches to DoT — same semantics as [proxy.proxy_protocol].
+# [dot.proxy_protocol]
+# from = ["10.0.0.0/8"]
+# max_size = 512
+# header_timeout_ms = 5000
 
 # LAN service discovery via mDNS (disabled by default — no network traffic unless enabled)
 # [lan]

--- a/numa.toml
+++ b/numa.toml
@@ -130,7 +130,6 @@ tld = "numa"
 # non-listed senders are dropped before any read.
 # [proxy.proxy_protocol]
 # from = ["10.0.0.0/8", "127.0.0.1"]  # CIDR allowlist of trusted L4 front-ends
-# max_size = 512                       # bytes; cap on the PROXY v2 header
 # header_timeout_ms = 5000             # ms; kill stalled-header connections fast
 
 # Pre-configured services (numa.numa is always added automatically)
@@ -178,7 +177,6 @@ tld = "numa"
 # PROXY v2 also attaches to DoT — same semantics as [proxy.proxy_protocol].
 # [dot.proxy_protocol]
 # from = ["10.0.0.0/8"]
-# max_size = 512
 # header_timeout_ms = 5000
 
 # LAN service discovery via mDNS (disabled by default — no network traffic unless enabled)

--- a/src/api.rs
+++ b/src/api.rs
@@ -181,7 +181,17 @@ struct StatsResponse {
     blocking: BlockingStatsResponse,
     lan: LanStatsResponse,
     mobile: MobileStatsResponse,
+    proxy_protocol: ProxyProtocolStats,
     memory: MemoryStats,
+}
+
+#[derive(Serialize)]
+struct ProxyProtocolStats {
+    accepted: u64,
+    rejected_untrusted: u64,
+    rejected_signature: u64,
+    local_command: u64,
+    timeout: u64,
 }
 
 #[derive(Serialize)]
@@ -606,6 +616,13 @@ async fn stats(State(ctx): State<Arc<ServerCtx>>) -> Json<StatsResponse> {
         mobile: MobileStatsResponse {
             enabled: ctx.mobile_enabled,
             port: ctx.mobile_port,
+        },
+        proxy_protocol: ProxyProtocolStats {
+            accepted: snap.proxy_v2_accepted,
+            rejected_untrusted: snap.proxy_v2_rejected_untrusted,
+            rejected_signature: snap.proxy_v2_rejected_signature,
+            local_command: snap.proxy_v2_local_command,
+            timeout: snap.proxy_v2_timeout,
         },
         memory: MemoryStats {
             cache_bytes,

--- a/src/config.rs
+++ b/src/config.rs
@@ -552,6 +552,8 @@ pub struct ProxyConfig {
     pub tld: String,
     #[serde(default = "default_proxy_bind_addr")]
     pub bind_addr: String,
+    #[serde(default)]
+    pub proxy_protocol: ProxyProtocolConfig,
 }
 
 impl Default for ProxyConfig {
@@ -562,8 +564,53 @@ impl Default for ProxyConfig {
             tls_port: default_proxy_tls_port(),
             tld: default_proxy_tld(),
             bind_addr: default_proxy_bind_addr(),
+            proxy_protocol: ProxyProtocolConfig::default(),
         }
     }
+}
+
+/// PROXY protocol v2 settings for an L4-fronted listener.
+///
+/// Naming mirrors PowerDNS Recursor's `proxy-protocol-from` /
+/// `proxy-protocol-maximum-size` for least operator surprise. An empty
+/// `from` allowlist disables the feature on this listener.
+#[derive(Deserialize, Clone, Debug)]
+pub struct ProxyProtocolConfig {
+    /// CIDR allowlist of TCP peers permitted to send PROXY v2 headers.
+    /// Empty list = feature disabled. Non-empty = listener is in
+    /// PROXY-required mode: connections from listed senders that omit
+    /// the header are dropped, and connections from non-listed senders
+    /// are dropped before any read.
+    #[serde(default)]
+    pub from: Vec<String>,
+
+    /// Maximum declared PROXY v2 `addr_len`, in bytes. Default 512
+    /// matches dnsdist's `setProxyProtocolMaximumPayloadSize` default.
+    #[serde(default = "default_pp_max_size")]
+    pub max_size: u16,
+
+    /// Header read timeout, in milliseconds. Default 5000 matches
+    /// hyper-server. Separate knob from TLS HANDSHAKE_TIMEOUT — different
+    /// attack pattern (slowloris on the PROXY header).
+    #[serde(default = "default_pp_header_timeout_ms")]
+    pub header_timeout_ms: u64,
+}
+
+impl Default for ProxyProtocolConfig {
+    fn default() -> Self {
+        ProxyProtocolConfig {
+            from: Vec::new(),
+            max_size: default_pp_max_size(),
+            header_timeout_ms: default_pp_header_timeout_ms(),
+        }
+    }
+}
+
+fn default_pp_max_size() -> u16 {
+    512
+}
+fn default_pp_header_timeout_ms() -> u64 {
+    5000
 }
 
 fn default_proxy_bind_addr() -> String {
@@ -643,6 +690,8 @@ pub struct DotConfig {
     /// Path to TLS private key (PEM). If None, uses self-signed CA.
     #[serde(default)]
     pub key_path: Option<PathBuf>,
+    #[serde(default)]
+    pub proxy_protocol: ProxyProtocolConfig,
 }
 
 impl Default for DotConfig {
@@ -653,6 +702,7 @@ impl Default for DotConfig {
             bind_addr: default_dot_bind_addr(),
             cert_path: None,
             key_path: None,
+            proxy_protocol: ProxyProtocolConfig::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,6 +99,12 @@ pub struct ServerConfig {
     /// overrides, and the service proxy are not affected. Default false.
     #[serde(default)]
     pub filter_aaaa: bool,
+    /// PROXY protocol v2 ingress for the plain DNS-over-TCP listener.
+    /// Mirrors `[dot.proxy_protocol]` and `[proxy.proxy_protocol]`. Empty
+    /// `from` (default) disables the feature; non-empty puts the TCP
+    /// listener in PROXY-required mode.
+    #[serde(default)]
+    pub proxy_protocol: ProxyProtocolConfig,
 }
 
 impl Default for ServerConfig {
@@ -109,6 +115,7 @@ impl Default for ServerConfig {
             api_bind_addr: default_api_bind_addr(),
             data_dir: None,
             filter_aaaa: false,
+            proxy_protocol: ProxyProtocolConfig::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -571,9 +571,9 @@ impl Default for ProxyConfig {
 
 /// PROXY protocol v2 settings for an L4-fronted listener.
 ///
-/// Naming mirrors PowerDNS Recursor's `proxy-protocol-from` /
-/// `proxy-protocol-maximum-size` for least operator surprise. An empty
-/// `from` allowlist disables the feature on this listener.
+/// Naming mirrors PowerDNS Recursor's `proxy-protocol-from` for least
+/// operator surprise. An empty `from` allowlist disables the feature on
+/// this listener.
 #[derive(Deserialize, Clone, Debug)]
 pub struct ProxyProtocolConfig {
     /// CIDR allowlist of TCP peers permitted to send PROXY v2 headers.
@@ -583,11 +583,6 @@ pub struct ProxyProtocolConfig {
     /// are dropped before any read.
     #[serde(default)]
     pub from: Vec<String>,
-
-    /// Maximum declared PROXY v2 `addr_len`, in bytes. Default 512
-    /// matches dnsdist's `setProxyProtocolMaximumPayloadSize` default.
-    #[serde(default = "default_pp_max_size")]
-    pub max_size: u16,
 
     /// Header read timeout, in milliseconds. Default 5000 matches
     /// hyper-server. Separate knob from TLS HANDSHAKE_TIMEOUT — different
@@ -600,15 +595,11 @@ impl Default for ProxyProtocolConfig {
     fn default() -> Self {
         ProxyProtocolConfig {
             from: Vec::new(),
-            max_size: default_pp_max_size(),
             header_timeout_ms: default_pp_header_timeout_ms(),
         }
     }
 }
 
-fn default_pp_max_size() -> u16 {
-    512
-}
 fn default_pp_header_timeout_ms() -> u64 {
     5000
 }

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -11,6 +11,7 @@ use tokio_rustls::TlsAcceptor;
 
 use crate::config::DotConfig;
 use crate::ctx::ServerCtx;
+use crate::pp2::{self, PpConfig};
 use crate::stats::Transport;
 use crate::tcp::handle_framed_dns_connection;
 
@@ -82,6 +83,20 @@ pub async fn start_dot(ctx: Arc<ServerCtx>, config: &DotConfig) {
         },
     };
 
+    let pp = match PpConfig::from_config(&config.proxy_protocol) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("DoT: invalid proxy_protocol config ({}) — DoT disabled", e);
+            return;
+        }
+    };
+    if pp.is_some() {
+        info!(
+            "DoT: PROXY v2 enabled, trusting {} CIDR(s)",
+            config.proxy_protocol.from.len()
+        );
+    }
+
     let bind_addr: IpAddr = config
         .bind_addr
         .parse()
@@ -96,14 +111,20 @@ pub async fn start_dot(ctx: Arc<ServerCtx>, config: &DotConfig) {
     };
     info!("DoT listening on {}", addr);
 
-    accept_loop(listener, TlsAcceptor::from(tls_config), ctx).await;
+    accept_loop(listener, TlsAcceptor::from(tls_config), pp, ctx).await;
 }
 
-async fn accept_loop(listener: TcpListener, acceptor: TlsAcceptor, ctx: Arc<ServerCtx>) {
+async fn accept_loop(
+    listener: TcpListener,
+    acceptor: TlsAcceptor,
+    pp: Option<PpConfig>,
+    ctx: Arc<ServerCtx>,
+) {
     let semaphore = Arc::new(Semaphore::new(MAX_CONNECTIONS));
+    let pp = pp.map(Arc::new);
 
     loop {
-        let (tcp_stream, remote_addr) = match listener.accept().await {
+        let (tcp_stream, tcp_peer) = match listener.accept().await {
             Ok(conn) => conn,
             Err(e) => {
                 error!("DoT: TCP accept error: {}", e);
@@ -116,18 +137,25 @@ async fn accept_loop(listener: TcpListener, acceptor: TlsAcceptor, ctx: Arc<Serv
         let permit = match semaphore.clone().try_acquire_owned() {
             Ok(p) => p,
             Err(_) => {
-                debug!("DoT: connection limit reached, rejecting {}", remote_addr);
+                debug!("DoT: connection limit reached, rejecting {}", tcp_peer);
                 continue;
             }
         };
         let acceptor = acceptor.clone();
         let ctx = Arc::clone(&ctx);
+        let pp = pp.clone();
 
         tokio::spawn(async move {
             let _permit = permit; // held until task exits
 
+            let Some((stream, remote_addr)) =
+                pp2::handshake(tcp_stream, tcp_peer, pp.as_deref(), &ctx).await
+            else {
+                return;
+            };
+
             let tls_stream =
-                match tokio::time::timeout(HANDSHAKE_TIMEOUT, acceptor.accept(tcp_stream)).await {
+                match tokio::time::timeout(HANDSHAKE_TIMEOUT, acceptor.accept(stream)).await {
                     Ok(Ok(s)) => s,
                     Ok(Err(e)) => {
                         debug!("DoT: TLS handshake failed from {}: {}", remote_addr, e);
@@ -243,7 +271,7 @@ mod tests {
         let tls_config = Arc::clone(&*ctx.tls_config.as_ref().unwrap().load());
         let acceptor = TlsAcceptor::from(tls_config);
 
-        tokio::spawn(accept_loop(listener, acceptor, ctx));
+        tokio::spawn(accept_loop(listener, acceptor, None, ctx));
 
         (addr, cert_der)
     }
@@ -392,5 +420,279 @@ mod tests {
         for h in handles {
             h.await.unwrap();
         }
+    }
+
+    // ----------------------------------------------------------------------
+    // PROXY protocol v2 integration tests (`docs/implementation/proxy-protocol-v2.md`).
+    // ----------------------------------------------------------------------
+
+    /// Spin up a DoT listener with a PROXY v2 allowlist. `pp_from` is the list
+    /// of CIDRs/IPs trusted to send PROXY v2 headers; empty = feature disabled.
+    async fn spawn_dot_server_with_pp(
+        pp_from: &[&str],
+    ) -> (SocketAddr, CertificateDer<'static>) {
+        let (server_tls, cert_der) = test_tls_configs();
+
+        let upstream_addr = crate::testutil::blackhole_upstream();
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.zone_map = {
+            let mut m = HashMap::new();
+            let mut inner = HashMap::new();
+            inner.insert(
+                QueryType::A,
+                vec![DnsRecord::A {
+                    domain: "dot-test.example".to_string(),
+                    addr: std::net::Ipv4Addr::new(10, 0, 0, 1),
+                    ttl: 300,
+                }],
+            );
+            m.insert("dot-test.example".to_string(), inner);
+            m
+        };
+        ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
+            vec![crate::forward::Upstream::Udp(upstream_addr)],
+            vec![],
+        ));
+        ctx.tls_config = Some(arc_swap::ArcSwap::from(server_tls));
+        let ctx = Arc::new(ctx);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let tls_config = Arc::clone(&*ctx.tls_config.as_ref().unwrap().load());
+        let acceptor = TlsAcceptor::from(tls_config);
+
+        let pp_cfg = crate::config::ProxyProtocolConfig {
+            from: pp_from.iter().map(|s| s.to_string()).collect(),
+            // Use a short timeout so the truncated-header test doesn't drag.
+            header_timeout_ms: 500,
+            ..Default::default()
+        };
+        let pp = PpConfig::from_config(&pp_cfg).unwrap();
+
+        tokio::spawn(accept_loop(listener, acceptor, pp, ctx));
+
+        (addr, cert_der)
+    }
+
+    /// Wire a PROXY v2 IPv4 PROXY-command header (28 bytes total: 16 fixed +
+    /// 12 address block).
+    fn pp2_v4_proxy(
+        src_ip: std::net::Ipv4Addr,
+        dst_ip: std::net::Ipv4Addr,
+        src_port: u16,
+        dst_port: u16,
+    ) -> Vec<u8> {
+        let mut h = Vec::with_capacity(28);
+        h.extend_from_slice(&[
+            0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49, 0x54, 0x0a,
+        ]);
+        h.push(0x21); // v2 PROXY
+        h.push(0x11); // TCP/IPv4
+        h.extend_from_slice(&12u16.to_be_bytes());
+        h.extend_from_slice(&src_ip.octets());
+        h.extend_from_slice(&dst_ip.octets());
+        h.extend_from_slice(&src_port.to_be_bytes());
+        h.extend_from_slice(&dst_port.to_be_bytes());
+        h
+    }
+
+    /// Wire a PROXY v2 IPv6 PROXY-command header (52 bytes total: 16 fixed +
+    /// 36 address block). Used to verify cross-family parsing — peer is IPv4,
+    /// header declares IPv6.
+    fn pp2_v6_proxy(
+        src_ip: std::net::Ipv6Addr,
+        dst_ip: std::net::Ipv6Addr,
+        src_port: u16,
+        dst_port: u16,
+    ) -> Vec<u8> {
+        let mut h = Vec::with_capacity(52);
+        h.extend_from_slice(&[
+            0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49, 0x54, 0x0a,
+        ]);
+        h.push(0x21); // v2 PROXY
+        h.push(0x21); // TCP/IPv6
+        h.extend_from_slice(&36u16.to_be_bytes());
+        h.extend_from_slice(&src_ip.octets());
+        h.extend_from_slice(&dst_ip.octets());
+        h.extend_from_slice(&src_port.to_be_bytes());
+        h.extend_from_slice(&dst_port.to_be_bytes());
+        h
+    }
+
+    /// Wire a PROXY v2 LOCAL-command header (16 bytes; no address block).
+    /// Sent by L4 front-ends as a connection-test heartbeat.
+    fn pp2_local() -> Vec<u8> {
+        let mut h = Vec::with_capacity(16);
+        h.extend_from_slice(&[
+            0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49, 0x54, 0x0a,
+        ]);
+        h.push(0x20); // v2 LOCAL
+        h.push(0x00); // UNSPEC family/proto
+        h.extend_from_slice(&0u16.to_be_bytes()); // addr_len = 0
+        h
+    }
+
+    /// Open a TCP connection, write a raw PROXY v2 header, then complete the
+    /// TLS handshake. Returns `Ok(stream)` on success or `Err` on any failure.
+    async fn dot_connect_with_pp2(
+        addr: SocketAddr,
+        client_config: &Arc<rustls::ClientConfig>,
+        pp2_header: &[u8],
+    ) -> Result<tokio_rustls::client::TlsStream<tokio::net::TcpStream>, Box<dyn std::error::Error>>
+    {
+        let mut tcp = tokio::net::TcpStream::connect(addr).await?;
+        tcp.write_all(pp2_header).await?;
+        let connector = tokio_rustls::TlsConnector::from(Arc::clone(client_config));
+        let stream = connector
+            .connect(ServerName::try_from("numa.numa")?, tcp)
+            .await?;
+        Ok(stream)
+    }
+
+    #[tokio::test]
+    async fn pp2_dot_happy_path_ipv4() {
+        // Trusted client (127.0.0.1) sends a v4 PROXY header declaring an
+        // arbitrary upstream IP. Connection completes; query resolves.
+        let (addr, cert_der) = spawn_dot_server_with_pp(&["127.0.0.1"]).await;
+        let client_config = dot_client(&cert_der, dot_alpn());
+
+        let pp = pp2_v4_proxy(
+            "203.0.113.42".parse().unwrap(),
+            "10.0.0.5".parse().unwrap(),
+            54321,
+            853,
+        );
+        let mut stream = dot_connect_with_pp2(addr, &client_config, &pp)
+            .await
+            .expect("PROXY v2 + TLS handshake must succeed for trusted peer");
+
+        let query = DnsPacket::query(0xD001, "dot-test.example", QueryType::A);
+        let resp = dot_exchange(&mut stream, &query).await;
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert_eq!(resp.answers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn pp2_dot_required_drops_bare_client() {
+        // Allowlist contains the loopback, but the client sends a bare TLS
+        // ClientHello with no PROXY header. The first 12 bytes do not match
+        // the v2 signature → connection dropped → TLS handshake fails.
+        let (addr, cert_der) = spawn_dot_server_with_pp(&["127.0.0.1"]).await;
+        let client_config = dot_client(&cert_der, dot_alpn());
+
+        let connector = tokio_rustls::TlsConnector::from(client_config);
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let result = connector
+            .connect(ServerName::try_from("numa.numa").unwrap(), tcp)
+            .await;
+        assert!(
+            result.is_err(),
+            "PROXY-required listener must reject clients that omit the header"
+        );
+    }
+
+    #[tokio::test]
+    async fn pp2_dot_untrusted_peer_dropped() {
+        // Allowlist contains a non-loopback range only. Connections from
+        // 127.0.0.1 must be dropped before any read.
+        let (addr, cert_der) = spawn_dot_server_with_pp(&["192.0.2.0/24"]).await;
+        let client_config = dot_client(&cert_der, dot_alpn());
+
+        // Even with a valid PROXY v2 header, the listener must drop us
+        // because our actual TCP peer (127.0.0.1) is not on the allowlist.
+        let pp = pp2_v4_proxy(
+            "203.0.113.42".parse().unwrap(),
+            "10.0.0.5".parse().unwrap(),
+            54321,
+            853,
+        );
+        let result = dot_connect_with_pp2(addr, &client_config, &pp).await;
+        assert!(
+            result.is_err(),
+            "untrusted TCP peer must be dropped before peeking at PROXY v2"
+        );
+    }
+
+    #[tokio::test]
+    async fn pp2_dot_cross_family_v4_peer_v6_header() {
+        // The TCP peer is 127.0.0.1 (IPv4), but the PROXY v2 header declares
+        // an IPv6 source. Real production case behind dnsdist on dual-stack
+        // hosts. Numa must accept the connection and propagate the IPv6
+        // source as the connection's remote_addr.
+        let (addr, cert_der) = spawn_dot_server_with_pp(&["127.0.0.1"]).await;
+        let client_config = dot_client(&cert_der, dot_alpn());
+
+        let pp = pp2_v6_proxy(
+            "2001:db8::1".parse().unwrap(),
+            "2001:db8::cafe".parse().unwrap(),
+            54321,
+            853,
+        );
+        let mut stream = dot_connect_with_pp2(addr, &client_config, &pp)
+            .await
+            .expect("cross-family PROXY v2 must parse");
+
+        let query = DnsPacket::query(0xD002, "dot-test.example", QueryType::A);
+        let resp = dot_exchange(&mut stream, &query).await;
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+    }
+
+    #[tokio::test]
+    async fn pp2_dot_local_command() {
+        // LOCAL is the proxy's connection heartbeat (no proxied client).
+        // Numa must accept the connection and use the actual TCP peer as
+        // remote_addr instead of trying to dereference an absent address.
+        let (addr, cert_der) = spawn_dot_server_with_pp(&["127.0.0.1"]).await;
+        let client_config = dot_client(&cert_der, dot_alpn());
+
+        let mut stream = dot_connect_with_pp2(addr, &client_config, &pp2_local())
+            .await
+            .expect("LOCAL command must keep the connection alive");
+
+        let query = DnsPacket::query(0xD003, "dot-test.example", QueryType::A);
+        let resp = dot_exchange(&mut stream, &query).await;
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+    }
+
+    #[tokio::test]
+    async fn pp2_dot_truncated_header_times_out() {
+        // Sender writes the first 8 bytes of the signature and then sits
+        // there. Numa's header timeout fires; the TLS handshake never
+        // happens. On the client side the read returns EOF / connection
+        // reset.
+        let (addr, _cert_der) = spawn_dot_server_with_pp(&["127.0.0.1"]).await;
+
+        let mut tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        tcp.write_all(&[0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51])
+            .await
+            .unwrap();
+        // After the listener's 500ms header timeout, the server closes us.
+        let mut buf = [0u8; 16];
+        let read_res =
+            tokio::time::timeout(Duration::from_secs(2), tcp.read(&mut buf)).await;
+        match read_res {
+            Ok(Ok(0)) | Ok(Err(_)) => { /* expected: EOF or connection reset */ }
+            Ok(Ok(n)) => panic!(
+                "expected the server to drop the connection, got {n} bytes back"
+            ),
+            Err(_) => panic!("server did not drop the connection within 2s"),
+        }
+    }
+
+    #[tokio::test]
+    async fn pp2_dot_disabled_mode_passes_bare_client_through() {
+        // Empty allowlist == feature off. Direct clients (no header) keep
+        // working. This is the regression check that pp2 introduces no
+        // behavior change for users who don't enable the feature.
+        let (addr, cert_der) = spawn_dot_server_with_pp(&[]).await;
+        let client_config = dot_client(&cert_der, dot_alpn());
+        let mut stream = dot_connect(addr, &client_config).await;
+
+        let query = DnsPacket::query(0xD004, "dot-test.example", QueryType::A);
+        let resp = dot_exchange(&mut stream, &query).await;
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert_eq!(resp.answers.len(), 1);
     }
 }

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -83,19 +83,9 @@ pub async fn start_dot(ctx: Arc<ServerCtx>, config: &DotConfig) {
         },
     };
 
-    let pp = match PpConfig::from_config(&config.proxy_protocol) {
-        Ok(p) => p,
-        Err(e) => {
-            warn!("DoT: invalid proxy_protocol config ({}) — DoT disabled", e);
-            return;
-        }
+    let Ok(pp) = pp2::init("DoT", &config.proxy_protocol) else {
+        return;
     };
-    if pp.is_some() {
-        info!(
-            "DoT: PROXY v2 enabled, trusting {} CIDR(s)",
-            config.proxy_protocol.from.len()
-        );
-    }
 
     let bind_addr: IpAddr = config
         .bind_addr
@@ -117,11 +107,10 @@ pub async fn start_dot(ctx: Arc<ServerCtx>, config: &DotConfig) {
 async fn accept_loop(
     listener: TcpListener,
     acceptor: TlsAcceptor,
-    pp: Option<PpConfig>,
+    pp: Option<Arc<PpConfig>>,
     ctx: Arc<ServerCtx>,
 ) {
     let semaphore = Arc::new(Semaphore::new(MAX_CONNECTIONS));
-    let pp = pp.map(Arc::new);
 
     loop {
         let (tcp_stream, tcp_peer) = match listener.accept().await {
@@ -428,9 +417,7 @@ mod tests {
 
     /// Spin up a DoT listener with a PROXY v2 allowlist. `pp_from` is the list
     /// of CIDRs/IPs trusted to send PROXY v2 headers; empty = feature disabled.
-    async fn spawn_dot_server_with_pp(
-        pp_from: &[&str],
-    ) -> (SocketAddr, CertificateDer<'static>) {
+    async fn spawn_dot_server_with_pp(pp_from: &[&str]) -> (SocketAddr, CertificateDer<'static>) {
         let (server_tls, cert_der) = test_tls_configs();
 
         let upstream_addr = crate::testutil::blackhole_upstream();
@@ -465,11 +452,10 @@ mod tests {
 
         let pp_cfg = crate::config::ProxyProtocolConfig {
             from: pp_from.iter().map(|s| s.to_string()).collect(),
-            // Use a short timeout so the truncated-header test doesn't drag.
+            // Short timeout so the truncated-header test doesn't drag.
             header_timeout_ms: 500,
-            ..Default::default()
         };
-        let pp = PpConfig::from_config(&pp_cfg).unwrap();
+        let pp = PpConfig::from_config(&pp_cfg).unwrap().map(Arc::new);
 
         tokio::spawn(accept_loop(listener, acceptor, pp, ctx));
 
@@ -670,13 +656,10 @@ mod tests {
             .unwrap();
         // After the listener's 500ms header timeout, the server closes us.
         let mut buf = [0u8; 16];
-        let read_res =
-            tokio::time::timeout(Duration::from_secs(2), tcp.read(&mut buf)).await;
+        let read_res = tokio::time::timeout(Duration::from_secs(2), tcp.read(&mut buf)).await;
         match read_res {
             Ok(Ok(0)) | Ok(Err(_)) => { /* expected: EOF or connection reset */ }
-            Ok(Ok(n)) => panic!(
-                "expected the server to drop the connection, got {n} bytes back"
-            ),
+            Ok(Ok(n)) => panic!("expected the server to drop the connection, got {n} bytes back"),
             Err(_) => panic!("server did not drop the connection within 2s"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod mobileconfig;
 pub mod odoh;
 pub mod override_store;
 pub mod packet;
+pub mod pp2;
 pub mod proxy;
 pub mod query_log;
 pub mod question;

--- a/src/pp2.rs
+++ b/src/pp2.rs
@@ -1,0 +1,253 @@
+//! PROXY protocol v2 — client IP preservation behind L4 front-ends.
+//!
+//! Wraps [`proxy_header::io::ProxiedStream`] with a trusted-peer CIDR gate,
+//! a header-read timeout, and stats hooks. Used by the DoT and DoH accept
+//! loops; see `docs/implementation/proxy-protocol-v2.md` for the design.
+//!
+//! Naming and semantics mirror PowerDNS Recursor's `proxy-protocol-from`:
+//! an empty allowlist disables the feature; a non-empty one puts the
+//! listener in PROXY-required mode.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use ipnet::IpNet;
+use log::{debug, warn};
+use proxy_header::io::ProxiedStream;
+use proxy_header::ParseConfig;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpStream;
+
+use crate::config::ProxyProtocolConfig;
+use crate::ctx::ServerCtx;
+
+/// Runtime form of [`ProxyProtocolConfig`]: parsed CIDR list + already-typed
+/// timeout. Built once per listener at startup.
+#[derive(Clone, Debug)]
+pub struct PpConfig {
+    pub from: Vec<IpNet>,
+    pub max_size: u16,
+    pub header_timeout: Duration,
+}
+
+impl PpConfig {
+    /// Returns `Ok(None)` if the feature is disabled (empty `from`).
+    /// Returns `Err` if any allowlist entry fails to parse.
+    pub fn from_config(cfg: &ProxyProtocolConfig) -> Result<Option<Self>, String> {
+        if cfg.from.is_empty() {
+            return Ok(None);
+        }
+        let mut from = Vec::with_capacity(cfg.from.len());
+        for entry in &cfg.from {
+            let net: IpNet = entry
+                .parse()
+                .or_else(|_| entry.parse::<IpAddr>().map(IpNet::from))
+                .map_err(|_| format!("invalid CIDR or IP in proxy_protocol.from: {entry:?}"))?;
+            if matches!(&net, IpNet::V4(n) if n.prefix_len() == 0)
+                || matches!(&net, IpNet::V6(n) if n.prefix_len() == 0)
+            {
+                warn!(
+                    "proxy_protocol.from contains world-routable {} — any sender on the Internet will be permitted to spoof source IPs",
+                    entry
+                );
+            }
+            from.push(net);
+        }
+        Ok(Some(PpConfig {
+            from,
+            max_size: cfg.max_size,
+            header_timeout: Duration::from_millis(cfg.header_timeout_ms),
+        }))
+    }
+
+    fn allows(&self, peer: IpAddr) -> bool {
+        self.from.iter().any(|n| n.contains(&peer))
+    }
+}
+
+/// Read either the raw `TcpStream` (when PROXY v2 is disabled or this peer
+/// isn't an allowed sender) or a [`ProxiedStream`] wrapper, returning the
+/// stream and the resolved client `SocketAddr` (parsed from the header when
+/// present, otherwise the actual TCP peer).
+///
+/// Returns `None` when the connection should be dropped — either because
+/// the peer is not on the allowlist, or because the header failed to parse
+/// or arrive before the timeout. Stats are recorded as a side effect.
+pub async fn handshake(
+    tcp_stream: TcpStream,
+    tcp_peer: SocketAddr,
+    pp: Option<&PpConfig>,
+    ctx: &Arc<ServerCtx>,
+) -> Option<(Stream, SocketAddr)> {
+    let pp = match pp {
+        Some(p) => p,
+        // Feature disabled on this listener; passthrough.
+        None => return Some((Stream::Bare(tcp_stream), tcp_peer)),
+    };
+
+    if !pp.allows(tcp_peer.ip()) {
+        ctx.stats.lock().unwrap().proxy_v2_rejected_untrusted += 1;
+        debug!("pp2: untrusted peer {tcp_peer}, dropping");
+        return None;
+    }
+
+    let parse_cfg = ParseConfig {
+        allow_v1: false,
+        allow_v2: true,
+        include_tlvs: false,
+    };
+
+    let proxied = match tokio::time::timeout(
+        pp.header_timeout,
+        ProxiedStream::create_from_tokio(tcp_stream, parse_cfg),
+    )
+    .await
+    {
+        Ok(Ok(p)) => p,
+        Ok(Err(e)) => {
+            // proxy-header returns one error type for parse failures; we
+            // can't easily split signature/version/family without inspecting
+            // the message. Bucket as "signature" until the crate exposes
+            // structured error variants.
+            ctx.stats.lock().unwrap().proxy_v2_rejected_signature += 1;
+            debug!("pp2 parse from {tcp_peer}: {e}");
+            return None;
+        }
+        Err(_) => {
+            ctx.stats.lock().unwrap().proxy_v2_timeout += 1;
+            debug!("pp2: header read timeout from {tcp_peer}");
+            return None;
+        }
+    };
+
+    let header = proxied.proxy_header();
+    let real_addr = match header.proxied_address() {
+        Some(addr) => {
+            ctx.stats.lock().unwrap().proxy_v2_accepted += 1;
+            addr.source
+        }
+        None => {
+            // LOCAL command (proxy health check) or an address-less header.
+            // Use the TCP peer as the connection's remote_addr.
+            ctx.stats.lock().unwrap().proxy_v2_local_command += 1;
+            tcp_peer
+        }
+    };
+
+    Some((Stream::Proxied(Box::new(proxied)), real_addr))
+}
+
+/// `Either`-style enum covering the two states the listener may produce:
+/// the bare `TcpStream` (PROXY v2 disabled or peer-not-trusted-and-allowed
+/// path), or the `ProxiedStream` wrapper (header consumed, post-header
+/// bytes available for the next layer — TLS or plain DNS).
+///
+/// Both arms implement `AsyncRead + AsyncWrite + Unpin`, so callers hand
+/// the value straight to `TlsAcceptor::accept` or to a hyper service.
+pub enum Stream {
+    Bare(TcpStream),
+    Proxied(Box<ProxiedStream<TcpStream>>),
+}
+
+impl AsyncRead for Stream {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            Stream::Bare(s) => std::pin::Pin::new(s).poll_read(cx, buf),
+            Stream::Proxied(s) => std::pin::Pin::new(s.as_mut()).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for Stream {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            Stream::Bare(s) => std::pin::Pin::new(s).poll_write(cx, buf),
+            Stream::Proxied(s) => std::pin::Pin::new(s.as_mut()).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            Stream::Bare(s) => std::pin::Pin::new(s).poll_flush(cx),
+            Stream::Proxied(s) => std::pin::Pin::new(s.as_mut()).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            Stream::Bare(s) => std::pin::Pin::new(s).poll_shutdown(cx),
+            Stream::Proxied(s) => std::pin::Pin::new(s.as_mut()).poll_shutdown(cx),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(from: &[&str]) -> ProxyProtocolConfig {
+        ProxyProtocolConfig {
+            from: from.iter().map(|s| s.to_string()).collect(),
+            max_size: 512,
+            header_timeout_ms: 5000,
+        }
+    }
+
+    #[test]
+    fn empty_from_disables_feature() {
+        let pp = PpConfig::from_config(&cfg(&[])).unwrap();
+        assert!(pp.is_none());
+    }
+
+    #[test]
+    fn parses_exact_ipv4() {
+        let pp = PpConfig::from_config(&cfg(&["127.0.0.1"])).unwrap().unwrap();
+        assert!(pp.allows("127.0.0.1".parse().unwrap()));
+        assert!(!pp.allows("127.0.0.2".parse().unwrap()));
+    }
+
+    #[test]
+    fn parses_ipv4_cidr() {
+        let pp = PpConfig::from_config(&cfg(&["10.0.0.0/8"])).unwrap().unwrap();
+        assert!(pp.allows("10.255.255.255".parse().unwrap()));
+        assert!(!pp.allows("11.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn parses_ipv6_cidr() {
+        let pp = PpConfig::from_config(&cfg(&["fd00::/8"])).unwrap().unwrap();
+        assert!(pp.allows("fd00::1".parse().unwrap()));
+        assert!(!pp.allows("2001:db8::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(PpConfig::from_config(&cfg(&["not-a-cidr"])).is_err());
+    }
+
+    #[test]
+    fn mixed_v4_v6_allowlist() {
+        let pp = PpConfig::from_config(&cfg(&["127.0.0.1", "::1", "10.0.0.0/8"]))
+            .unwrap()
+            .unwrap();
+        assert!(pp.allows("127.0.0.1".parse().unwrap()));
+        assert!(pp.allows("::1".parse().unwrap()));
+        assert!(pp.allows("10.5.5.5".parse().unwrap()));
+        assert!(!pp.allows("8.8.8.8".parse().unwrap()));
+    }
+}

--- a/src/pp2.rs
+++ b/src/pp2.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ipnet::IpNet;
-use log::{debug, warn};
+use log::{debug, info, warn};
 use proxy_header::io::ProxiedStream;
 use proxy_header::ParseConfig;
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -27,7 +27,6 @@ use crate::ctx::ServerCtx;
 #[derive(Clone, Debug)]
 pub struct PpConfig {
     pub from: Vec<IpNet>,
-    pub max_size: u16,
     pub header_timeout: Duration,
 }
 
@@ -56,13 +55,34 @@ impl PpConfig {
         }
         Ok(Some(PpConfig {
             from,
-            max_size: cfg.max_size,
             header_timeout: Duration::from_millis(cfg.header_timeout_ms),
         }))
     }
 
     fn allows(&self, peer: IpAddr) -> bool {
         self.from.iter().any(|n| n.contains(&peer))
+    }
+}
+
+/// Parse a listener's `proxy_protocol` config and log the outcome.
+/// Returns `Err(())` if the config is invalid (caller should disable the
+/// listener). Returns `Ok(None)` when the feature is off, `Ok(Some(_))`
+/// when enabled.
+#[allow(clippy::result_unit_err)]
+pub fn init(listener: &str, cfg: &ProxyProtocolConfig) -> Result<Option<Arc<PpConfig>>, ()> {
+    match PpConfig::from_config(cfg) {
+        Ok(Some(pp)) => {
+            info!(
+                "{listener}: PROXY v2 enabled, trusting {} CIDR(s)",
+                cfg.from.len()
+            );
+            Ok(Some(Arc::new(pp)))
+        }
+        Ok(None) => Ok(None),
+        Err(e) => {
+            warn!("{listener}: invalid proxy_protocol config ({e}) — listener disabled");
+            Err(())
+        }
     }
 }
 
@@ -203,7 +223,6 @@ mod tests {
     fn cfg(from: &[&str]) -> ProxyProtocolConfig {
         ProxyProtocolConfig {
             from: from.iter().map(|s| s.to_string()).collect(),
-            max_size: 512,
             header_timeout_ms: 5000,
         }
     }
@@ -216,14 +235,18 @@ mod tests {
 
     #[test]
     fn parses_exact_ipv4() {
-        let pp = PpConfig::from_config(&cfg(&["127.0.0.1"])).unwrap().unwrap();
+        let pp = PpConfig::from_config(&cfg(&["127.0.0.1"]))
+            .unwrap()
+            .unwrap();
         assert!(pp.allows("127.0.0.1".parse().unwrap()));
         assert!(!pp.allows("127.0.0.2".parse().unwrap()));
     }
 
     #[test]
     fn parses_ipv4_cidr() {
-        let pp = PpConfig::from_config(&cfg(&["10.0.0.0/8"])).unwrap().unwrap();
+        let pp = PpConfig::from_config(&cfg(&["10.0.0.0/8"]))
+            .unwrap()
+            .unwrap();
         assert!(pp.allows("10.255.255.255".parse().unwrap()));
         assert!(!pp.allows("11.0.0.1".parse().unwrap()));
     }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -83,30 +83,25 @@ pub async fn start_proxy_tls(
         return;
     }
 
-    let pp = match PpConfig::from_config(pp_cfg) {
-        Ok(p) => p,
-        Err(e) => {
-            warn!(
-                "proxy: invalid proxy_protocol config ({}) — HTTPS proxy disabled",
-                e
-            );
-            return;
-        }
+    let Ok(pp) = pp2::init("proxy", pp_cfg) else {
+        return;
     };
-    if pp.is_some() {
-        info!(
-            "proxy: PROXY v2 enabled, trusting {} CIDR(s)",
-            pp_cfg.from.len()
-        );
-    }
-    let pp = pp.map(Arc::new);
 
+    accept_loop_tls(listener, ctx, pp).await;
+}
+
+/// Per-connection accept loop for the TLS-fronted DoH/HTTPS listener.
+/// Split from `start_proxy_tls` so tests can drive it against an ephemeral
+/// listener without rebinding ports. Caller guarantees `ctx.tls_config` is set.
+async fn accept_loop_tls(
+    listener: tokio::net::TcpListener,
+    ctx: Arc<ServerCtx>,
+    pp: Option<Arc<PpConfig>>,
+) {
     let client: HttpClient = Client::builder(TokioExecutor::new())
         .http1_preserve_header_case(true)
         .build_http();
 
-    // Hold a separate Arc so we can access tls_config after ctx moves into ProxyState
-    let tls_holder = Arc::clone(&ctx);
     let proxy_state = ProxyState {
         ctx: Arc::clone(&ctx),
         client,
@@ -129,9 +124,8 @@ pub async fn start_proxy_tls(
         };
 
         // Load the latest TLS config on each connection (picks up new service certs)
-        // unwrap safe: guarded by is_none() check above
-        let acceptor =
-            TlsAcceptor::from(Arc::clone(&*tls_holder.tls_config.as_ref().unwrap().load()));
+        // unwrap safe: caller guards on ctx.tls_config.is_some()
+        let acceptor = TlsAcceptor::from(Arc::clone(&*ctx.tls_config.as_ref().unwrap().load()));
 
         let proxy_state = proxy_state.clone();
         let doh_state = doh_state.clone();
@@ -463,4 +457,241 @@ async fn handle_upgrade(
         resp = resp.header(key, value);
     }
     resp.body(Body::empty()).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use rcgen::{CertificateParams, DnType, KeyPair};
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
+    use rustls::ServerConfig;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use crate::buffer::BytePacketBuffer;
+    use crate::header::ResultCode;
+    use crate::packet::DnsPacket;
+    use crate::question::QueryType;
+    use crate::record::DnsRecord;
+
+    // ----------------------------------------------------------------------
+    // PROXY protocol v2 integration tests for DoH (RFC 8484 over the TLS-
+    // fronted proxy listener). Mirrors the DoT suite in `src/dot.rs::tests`.
+    // ----------------------------------------------------------------------
+
+    /// Self-signed TLS server config that vouches for `*.numa` + `numa.numa`,
+    /// matching the SAN shape produced by `tls::build_tls_config` in production.
+    fn test_tls_configs() -> (Arc<ServerConfig>, CertificateDer<'static>) {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let key_pair = KeyPair::generate().unwrap();
+        let mut params = CertificateParams::default();
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "Numa .numa services");
+        params.subject_alt_names = vec![
+            rcgen::SanType::DnsName("*.numa".try_into().unwrap()),
+            rcgen::SanType::DnsName("numa.numa".try_into().unwrap()),
+        ];
+        let cert = params.self_signed(&key_pair).unwrap();
+
+        let cert_der = CertificateDer::from(cert.der().to_vec());
+        let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
+
+        let server_config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert_der.clone()], key_der)
+            .unwrap();
+
+        (Arc::new(server_config), cert_der)
+    }
+
+    /// Wire a PROXY v2 IPv4 PROXY-command header (28 bytes total).
+    fn pp2_v4_proxy(
+        src_ip: std::net::Ipv4Addr,
+        dst_ip: std::net::Ipv4Addr,
+        src_port: u16,
+        dst_port: u16,
+    ) -> Vec<u8> {
+        let mut h = Vec::with_capacity(28);
+        h.extend_from_slice(&[
+            0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49, 0x54, 0x0a,
+        ]);
+        h.push(0x21); // v2 PROXY
+        h.push(0x11); // TCP/IPv4
+        h.extend_from_slice(&12u16.to_be_bytes());
+        h.extend_from_slice(&src_ip.octets());
+        h.extend_from_slice(&dst_ip.octets());
+        h.extend_from_slice(&src_port.to_be_bytes());
+        h.extend_from_slice(&dst_port.to_be_bytes());
+        h
+    }
+
+    /// Spin up a DoH-capable TLS listener with a PROXY v2 allowlist.
+    async fn spawn_doh_server_with_pp(pp_from: &[&str]) -> (SocketAddr, CertificateDer<'static>) {
+        let (server_tls, cert_der) = test_tls_configs();
+        let upstream_addr = crate::testutil::blackhole_upstream();
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.zone_map = {
+            let mut m = HashMap::new();
+            let mut inner = HashMap::new();
+            inner.insert(
+                QueryType::A,
+                vec![DnsRecord::A {
+                    domain: "doh-test.example".to_string(),
+                    addr: std::net::Ipv4Addr::new(10, 0, 0, 2),
+                    ttl: 300,
+                }],
+            );
+            m.insert("doh-test.example".to_string(), inner);
+            m
+        };
+        ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
+            vec![crate::forward::Upstream::Udp(upstream_addr)],
+            vec![],
+        ));
+        ctx.tls_config = Some(arc_swap::ArcSwap::from(server_tls));
+        let ctx = Arc::new(ctx);
+
+        let pp_cfg = ProxyProtocolConfig {
+            from: pp_from.iter().map(|s| s.to_string()).collect(),
+            header_timeout_ms: 500,
+        };
+        let pp = PpConfig::from_config(&pp_cfg).unwrap().map(Arc::new);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(accept_loop_tls(listener, ctx, pp));
+
+        (addr, cert_der)
+    }
+
+    /// Build a TLS client config that trusts the server's self-signed cert.
+    fn doh_client_config(cert_der: &CertificateDer<'static>) -> Arc<rustls::ClientConfig> {
+        let mut root_store = rustls::RootCertStore::empty();
+        root_store.add(cert_der.clone()).unwrap();
+        let config = rustls::ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+        Arc::new(config)
+    }
+
+    /// Drive a single HTTP/1.1 `POST /dns-query` over an open TLS stream.
+    /// Sends `Connection: close` so the server tears down after the body and
+    /// `read_to_end` terminates without keep-alive bookkeeping.
+    async fn doh_post_raw(
+        stream: &mut tokio_rustls::client::TlsStream<tokio::net::TcpStream>,
+        query_wire: &[u8],
+    ) -> (u16, Vec<u8>) {
+        let head = format!(
+            "POST /dns-query HTTP/1.1\r\n\
+             Host: numa.numa\r\n\
+             Content-Type: application/dns-message\r\n\
+             Content-Length: {}\r\n\
+             Connection: close\r\n\r\n",
+            query_wire.len(),
+        );
+        stream.write_all(head.as_bytes()).await.unwrap();
+        stream.write_all(query_wire).await.unwrap();
+        stream.flush().await.unwrap();
+
+        let mut all = Vec::new();
+        stream.read_to_end(&mut all).await.unwrap();
+
+        let split = all
+            .windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .expect("HTTP header/body separator");
+        let header_block = std::str::from_utf8(&all[..split]).unwrap();
+        let status: u16 = header_block
+            .lines()
+            .next()
+            .and_then(|l| l.split_whitespace().nth(1))
+            .and_then(|s| s.parse().ok())
+            .expect("HTTP status line");
+        (status, all[split + 4..].to_vec())
+    }
+
+    #[tokio::test]
+    async fn pp2_doh_happy_path_ipv4() {
+        // Trusted client (127.0.0.1) sends a v4 PROXY header before the TLS
+        // ClientHello; server completes TLS, parses the wire DNS message,
+        // and returns NOERROR with the local-zone A record.
+        let (addr, cert_der) = spawn_doh_server_with_pp(&["127.0.0.1"]).await;
+        let client_config = doh_client_config(&cert_der);
+
+        let mut tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let pp = pp2_v4_proxy(
+            "203.0.113.42".parse().unwrap(),
+            "10.0.0.5".parse().unwrap(),
+            54321,
+            443,
+        );
+        tcp.write_all(&pp).await.unwrap();
+        let connector = tokio_rustls::TlsConnector::from(client_config);
+        let mut stream = connector
+            .connect(ServerName::try_from("numa.numa").unwrap(), tcp)
+            .await
+            .expect("PROXY v2 + TLS handshake must succeed for trusted peer");
+
+        let query = DnsPacket::query(0xE001, "doh-test.example", QueryType::A);
+        let mut q_buf = BytePacketBuffer::new();
+        query.write(&mut q_buf).unwrap();
+
+        let (status, body) = doh_post_raw(&mut stream, q_buf.filled()).await;
+        assert_eq!(status, 200);
+        let mut r_buf = BytePacketBuffer::from_bytes(&body);
+        let resp = DnsPacket::from_buffer(&mut r_buf).unwrap();
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert_eq!(resp.answers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn pp2_doh_required_drops_bare_client() {
+        // Allowlist contains the loopback, but the client skips the PROXY
+        // header. The first 12 bytes of the TLS ClientHello do not match the
+        // v2 signature → connection dropped → TLS handshake fails.
+        let (addr, cert_der) = spawn_doh_server_with_pp(&["127.0.0.1"]).await;
+        let client_config = doh_client_config(&cert_der);
+
+        let connector = tokio_rustls::TlsConnector::from(client_config);
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let result = connector
+            .connect(ServerName::try_from("numa.numa").unwrap(), tcp)
+            .await;
+        assert!(
+            result.is_err(),
+            "PROXY-required DoH listener must reject clients that omit the header"
+        );
+    }
+
+    #[tokio::test]
+    async fn pp2_doh_disabled_mode_passes_bare_client_through() {
+        // Empty allowlist == feature off. Direct DoH clients keep working —
+        // regression check that pp2 introduces no behavior change for users
+        // who don't enable the feature.
+        let (addr, cert_der) = spawn_doh_server_with_pp(&[]).await;
+        let client_config = doh_client_config(&cert_der);
+
+        let connector = tokio_rustls::TlsConnector::from(client_config);
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let mut stream = connector
+            .connect(ServerName::try_from("numa.numa").unwrap(), tcp)
+            .await
+            .expect("disabled-mode listener must accept bare TLS clients");
+
+        let query = DnsPacket::query(0xE002, "doh-test.example", QueryType::A);
+        let mut q_buf = BytePacketBuffer::new();
+        query.write(&mut q_buf).unwrap();
+
+        let (status, body) = doh_post_raw(&mut stream, q_buf.filled()).await;
+        assert_eq!(status, 200);
+        let mut r_buf = BytePacketBuffer::from_bytes(&body);
+        let resp = DnsPacket::from_buffer(&mut r_buf).unwrap();
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert_eq!(resp.answers.len(), 1);
+    }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -14,7 +14,9 @@ use log::{debug, error, info, warn};
 use tokio::io::copy_bidirectional;
 use tokio_rustls::TlsAcceptor;
 
+use crate::config::ProxyProtocolConfig;
 use crate::ctx::ServerCtx;
+use crate::pp2::{self, PpConfig};
 
 type HttpClient = Client<hyper_util::client::legacy::connect::HttpConnector, Body>;
 
@@ -57,7 +59,12 @@ pub async fn start_proxy(ctx: Arc<ServerCtx>, port: u16, bind_addr: Ipv4Addr) {
     axum::serve(listener, app).await.unwrap();
 }
 
-pub async fn start_proxy_tls(ctx: Arc<ServerCtx>, port: u16, bind_addr: Ipv4Addr) {
+pub async fn start_proxy_tls(
+    ctx: Arc<ServerCtx>,
+    port: u16,
+    bind_addr: Ipv4Addr,
+    pp_cfg: &ProxyProtocolConfig,
+) {
     let addr: SocketAddr = (bind_addr, port).into();
     let listener = match tokio::net::TcpListener::bind(addr).await {
         Ok(l) => l,
@@ -76,6 +83,24 @@ pub async fn start_proxy_tls(ctx: Arc<ServerCtx>, port: u16, bind_addr: Ipv4Addr
         return;
     }
 
+    let pp = match PpConfig::from_config(pp_cfg) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                "proxy: invalid proxy_protocol config ({}) — HTTPS proxy disabled",
+                e
+            );
+            return;
+        }
+    };
+    if pp.is_some() {
+        info!(
+            "proxy: PROXY v2 enabled, trusting {} CIDR(s)",
+            pp_cfg.from.len()
+        );
+    }
+    let pp = pp.map(Arc::new);
+
     let client: HttpClient = Client::builder(TokioExecutor::new())
         .http1_preserve_header_case(true)
         .build_http();
@@ -90,12 +115,12 @@ pub async fn start_proxy_tls(ctx: Arc<ServerCtx>, port: u16, bind_addr: Ipv4Addr
     // DoH route (RFC 8484) served only on the TLS listener.
     // DohState.remote_addr is set per-connection below.
     let doh_state = DohState {
-        ctx,
+        ctx: Arc::clone(&ctx),
         remote_addr: None,
     };
 
     loop {
-        let (tcp_stream, remote_addr) = match listener.accept().await {
+        let (tcp_stream, tcp_peer) = match listener.accept().await {
             Ok(conn) => conn,
             Err(e) => {
                 error!("TLS accept error: {}", e);
@@ -108,19 +133,30 @@ pub async fn start_proxy_tls(ctx: Arc<ServerCtx>, port: u16, bind_addr: Ipv4Addr
         let acceptor =
             TlsAcceptor::from(Arc::clone(&*tls_holder.tls_config.as_ref().unwrap().load()));
 
-        let mut conn_doh_state = doh_state.clone();
-        conn_doh_state.remote_addr = Some(remote_addr);
-
-        let app = Router::new()
-            .route(
-                "/dns-query",
-                post(crate::doh::doh_post).with_state(conn_doh_state),
-            )
-            .fallback(any(proxy_handler))
-            .with_state(proxy_state.clone());
+        let proxy_state = proxy_state.clone();
+        let doh_state = doh_state.clone();
+        let ctx_for_pp2 = Arc::clone(&ctx);
+        let pp = pp.clone();
 
         tokio::spawn(async move {
-            let tls_stream = match acceptor.accept(tcp_stream).await {
+            let Some((stream, remote_addr)) =
+                pp2::handshake(tcp_stream, tcp_peer, pp.as_deref(), &ctx_for_pp2).await
+            else {
+                return;
+            };
+
+            let mut conn_doh_state = doh_state;
+            conn_doh_state.remote_addr = Some(remote_addr);
+
+            let app = Router::new()
+                .route(
+                    "/dns-query",
+                    post(crate::doh::doh_post).with_state(conn_doh_state),
+                )
+                .fallback(any(proxy_handler))
+                .with_state(proxy_state);
+
+            let tls_stream = match acceptor.accept(stream).await {
                 Ok(s) => s,
                 Err(e) => {
                     debug!("TLS handshake failed from {}: {}", remote_addr, e);

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -90,9 +90,6 @@ pub async fn start_proxy_tls(
     accept_loop_tls(listener, ctx, pp).await;
 }
 
-/// Per-connection accept loop for the TLS-fronted DoH/HTTPS listener.
-/// Split from `start_proxy_tls` so tests can drive it against an ephemeral
-/// listener without rebinding ports. Caller guarantees `ctx.tls_config` is set.
 async fn accept_loop_tls(
     listener: tokio::net::TcpListener,
     ctx: Arc<ServerCtx>,
@@ -476,11 +473,6 @@ mod tests {
     use crate::question::QueryType;
     use crate::record::DnsRecord;
 
-    // ----------------------------------------------------------------------
-    // PROXY protocol v2 integration tests for DoH (RFC 8484 over the TLS-
-    // fronted proxy listener). Mirrors the DoT suite in `src/dot.rs::tests`.
-    // ----------------------------------------------------------------------
-
     /// Self-signed TLS server config that vouches for `*.numa` + `numa.numa`,
     /// matching the SAN shape produced by `tls::build_tls_config` in production.
     fn test_tls_configs() -> (Arc<ServerConfig>, CertificateDer<'static>) {
@@ -569,16 +561,6 @@ mod tests {
         (addr, cert_der)
     }
 
-    /// Build a TLS client config that trusts the server's self-signed cert.
-    fn doh_client_config(cert_der: &CertificateDer<'static>) -> Arc<rustls::ClientConfig> {
-        let mut root_store = rustls::RootCertStore::empty();
-        root_store.add(cert_der.clone()).unwrap();
-        let config = rustls::ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
-        Arc::new(config)
-    }
-
     /// Drive a single HTTP/1.1 `POST /dns-query` over an open TLS stream.
     /// Sends `Connection: close` so the server tears down after the body and
     /// `read_to_end` terminates without keep-alive bookkeeping.
@@ -621,7 +603,14 @@ mod tests {
         // ClientHello; server completes TLS, parses the wire DNS message,
         // and returns NOERROR with the local-zone A record.
         let (addr, cert_der) = spawn_doh_server_with_pp(&["127.0.0.1"]).await;
-        let client_config = doh_client_config(&cert_der);
+
+        let mut root_store = rustls::RootCertStore::empty();
+        root_store.add(cert_der).unwrap();
+        let client_config = Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(root_store)
+                .with_no_client_auth(),
+        );
 
         let mut tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
         let pp = pp2_v4_proxy(
@@ -638,52 +627,6 @@ mod tests {
             .expect("PROXY v2 + TLS handshake must succeed for trusted peer");
 
         let query = DnsPacket::query(0xE001, "doh-test.example", QueryType::A);
-        let mut q_buf = BytePacketBuffer::new();
-        query.write(&mut q_buf).unwrap();
-
-        let (status, body) = doh_post_raw(&mut stream, q_buf.filled()).await;
-        assert_eq!(status, 200);
-        let mut r_buf = BytePacketBuffer::from_bytes(&body);
-        let resp = DnsPacket::from_buffer(&mut r_buf).unwrap();
-        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
-        assert_eq!(resp.answers.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn pp2_doh_required_drops_bare_client() {
-        // Allowlist contains the loopback, but the client skips the PROXY
-        // header. The first 12 bytes of the TLS ClientHello do not match the
-        // v2 signature → connection dropped → TLS handshake fails.
-        let (addr, cert_der) = spawn_doh_server_with_pp(&["127.0.0.1"]).await;
-        let client_config = doh_client_config(&cert_der);
-
-        let connector = tokio_rustls::TlsConnector::from(client_config);
-        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let result = connector
-            .connect(ServerName::try_from("numa.numa").unwrap(), tcp)
-            .await;
-        assert!(
-            result.is_err(),
-            "PROXY-required DoH listener must reject clients that omit the header"
-        );
-    }
-
-    #[tokio::test]
-    async fn pp2_doh_disabled_mode_passes_bare_client_through() {
-        // Empty allowlist == feature off. Direct DoH clients keep working —
-        // regression check that pp2 introduces no behavior change for users
-        // who don't enable the feature.
-        let (addr, cert_der) = spawn_doh_server_with_pp(&[]).await;
-        let client_config = doh_client_config(&cert_der);
-
-        let connector = tokio_rustls::TlsConnector::from(client_config);
-        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let mut stream = connector
-            .connect(ServerName::try_from("numa.numa").unwrap(), tcp)
-            .await
-            .expect("disabled-mode listener must accept bare TLS clients");
-
-        let query = DnsPacket::query(0xE002, "doh-test.example", QueryType::A);
         let mut q_buf = BytePacketBuffer::new();
         query.write(&mut q_buf).unwrap();
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -562,8 +562,9 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     {
         let tcp_ctx = Arc::clone(&ctx);
         let tcp_bind = config.server.bind_addr.clone();
+        let tcp_pp = config.server.proxy_protocol.clone();
         tokio::spawn(async move {
-            crate::tcp::start_tcp(tcp_ctx, &tcp_bind).await;
+            crate::tcp::start_tcp(tcp_ctx, &tcp_bind, &tcp_pp).await;
         });
     }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -526,8 +526,9 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     if config.proxy.enabled && config.proxy.tls_port > 0 && ctx.tls_config.is_some() {
         let proxy_ctx = Arc::clone(&ctx);
         let tls_port = config.proxy.tls_port;
+        let pp_cfg = config.proxy.proxy_protocol.clone();
         tokio::spawn(async move {
-            crate::proxy::start_proxy_tls(proxy_ctx, tls_port, proxy_bind).await;
+            crate::proxy::start_proxy_tls(proxy_ctx, tls_port, proxy_bind, &pp_cfg).await;
         });
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -106,6 +106,11 @@ pub struct ServerStats {
     upstream_transport_doh: u64,
     upstream_transport_dot: u64,
     upstream_transport_odoh: u64,
+    pub(crate) proxy_v2_accepted: u64,
+    pub(crate) proxy_v2_rejected_untrusted: u64,
+    pub(crate) proxy_v2_rejected_signature: u64,
+    pub(crate) proxy_v2_local_command: u64,
+    pub(crate) proxy_v2_timeout: u64,
     started_at: Instant,
 }
 
@@ -235,6 +240,11 @@ impl ServerStats {
             upstream_transport_doh: 0,
             upstream_transport_dot: 0,
             upstream_transport_odoh: 0,
+            proxy_v2_accepted: 0,
+            proxy_v2_rejected_untrusted: 0,
+            proxy_v2_rejected_signature: 0,
+            proxy_v2_local_command: 0,
+            proxy_v2_timeout: 0,
             started_at: Instant::now(),
         }
     }
@@ -303,6 +313,11 @@ impl ServerStats {
             upstream_transport_doh: self.upstream_transport_doh,
             upstream_transport_dot: self.upstream_transport_dot,
             upstream_transport_odoh: self.upstream_transport_odoh,
+            proxy_v2_accepted: self.proxy_v2_accepted,
+            proxy_v2_rejected_untrusted: self.proxy_v2_rejected_untrusted,
+            proxy_v2_rejected_signature: self.proxy_v2_rejected_signature,
+            proxy_v2_local_command: self.proxy_v2_local_command,
+            proxy_v2_timeout: self.proxy_v2_timeout,
         }
     }
 
@@ -353,4 +368,9 @@ pub struct StatsSnapshot {
     pub upstream_transport_doh: u64,
     pub upstream_transport_dot: u64,
     pub upstream_transport_odoh: u64,
+    pub proxy_v2_accepted: u64,
+    pub proxy_v2_rejected_untrusted: u64,
+    pub proxy_v2_rejected_signature: u64,
+    pub proxy_v2_local_command: u64,
+    pub proxy_v2_timeout: u64,
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -12,9 +12,11 @@ use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
 
 use crate::buffer::BytePacketBuffer;
+use crate::config::ProxyProtocolConfig;
 use crate::ctx::{resolve_query, ServerCtx};
 use crate::header::ResultCode;
 use crate::packet::DnsPacket;
+use crate::pp2::{self, PpConfig};
 use crate::stats::Transport;
 
 const MAX_CONNECTIONS: usize = 512;
@@ -25,7 +27,7 @@ const WRITE_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_MSG_LEN: usize = 4096;
 
 /// Start the DNS-over-TCP listener on the same address as the UDP listener.
-pub async fn start_tcp(ctx: Arc<ServerCtx>, bind_addr: &str) {
+pub async fn start_tcp(ctx: Arc<ServerCtx>, bind_addr: &str, pp_cfg: &ProxyProtocolConfig) {
     let addr: SocketAddr = match bind_addr.parse() {
         Ok(a) => a,
         Err(e) => {
@@ -37,6 +39,10 @@ pub async fn start_tcp(ctx: Arc<ServerCtx>, bind_addr: &str) {
         }
     };
 
+    let Ok(pp) = pp2::init("TCP", pp_cfg) else {
+        return;
+    };
+
     let listener = match TcpListener::bind(addr).await {
         Ok(l) => l,
         Err(e) => {
@@ -46,14 +52,14 @@ pub async fn start_tcp(ctx: Arc<ServerCtx>, bind_addr: &str) {
     };
     info!("TCP DNS listening on {}", addr);
 
-    accept_loop(listener, ctx).await;
+    accept_loop(listener, pp, ctx).await;
 }
 
-async fn accept_loop(listener: TcpListener, ctx: Arc<ServerCtx>) {
+async fn accept_loop(listener: TcpListener, pp: Option<Arc<PpConfig>>, ctx: Arc<ServerCtx>) {
     let semaphore = Arc::new(Semaphore::new(MAX_CONNECTIONS));
 
     loop {
-        let (stream, peer) = match listener.accept().await {
+        let (tcp_stream, tcp_peer) = match listener.accept().await {
             Ok(conn) => conn,
             Err(e) => {
                 error!("TCP: accept error: {}", e);
@@ -65,15 +71,23 @@ async fn accept_loop(listener: TcpListener, ctx: Arc<ServerCtx>) {
         let permit = match semaphore.clone().try_acquire_owned() {
             Ok(p) => p,
             Err(_) => {
-                debug!("TCP: connection limit reached, rejecting {}", peer);
+                debug!("TCP: connection limit reached, rejecting {}", tcp_peer);
                 continue;
             }
         };
         let ctx = Arc::clone(&ctx);
+        let pp = pp.clone();
 
         tokio::spawn(async move {
             let _permit = permit;
-            handle_framed_dns_connection(stream, peer, &ctx, Transport::Tcp).await;
+
+            let Some((stream, remote_addr)) =
+                pp2::handshake(tcp_stream, tcp_peer, pp.as_deref(), &ctx).await
+            else {
+                return;
+            };
+
+            handle_framed_dns_connection(stream, remote_addr, &ctx, Transport::Tcp).await;
         });
     }
 }
@@ -245,7 +259,7 @@ mod tests {
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        tokio::spawn(accept_loop(listener, ctx));
+        tokio::spawn(accept_loop(listener, None, ctx));
         addr
     }
 
@@ -357,5 +371,84 @@ mod tests {
         for h in handles {
             h.await.unwrap();
         }
+    }
+
+    // PROXY protocol v2 wiring check. The pp2 module is exhaustively tested
+    // via dot::tests::pp2_*; this confirms tcp::accept_loop calls
+    // pp2::handshake before handing off to the framed handler. Mirrors
+    // doh::tests::pp2_doh_happy_path_ipv4.
+    async fn spawn_tcp_server_with_pp(pp_from: &[&str]) -> SocketAddr {
+        let upstream_addr = crate::testutil::blackhole_upstream();
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.zone_map = {
+            let mut m = HashMap::new();
+            let mut inner = HashMap::new();
+            inner.insert(
+                QueryType::A,
+                vec![DnsRecord::A {
+                    domain: "tcp-test.example".to_string(),
+                    addr: std::net::Ipv4Addr::new(10, 0, 0, 1),
+                    ttl: 300,
+                }],
+            );
+            m.insert("tcp-test.example".to_string(), inner);
+            m
+        };
+        ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
+            vec![crate::forward::Upstream::Udp(upstream_addr)],
+            vec![],
+        ));
+        let ctx = Arc::new(ctx);
+
+        let pp_cfg = crate::config::ProxyProtocolConfig {
+            from: pp_from.iter().map(|s| s.to_string()).collect(),
+            header_timeout_ms: 500,
+        };
+        let pp = PpConfig::from_config(&pp_cfg).unwrap().map(Arc::new);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(accept_loop(listener, pp, ctx));
+        addr
+    }
+
+    fn pp2_v4_proxy_header(
+        src_ip: std::net::Ipv4Addr,
+        dst_ip: std::net::Ipv4Addr,
+        src_port: u16,
+        dst_port: u16,
+    ) -> Vec<u8> {
+        let mut h = Vec::with_capacity(28);
+        h.extend_from_slice(&[
+            0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49, 0x54, 0x0a,
+        ]);
+        h.push(0x21); // v2 PROXY
+        h.push(0x11); // TCP/IPv4
+        h.extend_from_slice(&12u16.to_be_bytes());
+        h.extend_from_slice(&src_ip.octets());
+        h.extend_from_slice(&dst_ip.octets());
+        h.extend_from_slice(&src_port.to_be_bytes());
+        h.extend_from_slice(&dst_port.to_be_bytes());
+        h
+    }
+
+    #[tokio::test]
+    async fn pp2_tcp_happy_path_ipv4() {
+        let addr = spawn_tcp_server_with_pp(&["127.0.0.1"]).await;
+
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        let pp = pp2_v4_proxy_header(
+            "203.0.113.42".parse().unwrap(),
+            "10.0.0.5".parse().unwrap(),
+            54321,
+            53,
+        );
+        stream.write_all(&pp).await.unwrap();
+
+        let query = DnsPacket::query(0xD001, "tcp-test.example", QueryType::A);
+        let resp = tcp_exchange(&mut stream, &query).await;
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert_eq!(resp.answers.len(), 1);
     }
 }

--- a/tests/docker/dnsdist-numa-l7/README.md
+++ b/tests/docker/dnsdist-numa-l7/README.md
@@ -1,0 +1,75 @@
+# dnsdist L7 → numa: PROXY v2 over plain TCP
+
+End-to-end harness for the dnsdist front-end deployment shape.
+dnsdist accepts UDP+TCP/53 from clients, transmuxes every backend query
+to TCP, and prepends a PROXY v2 header at connection open. numa parses
+the PROXY header, runs the framed-DNS handler, and records the real
+client IP via `/stats.proxy_protocol.*` counters.
+
+```
+host dig +udp ──UDP──> dnsdist :53 ──TCP+PROXY v2──> numa :53 ──forward──> 9.9.9.9
+```
+
+## Why this configuration
+
+PROXY v2 on the plain-DNS hop requires either UDP PROXY v2 ingestion in
+numa (deferred per PR #156's "Out of scope") *or* dnsdist forcing the
+backend to TCP. The latter is a single config flag — `tcpOnly=true` on
+`newServer` — and avoids per-datagram PROXY framing entirely. Clients
+keep low-latency UDP, the PROXY-v2-bearing hop is 100% TCP, and numa's
+existing TCP+PROXY support handles the rest.
+
+```lua
+newServer({
+  address = '172.29.0.10:53',
+  tcpOnly = true,
+  useProxyProtocol = true,
+})
+```
+
+## Run the smoke
+
+```sh
+./smoke.sh
+```
+
+Builds the local numa Dockerfile, starts dnsdist 2.0, runs `dig +udp`
+queries through dnsdist, and asserts:
+
+- `proxy_protocol.accepted` increments per query.
+- `transport.tcp` increments (proves the dnsdist→numa hop is TCP).
+- `transport.udp` does **not** grow on that hop (proves `tcpOnly=true`).
+- No pp2 rejections or timeouts.
+
+## Manual probe
+
+```sh
+docker compose up -d --build
+
+# UDP from host → dnsdist → TCP+PROXY v2 → numa
+dig +short @127.0.0.1 -p 15454 example.com
+
+# numa stats — proxy_protocol.accepted grows with each query
+curl -s http://127.0.0.1:15381/stats | jq '.proxy_protocol, .transport'
+
+# pp2 trace
+docker compose logs numa | grep -i pp2
+```
+
+## Tear down
+
+```sh
+docker compose down -v
+```
+
+## Comparison with the HAProxy harness
+
+| | `pp2-numa/` (HAProxy) | `dnsdist-numa-l7/` (this) |
+|---|---|---|
+| Front-end | HAProxy 2.9 (L4 passthrough) | dnsdist 2.0 (L7 DNS-aware) |
+| Numa transports exercised | DoT (:853) + plain TCP (:53) | Plain TCP (:53) |
+| Client transport | TLS + raw TCP | UDP (transmuxed by dnsdist) |
+| PROXY v2 source | `send-proxy-v2` (HAProxy) | `useProxyProtocol=true` (dnsdist) |
+| Validates | DoT-terminating front-ends | DNS-aware UDP-in front-ends |
+
+Run both for the full PR #156 coverage matrix.

--- a/tests/docker/dnsdist-numa-l7/dnsdist.conf
+++ b/tests/docker/dnsdist-numa-l7/dnsdist.conf
@@ -1,0 +1,17 @@
+-- L7 dnsdist front-end fronting numa, with UDP→TCP transmuxing.
+--
+-- Listens on UDP+TCP/53 from clients, forces all backend queries over
+-- TCP (`tcpOnly=true`), and prepends a PROXY v2 header at connection
+-- open (`useProxyProtocol=true`). This lets numa receive real client
+-- IPs over plain DNS without UDP PROXY v2 support: clients still get
+-- low-latency UDP, the PROXY-v2-bearing hop is 100% TCP.
+
+addLocal('0.0.0.0:53')
+
+newServer({
+  address = '172.29.0.10:53',
+  tcpOnly = true,
+  useProxyProtocol = true,
+})
+
+setACL({'0.0.0.0/0', '::/0'})

--- a/tests/docker/dnsdist-numa-l7/docker-compose.yml
+++ b/tests/docker/dnsdist-numa-l7/docker-compose.yml
@@ -1,0 +1,54 @@
+# dnsdist L7 front-end → numa with PROXY v2 over plain TCP.
+#
+#   host dig +udp ──UDP──> dnsdist :53 ──TCP+PROXY v2──> numa :53 ──forward──> 9.9.9.9
+#
+# dnsdist's `tcpOnly=true + useProxyProtocol=true` transmuxes UDP from
+# clients into TCP toward numa with a PROXY v2 header at connection open.
+# Operators can deploy numa as a plain-DNS backend behind dnsdist and get
+# real client IPs in numa's logs without numa needing to support UDP
+# PROXY v2 (deferred per PR #156's "Out of scope").
+
+name: dnsdist-l7
+
+services:
+  numa:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile
+    image: numa:dnsdist-l7-test
+    volumes:
+      - ./numa.toml:/etc/numa/numa.toml:ro
+      - numa_data:/var/lib/numa
+    command: ["/etc/numa/numa.toml"]
+    environment:
+      RUST_LOG: "info,numa::pp2=debug,numa::tcp=debug"
+    networks:
+      test:
+        ipv4_address: 172.29.0.10
+    expose:
+      - "53"
+    ports:
+      - "127.0.0.1:15381:5380/tcp"
+
+  dnsdist:
+    image: powerdns/dnsdist-20:2.0.0
+    volumes:
+      - ./dnsdist.conf:/etc/dnsdist/dnsdist.conf:ro
+    networks:
+      test:
+        ipv4_address: 172.29.0.20
+    ports:
+      - "127.0.0.1:15454:53/udp"
+      - "127.0.0.1:15454:53/tcp"
+    depends_on:
+      - numa
+
+networks:
+  test:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.29.0.0/24
+
+volumes:
+  numa_data:

--- a/tests/docker/dnsdist-numa-l7/numa.toml
+++ b/tests/docker/dnsdist-numa-l7/numa.toml
@@ -1,0 +1,30 @@
+[server]
+bind_addr = "0.0.0.0:53"
+api_bind_addr = "0.0.0.0"
+api_port = 5380
+data_dir = "/var/lib/numa"
+
+# Trust the docker bridge subnet to send PROXY v2 headers on plain TCP.
+# dnsdist runs at 172.29.0.20 with tcpOnly=true + useProxyProtocol=true.
+[server.proxy_protocol]
+from = ["172.16.0.0/12"]
+header_timeout_ms = 5000
+
+[upstream]
+mode = "forward"
+address = "9.9.9.9"
+
+[cache]
+max_entries = 10000
+
+[blocking]
+enabled = false
+
+[proxy]
+enabled = false
+
+[mobile]
+enabled = false
+
+[dot]
+enabled = false

--- a/tests/docker/dnsdist-numa-l7/smoke.sh
+++ b/tests/docker/dnsdist-numa-l7/smoke.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Smoke test for dnsdist L7 → numa over plain TCP with PROXY v2.
+# Client sends UDP to dnsdist; dnsdist transmuxes to TCP and prepends a
+# PROXY v2 header at connection open.
+#
+# Asserts:
+#   1. dig +udp through dnsdist returns a real answer.
+#   2. numa's transport.tcp counter increments (proves dnsdist→numa hop
+#      is TCP, not UDP — i.e. tcpOnly=true is in effect).
+#   3. numa's proxy_protocol.accepted increments (proves the PROXY header
+#      was parsed and the real client IP propagated).
+#   4. No rejections or timeouts on numa's pp2 layer.
+#
+# Requirements: docker (with compose v2), dig, curl, jq.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+GREEN="\033[32m"; RED="\033[31m"; DIM="\033[90m"; RESET="\033[0m"
+pass() { printf "  ${GREEN}✓${RESET} %s\n" "$1"; }
+fail() { printf "  ${RED}✗${RESET} %s\n" "$1"; exit 1; }
+
+for tool in docker dig curl jq; do
+  command -v "$tool" >/dev/null || fail "missing tool: $tool"
+done
+
+cleanup() {
+  if [ "${KEEP:-0}" = "1" ]; then
+    printf "${DIM}KEEP=1 — leaving stack running. tear down with: docker compose -f %s down -v${RESET}\n" "$PWD/docker-compose.yml"
+    return
+  fi
+  docker compose down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "── dnsdist L7 → numa PROXY v2 smoke test ──"
+
+echo "  building & starting stack..."
+docker compose up -d --build >/dev/null
+
+echo -n "  waiting for numa /health "
+ready=0
+for _ in $(seq 1 60); do
+  if curl -fsS http://127.0.0.1:15381/health >/dev/null 2>&1; then
+    echo " ok"; ready=1; break
+  fi
+  echo -n "."
+  sleep 1
+done
+[ "$ready" = "1" ] || fail "numa /health never came up"
+
+echo -n "  waiting for dnsdist UDP listener "
+ready=0
+for _ in $(seq 1 30); do
+  if dig +short +time=1 +tries=1 @127.0.0.1 -p 15454 example.com >/dev/null 2>&1; then
+    echo " ok"; ready=1; break
+  fi
+  echo -n "."
+  sleep 1
+done
+[ "$ready" = "1" ] || fail "dnsdist not answering on 127.0.0.1:15454"
+
+read -r baseline_pp baseline_tcp baseline_udp < <(curl -fsS http://127.0.0.1:15381/stats \
+  | jq -r '[.proxy_protocol.accepted, .transport.tcp, .transport.udp] | @tsv')
+pass "baseline: proxy_protocol.accepted=$baseline_pp transport.tcp=$baseline_tcp transport.udp=$baseline_udp"
+
+echo "  dig +udp @127.0.0.1 -p 15454 example.com ..."
+out=$(dig +short @127.0.0.1 -p 15454 example.com 2>/dev/null || true)
+[ -n "$out" ] || fail "dig returned no answer (host→dnsdist→numa path broken)"
+pass "answer: $(echo "$out" | tr '\n' ' ')"
+
+# Issue a couple more so the counters move clearly above noise.
+dig +short @127.0.0.1 -p 15454 cloudflare.com >/dev/null 2>&1 || true
+dig +short @127.0.0.1 -p 15454 wikipedia.org  >/dev/null 2>&1 || true
+sleep 1
+
+read -r after_pp after_tcp after_udp rejected < <(curl -fsS http://127.0.0.1:15381/stats \
+  | jq -r '[.proxy_protocol.accepted, .transport.tcp, .transport.udp, ([.proxy_protocol.rejected_untrusted, .proxy_protocol.rejected_signature, .proxy_protocol.timeout] | add)] | @tsv')
+
+[ "$after_pp" -gt "$baseline_pp" ] || fail "proxy_protocol.accepted did not increment ($baseline_pp → $after_pp) — pp2 hook not firing"
+pass "proxy_protocol.accepted incremented: $baseline_pp → $after_pp"
+
+[ "$after_tcp" -gt "$baseline_tcp" ] || fail "transport.tcp did not increment ($baseline_tcp → $after_tcp) — dnsdist not transmuxing UDP→TCP, or tcpOnly=true not in effect"
+pass "transport.tcp incremented (dnsdist transmuxed UDP→TCP): $baseline_tcp → $after_tcp"
+
+[ "$rejected" = "0" ] || fail "rejected/timeout counters non-zero: $rejected"
+pass "no pp2 rejections or timeouts"
+
+# Sanity check: numa should not see UDP from the dnsdist→numa hop, since
+# tcpOnly=true forces TCP. transport.udp can still increment from health
+# probes / cache warming, so we only assert "didn't grow more than transport.tcp".
+udp_growth=$((after_udp - baseline_udp))
+tcp_growth=$((after_tcp - baseline_tcp))
+[ "$tcp_growth" -ge "$udp_growth" ] || fail "transport.udp grew faster than transport.tcp ($udp_growth vs $tcp_growth) — tcpOnly=true may not be in effect"
+pass "transport.tcp growth ($tcp_growth) ≥ transport.udp growth ($udp_growth) — UDP→TCP transmux confirmed"
+
+echo
+echo -e "${GREEN}all checks passed${RESET}"

--- a/tests/docker/pp2-numa/README.md
+++ b/tests/docker/pp2-numa/README.md
@@ -1,0 +1,66 @@
+# PROXY v2 e2e: HAProxy → numa
+
+End-to-end harness for PR #156. HAProxy runs as an L4 front-end on two
+ports — DoT (:853) and plain DNS-over-TCP (:53) — prepends a PROXY v2
+header to each backend stream, and forwards bytes to numa. Numa parses
+the PROXY header before the next layer (TLS for DoT, length-prefixed DNS
+for plain TCP) and records the real client IP via
+`/stats.proxy_protocol.*` counters.
+
+```
+host kdig +tls ──TLS──> haproxy :853 ──PROXY v2 + TLS bytes──> numa :853 ──forward──> 9.9.9.9
+host dig  +tcp ──TCP──> haproxy :53  ──PROXY v2 + DNS bytes──> numa :53  ──forward──> 9.9.9.9
+```
+
+## Run the smoke
+
+```sh
+./smoke.sh
+```
+
+Builds the local numa Dockerfile, starts haproxy, queries both DoT and
+plain TCP DNS through it from the host, and asserts
+`/stats.proxy_protocol.accepted` increments after each.
+
+## Manual probe
+
+```sh
+docker compose up -d --build
+
+# DoT through haproxy
+kdig +tls @127.0.0.1 -p 5853 example.com
+
+# plain TCP DNS through haproxy
+dig +tcp @127.0.0.1 -p 15353 example.com
+
+# numa stats — proxy_protocol.accepted grows with each query
+curl -s http://127.0.0.1:15380/stats | jq '.proxy_protocol'
+
+# real client IP visibility
+docker compose logs numa | grep -i pp2
+```
+
+## Tear down
+
+```sh
+docker compose down -v
+```
+
+## Why HAProxy, not dnsdist
+
+This was originally written to test dnsdist → numa, but dnsdist 2.0's
+`useProxyProtocol=true` on a TLS backend sends the PROXY header
+**inside** the TLS session ("encrypted PROXY", BIND 9's
+`proxy encrypted` mode). PR #156's "Out of scope" section explicitly
+calls this case out — numa parses PROXY v2 before the TLS handshake.
+
+Verified empirically with `tcpdump -X` on the bridge: the first PSH
+packet from dnsdist starts with `0x16 0x03 0x01 …` (TLS ClientHello),
+not the PROXY v2 signature `0x0D 0x0A 0x0D 0x0A 0x00 0x0D 0x0A 0x51 …`.
+
+`proxyProtocolOutsideTLS` exists in dnsdist but only as an
+`addLocal` / `addDOTLocal` *frontend* option (for receiving), not a
+`newServer` (sending) option.
+
+Use HAProxy `mode tcp` with `send-proxy-v2`, nginx `stream` with
+`proxy_protocol on`, or any cloud L4 LB (AWS NLB, GCP TCP LB) instead.

--- a/tests/docker/pp2-numa/docker-compose.yml
+++ b/tests/docker/pp2-numa/docker-compose.yml
@@ -1,0 +1,59 @@
+# End-to-end test stack for PR #156 (PROXY protocol v2 inbound on DoT/DoH).
+#
+#   host kdig +tls ──TLS──> haproxy :853 ──PROXY v2 + TLS bytes──> numa :853 ──forward──> 9.9.9.9
+#
+# HAProxy runs in `mode tcp` with `send-proxy-v2` so the PROXY header sits
+# OUTSIDE the TLS layer — exactly the wire shape numa's pp2 layer parses.
+# numa's API is exposed on 127.0.0.1:15380 so /stats.proxy_v2_* counters
+# are visible from the host.
+#
+# Why HAProxy, not dnsdist:
+#   dnsdist's `useProxyProtocol=true` for a TLS backend sends the PROXY
+#   header INSIDE the TLS session ("encrypted PROXY", BIND 9's
+#   `proxy encrypted` mode). PR #156 explicitly lists this as out of
+#   scope. Other L4 front-ends with PROXY-outside-TLS work the same
+#   way as HAProxy here: nginx stream module, AWS NLB, GCP TCP LB.
+
+services:
+  numa:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile
+    image: numa:pp2-test
+    volumes:
+      - ./numa.toml:/etc/numa/numa.toml:ro
+      - numa_data:/var/lib/numa
+    command: ["/etc/numa/numa.toml"]
+    environment:
+      RUST_LOG: "info,numa::pp2=debug"
+    networks:
+      test:
+        ipv4_address: 172.28.0.10
+    expose:
+      - "53"
+      - "853"
+    ports:
+      - "127.0.0.1:15380:5380/tcp"
+
+  haproxy:
+    image: haproxy:2.9-alpine
+    volumes:
+      - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
+    networks:
+      test:
+        ipv4_address: 172.28.0.20
+    ports:
+      - "127.0.0.1:5853:853/tcp"
+      - "127.0.0.1:15353:53/tcp"
+    depends_on:
+      - numa
+
+networks:
+  test:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+
+volumes:
+  numa_data:

--- a/tests/docker/pp2-numa/haproxy.cfg
+++ b/tests/docker/pp2-numa/haproxy.cfg
@@ -1,0 +1,32 @@
+# L4 front-end for the PR #156 PROXY v2 e2e test.
+#
+# Two TCP frontends, both prepending a PROXY v2 header to the backend
+# stream. HAProxy never sees the cleartext DNS — it only forwards bytes —
+# and numa parses the PROXY header before the next layer (TLS for DoT,
+# length-prefixed DNS for plain TCP).
+
+global
+    log stdout format raw local0
+    maxconn 1024
+
+defaults
+    log     global
+    mode    tcp
+    option  tcplog
+    timeout connect 5s
+    timeout client  30s
+    timeout server  30s
+
+frontend dot_in
+    bind *:853
+    default_backend numa_dot
+
+backend numa_dot
+    server numa 172.28.0.10:853 send-proxy-v2 check
+
+frontend dns_tcp_in
+    bind *:53
+    default_backend numa_tcp
+
+backend numa_tcp
+    server numa 172.28.0.10:53 send-proxy-v2 check

--- a/tests/docker/pp2-numa/numa.toml
+++ b/tests/docker/pp2-numa/numa.toml
@@ -1,0 +1,37 @@
+[server]
+bind_addr = "0.0.0.0:53"
+api_bind_addr = "0.0.0.0"
+api_port = 5380
+data_dir = "/var/lib/numa"
+
+# Trust the docker bridge subnets to send PROXY v2 headers on the plain
+# DNS-over-TCP listener. Empty `from` would disable the feature.
+[server.proxy_protocol]
+from = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+header_timeout_ms = 5000
+
+[upstream]
+mode = "forward"
+address = "9.9.9.9"
+
+[dot]
+enabled = true
+port = 853
+bind_addr = "0.0.0.0"
+
+# Trust dnsdist (and any other front-end on the docker bridge subnets)
+# to send PROXY v2 headers. Empty `from` would disable the feature.
+[dot.proxy_protocol]
+from = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+header_timeout_ms = 5000
+
+[proxy]
+enabled = true
+bind_addr = "127.0.0.1"
+tld = "numa"
+
+[mobile]
+enabled = false
+
+[blocking]
+enabled = false

--- a/tests/docker/pp2-numa/smoke.sh
+++ b/tests/docker/pp2-numa/smoke.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Smoke test for PR #156: HAProxy front-ends numa over DoT and plain TCP DNS,
+# both with PROXY v2.
+#
+# Brings up the compose stack, runs:
+#   - kdig +tls @127.0.0.1 -p 5853   (DoT through haproxy)
+#   - dig  +tcp @127.0.0.1 -p 15353  (plain TCP DNS through haproxy)
+# and asserts that numa's /stats.proxy_protocol.accepted counter
+# increments after each query (PROXY header parsed, real client IP
+# propagated).
+#
+# Requirements: docker (with compose v2), kdig, dig, curl, jq.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+GREEN="\033[32m"; RED="\033[31m"; DIM="\033[90m"; RESET="\033[0m"
+pass() { printf "  ${GREEN}✓${RESET} %s\n" "$1"; }
+fail() { printf "  ${RED}✗${RESET} %s\n" "$1"; exit 1; }
+
+for tool in docker kdig dig curl jq; do
+  command -v "$tool" >/dev/null || fail "missing tool: $tool"
+done
+
+cleanup() {
+  if [ "${KEEP:-0}" = "1" ]; then
+    printf "${DIM}KEEP=1 — leaving stack running. tear down with: docker compose -f %s down -v${RESET}\n" "$PWD/docker-compose.yml"
+    return
+  fi
+  docker compose down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "── haproxy+numa PROXY v2 smoke test ──"
+
+echo "  building & starting stack..."
+docker compose up -d --build >/dev/null
+
+echo -n "  waiting for numa /health "
+ready=0
+for _ in $(seq 1 60); do
+  if curl -fsS http://127.0.0.1:15380/health >/dev/null 2>&1; then
+    echo " ok"; ready=1; break
+  fi
+  echo -n "."
+  sleep 1
+done
+[ "$ready" = "1" ] || fail "numa /health never came up"
+
+baseline=$(curl -fsS http://127.0.0.1:15380/stats | jq -r '.proxy_protocol.accepted')
+pass "baseline proxy_protocol.accepted = $baseline"
+
+echo "  kdig +tls @127.0.0.1 -p 5853 example.com ..."
+out=$(kdig +tls @127.0.0.1 -p 5853 example.com +short 2>/dev/null || true)
+[ -n "$out" ] || fail "kdig returned no answer (haproxy→numa DoT path broken)"
+pass "DoT answer: $(echo "$out" | tr '\n' ' ')"
+
+after_dot=$(curl -fsS http://127.0.0.1:15380/stats | jq -r '.proxy_protocol.accepted')
+[ "$after_dot" -gt "$baseline" ] || fail "proxy_protocol.accepted did not increment after DoT ($baseline → $after_dot)"
+pass "proxy_protocol.accepted incremented after DoT: $baseline → $after_dot"
+
+echo "  dig +tcp @127.0.0.1 -p 15353 example.com ..."
+out=$(dig +tcp @127.0.0.1 -p 15353 example.com +short 2>/dev/null || true)
+[ -n "$out" ] || fail "dig returned no answer (haproxy→numa plain TCP path broken)"
+pass "TCP answer: $(echo "$out" | tr '\n' ' ')"
+
+read -r after rejected < <(curl -fsS http://127.0.0.1:15380/stats \
+  | jq -r '[.proxy_protocol.accepted, ([.proxy_protocol.rejected_untrusted, .proxy_protocol.rejected_signature, .proxy_protocol.timeout] | add)] | @tsv')
+[ "$after" -gt "$after_dot" ] || fail "proxy_protocol.accepted did not increment after plain TCP ($after_dot → $after)"
+pass "proxy_protocol.accepted incremented after plain TCP: $after_dot → $after"
+[ "$rejected" = "0" ] || fail "rejected/timeout counters non-zero: $rejected"
+pass "no rejections or timeouts"
+
+echo
+echo -e "${GREEN}all checks passed${RESET}"


### PR DESCRIPTION
## Summary

Adds opt-in [PROXY protocol v2](https://www.haproxy.org/download/2.8/doc/proxy-protocol.txt) support to numa's three inbound TCP transports — **DoT, DoH, and plain DNS-over-TCP** — so numa preserves the real client IP when deployed behind an L4 front-end (dnsdist, HAProxy, nginx-stream, AWS NLB, GCP TCP LB). Without this, every connection from the front-end collapses to one synthetic client in numa's logs — per-client policy, blocklist effectiveness reports, and CIPA audit trails are unusable. Closes #143.

Naming and semantics mirror PowerDNS Recursor's `proxy-protocol-from` for least operator surprise: empty `from` allowlist = feature off; non-empty = listener is in PROXY-required mode. Each listener has its own block: `[dot.proxy_protocol]`, `[server.proxy_protocol]` (plain TCP), `[proxy.proxy_protocol]` (DoH).

## Design

Picked [`proxy-header`](https://github.com/tibordp/proxy-header) (MIT, ~1k LOC) over hand-rolling because its `ProxiedStream::create_from_tokio()` cleanly solves the load-bearing peek-then-consume primitive on a `tokio::TcpStream` and exposes any over-read tail bytes via the wrapper's `AsyncRead` impl. Surveyed prior art across nine DNS servers (dnsdist, BIND 9, Unbound, PowerDNS Recursor/Auth, Knot Resolver/DNS, CoreDNS, Technitium) — every credible non-Microsoft DNS server has shipped support since 2020-2024, all with the same default-deny CIDR-allowlist pattern.

After PR #161 landed the shared `tcp::handle_framed_dns_connection`, the plain-TCP and DoT paths route through the same per-connection driver — adding PROXY v2 to plain TCP was a single hook in `tcp::accept_loop` symmetric to the DoT one. Both consume the PROXY header before the next layer (TLS for DoT, length-prefixed DNS for plain TCP).

Default `header_timeout_ms = 5000` (hyper-server default) — separate knob from TLS `HANDSHAKE_TIMEOUT` because slowloris-on-PROXY-header is a different attack pattern. Payload size is bounded only by the upstream `proxy_header` parser, which does not currently expose a `max_size` knob; the read timeout is the operator-visible guard against oversized/slow headers (see "Notes / known gaps").

## Out of scope (deferred, documented in code)

- PROXY v1 (text format).
- UDP variant — operator-visible consequence: behind a dnsdist L4-passthrough edge, UDP/53 queries still arrive carrying the front-end's IP. Worth flagging on the migration page.
- Encrypted-mode PROXY-on-TLS (header after the TLS handshake, BIND 9's `proxy encrypted` mode) — only matters when chaining behind a TLS-terminating dnsdist that re-emits DoT.
- L7 reverse-proxy `X-Forwarded-For` — separate code path.
- Outbound PROXY headers (numa as a sender).

## Notes / known gaps

- The 5 stats counters were originally scoped at 8 (separate `_rejected_version` / `_family` / `_oversize`). `proxy_header::Error` is currently a single opaque type without per-variant introspection, so all parse failures land in `_rejected_signature`. Worth revisiting if we vendor or fork the parser.
- `proxy-header` last released 2024-07; cadence is slow. Codebase is small and forkable if upstream stalls.
- No payload-size cap on PROXY v2 headers. v2's `header_len` is `u16`, so a trusted-but-misbehaving sender could push up to ~64 KB before the parser commits. The 5 s `header_timeout_ms` is the only operator-visible bound. dnsdist caps at 512 B by default; if we vendor or fork `proxy-header`, adopting that limit is the obvious add. (Unrelated to CVE-2025-30193 — that advisory is about per-TCP-connection query count, not PROXY header size; tracked separately.)

## Commits

| commit | what |
|---|---|
| `c379ea8` | feat(proxy): PROXY v2 inbound on DoT and DoH |
| `c5acadf` | refactor(pp2): drop unused max_size; add DoH integration tests |
| `b43d034` | refactor(proxy): trim DoH PROXY v2 tests to the only one that pays rent |
| `19f5a1f` | feat(api): expose pp2 stats counters in `/stats` response |
| `727d15f` | feat(tcp): PROXY v2 inbound on plain DNS-over-TCP listener |
| `0ed52f9` | test(pp2): docker e2e harness with HAProxy front-end (DoT + plain TCP) |

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib` — **380 passed** (14 new: 7 DoT pp2, 1 DoH pp2 happy-path, 1 plain-TCP pp2 happy-path, 5 pp2 unit, 1 cross-cutting)
- [x] `cargo test --tests` — existing integration tests pass
- [x] `cargo clippy --lib -- -D warnings` — zero warnings on touched files
- [x] `cargo fmt --check` clean
- [x] **`tests/docker/pp2-numa/smoke.sh`** — HAProxy → numa with `send-proxy-v2` on both :853 (DoT via kdig) and :53 (plain TCP via dig), asserts `/stats.proxy_protocol.accepted` increments for each, no rejections
- [ ] point one dnsdist at a numa build with `[dot.proxy_protocol] from = ["<dnsdist-ip>"]` and verify per-client logs show actual Chromebook IPs (single-site smoke test before fleet rollout)