### PR TITLE
feat(blocklist): support local file:// sources and multi-alias hosts lines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["dns", "dns-server", "ad-blocking", "reverse-proxy", "developer-tool
 categories = ["network-programming", "development-tools"]
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync", "signal", "fs"] }
 axum = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/numa.toml
+++ b/numa.toml
@@ -106,7 +106,11 @@ api_port = 5380
 # [blocking]
 # enabled = true               # set to false to disable ad blocking
 # refresh_hours = 24
-# lists = ["https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/hosts/pro.txt"]
+# lists = [
+#     "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/hosts/pro.txt",
+#     "file:///etc/numa/local-blocklist.txt",  # local hosts-style file
+#     "/etc/numa/extra-blocks.txt",            # bare absolute path also works
+# ]
 # allowlist = ["example.com"]  # domains to never block
 
 [cache]

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -217,34 +217,38 @@ pub fn parse_blocklist(text: &str) -> HashSet<String> {
             continue;
         }
 
-        // Handle hosts-file format: "0.0.0.0 domain" or "127.0.0.1 domain" (space or tab)
-        let domain = if line.starts_with("0.0.0.0")
+        if line.starts_with("0.0.0.0")
             || line.starts_with("127.0.0.1")
             || line.starts_with("::")
         {
-            line.split_whitespace()
-                .nth(1)
-                .unwrap_or("")
-                .trim_end_matches('.')
-        } else if line.contains(' ') || line.contains('\t') {
+            // Hosts format: an IP followed by one or more whitespace-separated
+            // aliases. BSD hosts(5) has always allowed multiple names per IP,
+            // and several published lists rely on it for size. Inline `# ...`
+            // tails are stripped — domains don't contain '#'.
+            let payload = line.split('#').next().unwrap_or(line);
+            for alias in payload.split_whitespace().skip(1) {
+                insert_if_valid(&mut domains, alias);
+            }
             continue;
-        } else {
-            // Plain domain or adblock filter syntax
-            let d = line.trim_start_matches("*.").trim_start_matches("||");
-            let d = d.split('$').next().unwrap_or(d); // strip adblock $options
-            d.trim_end_matches('^').trim_end_matches('.')
-        };
-
-        let domain = domain.to_lowercase();
-        if !domain.is_empty()
-            && domain.contains('.')
-            && domain != "localhost"
-            && domain != "localhost.localdomain"
-        {
-            domains.insert(domain);
         }
+
+        if line.contains(' ') || line.contains('\t') {
+            continue;
+        }
+
+        // Plain domain or adblock filter syntax.
+        let d = line.trim_start_matches("*.").trim_start_matches("||");
+        let d = d.split('$').next().unwrap_or(d); // strip adblock $options
+        insert_if_valid(&mut domains, d.trim_end_matches('^'));
     }
     domains
+}
+
+fn insert_if_valid(set: &mut HashSet<String>, raw: &str) {
+    let d = raw.trim_end_matches('.').to_lowercase();
+    if !d.is_empty() && d.contains('.') && d != "localhost" && d != "localhost.localdomain" {
+        set.insert(d);
+    }
 }
 
 #[cfg(test)]
@@ -343,6 +347,56 @@ mod tests {
     }
 
     #[test]
+    fn parses_multi_alias_hosts_line() {
+        // BSD hosts(5) allows multiple names per IP; the parser must load
+        // all aliases, not silently drop everything after the first.
+        let domains = parse_blocklist("0.0.0.0 a.com b.com c.com\n");
+        assert_eq!(domains.len(), 3);
+        assert!(domains.contains("a.com"));
+        assert!(domains.contains("b.com"));
+        assert!(domains.contains("c.com"));
+    }
+
+    #[test]
+    fn parses_hosts_inline_comment() {
+        let domains = parse_blocklist("0.0.0.0 a.com b.com  # trailing note\n");
+        assert_eq!(domains.len(), 2);
+        assert!(domains.contains("a.com"));
+        assert!(domains.contains("b.com"));
+    }
+
+    #[test]
+    fn excludes_localhost_aliases_in_hosts_line() {
+        let domains =
+            parse_blocklist("127.0.0.1 localhost localhost.localdomain my.local.dev\n");
+        assert_eq!(domains.len(), 1);
+        assert!(domains.contains("my.local.dev"));
+    }
+
+    #[test]
+    fn local_path_recognises_file_url() {
+        assert_eq!(
+            local_path("file:///etc/numa/local.txt"),
+            Some(std::path::PathBuf::from("/etc/numa/local.txt"))
+        );
+    }
+
+    #[test]
+    fn local_path_recognises_bare_absolute_unix() {
+        #[cfg(unix)]
+        assert_eq!(
+            local_path("/etc/numa/local.txt"),
+            Some(std::path::PathBuf::from("/etc/numa/local.txt"))
+        );
+    }
+
+    #[test]
+    fn local_path_ignores_http_url() {
+        assert!(local_path("https://example.com/list.txt").is_none());
+        assert!(local_path("http://example.com/list.txt").is_none());
+    }
+
+    #[test]
     fn heap_bytes_grows_with_domains() {
         let mut store = BlocklistStore::new();
         let empty = store.heap_bytes();
@@ -369,12 +423,26 @@ pub async fn download_blocklists(
     }
     let client = builder.build().unwrap_or_default();
 
-    let fetches = lists.iter().map(|url| {
+    let fetches = lists.iter().map(|source| {
         let client = &client;
         async move {
-            let text = fetch_with_retry(client, url).await?;
-            info!("downloaded blocklist: {} ({} bytes)", url, text.len());
-            Some((url.clone(), text))
+            let text = if let Some(path) = local_path(source) {
+                match tokio::fs::read_to_string(&path).await {
+                    Ok(t) => {
+                        info!("loaded local blocklist: {} ({} bytes)", source, t.len());
+                        t
+                    }
+                    Err(e) => {
+                        warn!("blocklist {} unreadable: {} — skipping", source, e);
+                        return None;
+                    }
+                }
+            } else {
+                let t = fetch_with_retry(client, source).await?;
+                info!("downloaded blocklist: {} ({} bytes)", source, t.len());
+                t
+            };
+            Some((source.clone(), text))
         }
     });
     futures::future::join_all(fetches)
@@ -382,6 +450,19 @@ pub async fn download_blocklists(
         .into_iter()
         .flatten()
         .collect()
+}
+
+/// Recognises a blocklist `source` as a local-file reference: either a
+/// `file://` URL or a bare absolute filesystem path. Returns `None` for
+/// anything else (HTTP/HTTPS URLs, relative paths).
+fn local_path(source: &str) -> Option<std::path::PathBuf> {
+    if let Some(rest) = source.strip_prefix("file://") {
+        return Some(std::path::PathBuf::from(rest));
+    }
+    if std::path::Path::new(source).is_absolute() {
+        return Some(std::path::PathBuf::from(source));
+    }
+    None
 }
 
 async fn fetch_with_retry(client: &reqwest::Client, url: &str) -> Option<String> {
@@ -484,6 +565,63 @@ mod retry_tests {
         let url = format!("http://{addr}/");
         let result = fetch_with_retry_delays(&client, &url, &delays).await;
         assert_eq!(result.as_deref(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn download_blocklists_reads_file_url() {
+        let path = std::env::temp_dir().join(format!(
+            "numa_blocklist_{}.txt",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        tokio::fs::write(&path, "0.0.0.0 a.com b.com\n")
+            .await
+            .unwrap();
+
+        let url = format!("file://{}", path.display());
+        let result = download_blocklists(std::slice::from_ref(&url), None).await;
+        let _ = tokio::fs::remove_file(&path).await;
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, url);
+        let domains = parse_blocklist(&result[0].1);
+        assert!(domains.contains("a.com"));
+        assert!(domains.contains("b.com"));
+    }
+
+    #[tokio::test]
+    async fn download_blocklists_reads_bare_absolute_path() {
+        let path = std::env::temp_dir().join(format!(
+            "numa_blocklist_bare_{}.txt",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        tokio::fs::write(&path, "ads.example.com\n").await.unwrap();
+
+        let source = path.display().to_string();
+        let result = download_blocklists(std::slice::from_ref(&source), None).await;
+        let _ = tokio::fs::remove_file(&path).await;
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, source);
+        assert!(result[0].1.contains("ads.example.com"));
+    }
+
+    #[tokio::test]
+    async fn download_blocklists_skips_missing_local_file() {
+        let url = format!(
+            "file:///does/not/exist/numa_blocklist_{}.txt",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let result = download_blocklists(&[url], None).await;
+        assert!(result.is_empty());
     }
 
     #[tokio::test]

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -86,7 +86,7 @@ impl BlocklistStore {
                 return false;
             }
         }
-        let domain = Self::normalize(domain);
+        let domain = normalize(domain);
         if Self::find_in_set(&domain, &self.allowlist).is_some() {
             return false;
         }
@@ -104,7 +104,7 @@ impl BlocklistStore {
             }
         }
 
-        let domain = Self::normalize(domain);
+        let domain = normalize(domain);
 
         if let Some(matched) = Self::find_in_set(&domain, &self.allowlist) {
             let reason = if matched == domain {
@@ -125,10 +125,6 @@ impl BlocklistStore {
         }
 
         BlockCheckResult::not_blocked()
-    }
-
-    fn normalize(domain: &str) -> String {
-        domain.to_lowercase().trim_end_matches('.').to_string()
     }
 
     fn find_in_set<'a>(domain: &'a str, set: &HashSet<String>) -> Option<&'a str> {
@@ -176,11 +172,11 @@ impl BlocklistStore {
     }
 
     pub fn add_to_allowlist(&mut self, domain: &str) {
-        self.allowlist.insert(Self::normalize(domain));
+        self.allowlist.insert(normalize(domain));
     }
 
     pub fn remove_from_allowlist(&mut self, domain: &str) -> bool {
-        self.allowlist.remove(&Self::normalize(domain))
+        self.allowlist.remove(&normalize(domain))
     }
 
     pub fn allowlist(&self) -> Vec<String> {
@@ -218,10 +214,7 @@ pub fn parse_blocklist(text: &str) -> HashSet<String> {
         }
 
         if line.starts_with("0.0.0.0") || line.starts_with("127.0.0.1") || line.starts_with("::") {
-            // Hosts format: an IP followed by one or more whitespace-separated
-            // aliases. BSD hosts(5) has always allowed multiple names per IP,
-            // and several published lists rely on it for size. Inline `# ...`
-            // tails are stripped — domains don't contain '#'.
+            // BSD hosts(5): an IP followed by N aliases; '#' starts an inline comment.
             let payload = line.split('#').next().unwrap_or(line);
             for alias in payload.split_whitespace().skip(1) {
                 insert_if_valid(&mut domains, alias);
@@ -241,8 +234,12 @@ pub fn parse_blocklist(text: &str) -> HashSet<String> {
     domains
 }
 
+fn normalize(domain: &str) -> String {
+    domain.to_lowercase().trim_end_matches('.').to_string()
+}
+
 fn insert_if_valid(set: &mut HashSet<String>, raw: &str) {
-    let d = raw.trim_end_matches('.').to_lowercase();
+    let d = normalize(raw);
     if !d.is_empty() && d.contains('.') && d != "localhost" && d != "localhost.localdomain" {
         set.insert(d);
     }
@@ -345,8 +342,6 @@ mod tests {
 
     #[test]
     fn parses_multi_alias_hosts_line() {
-        // BSD hosts(5) allows multiple names per IP; the parser must load
-        // all aliases, not silently drop everything after the first.
         let domains = parse_blocklist("0.0.0.0 a.com b.com c.com\n");
         assert_eq!(domains.len(), 3);
         assert!(domains.contains("a.com"));
@@ -429,7 +424,11 @@ pub async fn download_blocklists(
                         t
                     }
                     Err(e) => {
-                        warn!("blocklist {} unreadable: {} — skipping", source, e);
+                        warn!(
+                            "blocklist {} unreadable: {} — skipping",
+                            source,
+                            format_error_chain(&e)
+                        );
                         return None;
                     }
                 }
@@ -448,9 +447,6 @@ pub async fn download_blocklists(
         .collect()
 }
 
-/// Recognises a blocklist `source` as a local-file reference: either a
-/// `file://` URL or a bare absolute filesystem path. Returns `None` for
-/// anything else (HTTP/HTTPS URLs, relative paths).
 fn local_path(source: &str) -> Option<std::path::PathBuf> {
     if let Some(rest) = source.strip_prefix("file://") {
         return Some(std::path::PathBuf::from(rest));
@@ -563,15 +559,17 @@ mod retry_tests {
         assert_eq!(result.as_deref(), Some(body));
     }
 
+    fn unique_temp_path(prefix: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}_{nanos}.txt"))
+    }
+
     #[tokio::test]
     async fn download_blocklists_reads_file_url() {
-        let path = std::env::temp_dir().join(format!(
-            "numa_blocklist_{}.txt",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let path = unique_temp_path("numa_blocklist");
         tokio::fs::write(&path, "0.0.0.0 a.com b.com\n")
             .await
             .unwrap();
@@ -589,13 +587,7 @@ mod retry_tests {
 
     #[tokio::test]
     async fn download_blocklists_reads_bare_absolute_path() {
-        let path = std::env::temp_dir().join(format!(
-            "numa_blocklist_bare_{}.txt",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let path = unique_temp_path("numa_blocklist_bare");
         tokio::fs::write(&path, "ads.example.com\n").await.unwrap();
 
         let source = path.display().to_string();
@@ -609,12 +601,10 @@ mod retry_tests {
 
     #[tokio::test]
     async fn download_blocklists_skips_missing_local_file() {
+        let path = unique_temp_path("numa_blocklist_missing");
         let url = format!(
-            "file:///does/not/exist/numa_blocklist_{}.txt",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+            "file:///does/not/exist/{}",
+            path.file_name().unwrap().to_string_lossy()
         );
         let result = download_blocklists(&[url], None).await;
         assert!(result.is_empty());

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -217,10 +217,7 @@ pub fn parse_blocklist(text: &str) -> HashSet<String> {
             continue;
         }
 
-        if line.starts_with("0.0.0.0")
-            || line.starts_with("127.0.0.1")
-            || line.starts_with("::")
-        {
+        if line.starts_with("0.0.0.0") || line.starts_with("127.0.0.1") || line.starts_with("::") {
             // Hosts format: an IP followed by one or more whitespace-separated
             // aliases. BSD hosts(5) has always allowed multiple names per IP,
             // and several published lists rely on it for size. Inline `# ...`
@@ -367,8 +364,7 @@ mod tests {
 
     #[test]
     fn excludes_localhost_aliases_in_hosts_line() {
-        let domains =
-            parse_blocklist("127.0.0.1 localhost localhost.localdomain my.local.dev\n");
+        let domains = parse_blocklist("127.0.0.1 localhost localhost.localdomain my.local.dev\n");
         assert_eq!(domains.len(), 1);
         assert!(domains.contains("my.local.dev"));
     }


### PR DESCRIPTION
## Summary

Closes the two blocklist asks in #157:

- **Multi-alias hosts lines** — the parser used to silently drop every alias after the first on a hosts line. `0.0.0.0 a.com b.com c.com` loaded only `a.com`. Now all whitespace-separated aliases are loaded, matching the original BSD `hosts(5)` semantics that several published lists rely on for size. Inline `# comment` tails are also stripped.

- **Local-file blocklist sources** — `download_blocklists` now recognises `file://` URLs and bare absolute filesystem paths in addition to HTTP(S). Useful for air-gapped hosts, corporate-curated lists, and Pi-hole exports.

The third item raised in #157 (install service without taking over system DNS) is unrelated to blocklists and warrants its own issue/PR.

## Test plan

- [x] `cargo test --lib` — 369 passed (10 new in `blocklist`).
- [x] `cargo clippy --lib --tests -- -D warnings` — clean on touched files (5 pre-existing warnings elsewhere).

