### PR TITLE
feat(tcp): plain DNS-over-TCP listener

### DIFF
--- a/src/dot.rs
+++ b/src/dot.rs
@@ -5,25 +5,17 @@ use std::time::Duration;
 
 use log::{debug, error, info, warn};
 use rustls::ServerConfig;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
 use tokio_rustls::TlsAcceptor;
 
-use crate::buffer::BytePacketBuffer;
 use crate::config::DotConfig;
-use crate::ctx::{resolve_query, ServerCtx};
-use crate::header::ResultCode;
-use crate::packet::DnsPacket;
+use crate::ctx::ServerCtx;
 use crate::stats::Transport;
+use crate::tcp::handle_framed_dns_connection;
 
 const MAX_CONNECTIONS: usize = 512;
-const IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
-const WRITE_TIMEOUT: Duration = Duration::from_secs(10);
-// Matches BytePacketBuffer::BUF_SIZE — RFC 7858 allows up to 65535 but our
-// buffer would silently truncate anything larger.
-const MAX_MSG_LEN: usize = 4096;
 
 fn dot_alpn() -> Vec<Vec<u8>> {
     vec![b"dot".to_vec()]
@@ -147,131 +139,8 @@ async fn accept_loop(listener: TcpListener, acceptor: TlsAcceptor, ctx: Arc<Serv
                     }
                 };
 
-            handle_dot_connection(tls_stream, remote_addr, &ctx).await;
+            handle_framed_dns_connection(tls_stream, remote_addr, &ctx, Transport::Dot).await;
         });
-    }
-}
-
-/// Handle a single persistent DoT connection (RFC 7858).
-/// Reads length-prefixed DNS queries until EOF, idle timeout, or error.
-async fn handle_dot_connection<S>(
-    mut stream: S,
-    remote_addr: SocketAddr,
-    ctx: &std::sync::Arc<ServerCtx>,
-) where
-    S: AsyncReadExt + AsyncWriteExt + Unpin,
-{
-    loop {
-        // Read 2-byte length prefix (RFC 1035 §4.2.2) with idle timeout
-        let mut len_buf = [0u8; 2];
-        let Ok(Ok(_)) = tokio::time::timeout(IDLE_TIMEOUT, stream.read_exact(&mut len_buf)).await
-        else {
-            break;
-        };
-        let msg_len = u16::from_be_bytes(len_buf) as usize;
-        if msg_len > MAX_MSG_LEN {
-            debug!("DoT: oversized message {} from {}", msg_len, remote_addr);
-            break;
-        }
-
-        let mut buffer = BytePacketBuffer::new();
-        let Ok(Ok(_)) =
-            tokio::time::timeout(IDLE_TIMEOUT, stream.read_exact(&mut buffer.buf[..msg_len])).await
-        else {
-            break;
-        };
-
-        let query = match DnsPacket::from_buffer(&mut buffer) {
-            Ok(q) => q,
-            Err(e) => {
-                warn!("{} | PARSE ERROR | {}", remote_addr, e);
-                // BytePacketBuffer is zero-initialized, so buf[0..2] reads as 0x0000
-                // for sub-2-byte messages — harmless FORMERR with id=0.
-                let query_id = u16::from_be_bytes([buffer.buf[0], buffer.buf[1]]);
-                let mut resp = DnsPacket::new();
-                resp.header.id = query_id;
-                resp.header.response = true;
-                resp.header.rescode = ResultCode::FORMERR;
-                if send_response(&mut stream, &resp, remote_addr)
-                    .await
-                    .is_err()
-                {
-                    break;
-                }
-                continue;
-            }
-        };
-
-        match resolve_query(
-            query.clone(),
-            &buffer.buf[..msg_len],
-            remote_addr,
-            ctx,
-            Transport::Dot,
-        )
-        .await
-        {
-            Ok((resp_buffer, _)) => {
-                if write_framed(&mut stream, resp_buffer.filled())
-                    .await
-                    .is_err()
-                {
-                    break;
-                }
-            }
-            Err(e) => {
-                warn!("{} | RESOLVE ERROR | {}", remote_addr, e);
-                // SERVFAIL that echoes the original question section.
-                let resp = DnsPacket::response_from(&query, ResultCode::SERVFAIL);
-                if send_response(&mut stream, &resp, remote_addr)
-                    .await
-                    .is_err()
-                {
-                    break;
-                }
-            }
-        }
-    }
-}
-
-/// Serialize a DNS response and send it framed. Logs serialization failures
-/// and returns Err so the caller can tear down the connection.
-async fn send_response<S>(
-    stream: &mut S,
-    resp: &DnsPacket,
-    remote_addr: SocketAddr,
-) -> std::io::Result<()>
-where
-    S: AsyncWriteExt + Unpin,
-{
-    let mut out_buf = BytePacketBuffer::new();
-    if resp.write(&mut out_buf).is_err() {
-        debug!(
-            "DoT: failed to serialize {:?} response for {}",
-            resp.header.rescode, remote_addr
-        );
-        return Err(std::io::Error::other("serialize failed"));
-    }
-    write_framed(stream, out_buf.filled()).await
-}
-
-/// Write a DNS message with its 2-byte length prefix, coalesced into one syscall.
-/// Bounded by WRITE_TIMEOUT so a stalled reader can't indefinitely hold a worker.
-async fn write_framed<S>(stream: &mut S, msg: &[u8]) -> std::io::Result<()>
-where
-    S: AsyncWriteExt + Unpin,
-{
-    let mut out = Vec::with_capacity(2 + msg.len());
-    out.extend_from_slice(&(msg.len() as u16).to_be_bytes());
-    out.extend_from_slice(msg);
-    match tokio::time::timeout(WRITE_TIMEOUT, async {
-        stream.write_all(&out).await?;
-        stream.flush().await
-    })
-    .await
-    {
-        Ok(result) => result,
-        Err(_) => Err(std::io::Error::other("write timeout")),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod srtt;
 pub mod stats;
 pub mod svcb;
 pub mod system_dns;
+pub mod tcp;
 pub mod tls;
 pub mod wire;
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -557,6 +557,18 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         });
     }
 
+    // Spawn DNS-over-TCP listener (RFC 1035 §4.2.2 / RFC 7766) on the same
+    // address as UDP. Required so clients can retry after a TC=1 truncated
+    // UDP response, and for queries that don't fit a UDP datagram in the
+    // first place (DNSSEC chains, large TXT, ANY).
+    {
+        let tcp_ctx = Arc::clone(&ctx);
+        let tcp_bind = config.server.bind_addr.clone();
+        tokio::spawn(async move {
+            crate::tcp::start_tcp(tcp_ctx, &tcp_bind).await;
+        });
+    }
+
     // UDP DNS listener
     #[allow(clippy::infinite_loop)]
     loop {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -557,10 +557,7 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         });
     }
 
-    // Spawn DNS-over-TCP listener (RFC 1035 §4.2.2 / RFC 7766) on the same
-    // address as UDP. Required so clients can retry after a TC=1 truncated
-    // UDP response, and for queries that don't fit a UDP datagram in the
-    // first place (DNSSEC chains, large TXT, ANY).
+    // Spawn DNS-over-TCP listener (RFC 1035 / RFC 7766)
     {
         let tcp_ctx = Arc::clone(&ctx);
         let tcp_bind = config.server.bind_addr.clone();

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,12 +1,6 @@
-//! Plain DNS-over-TCP listener (RFC 1035 §4.2.2, RFC 7766).
-//!
-//! TCP support is not optional: when a UDP response exceeds the client's
-//! advertised buffer (or 512 bytes without EDNS0), numa sets the TC bit and
-//! a compliant client retries the same query over TCP on the same `bind_addr`.
-//! Without this listener, those retries silently fail.
-//!
-//! Connection model mirrors `dot.rs`: bounded concurrency, per-connection
-//! idle timeout, length-prefixed framing, FORMERR for parse errors.
+//! Plain DNS-over-TCP listener (RFC 1035 §4.2.2, RFC 7766). Required so
+//! clients can retry after a TC=1 truncated UDP response — without it, those
+//! retries hit a closed port. Connection model mirrors `dot.rs`.
 
 use std::net::SocketAddr;
 use std::sync::Arc;

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,0 +1,356 @@
+//! Plain DNS-over-TCP listener (RFC 1035 §4.2.2, RFC 7766).
+//!
+//! TCP support is not optional: when a UDP response exceeds the client's
+//! advertised buffer (or 512 bytes without EDNS0), numa sets the TC bit and
+//! a compliant client retries the same query over TCP on the same `bind_addr`.
+//! Without this listener, those retries silently fail.
+//!
+//! Connection model mirrors `dot.rs`: bounded concurrency, per-connection
+//! idle timeout, length-prefixed framing, FORMERR for parse errors.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use log::{debug, error, info, warn};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Semaphore;
+
+use crate::buffer::BytePacketBuffer;
+use crate::ctx::{resolve_query, ServerCtx};
+use crate::header::ResultCode;
+use crate::packet::DnsPacket;
+use crate::stats::Transport;
+
+const MAX_CONNECTIONS: usize = 512;
+const IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+const WRITE_TIMEOUT: Duration = Duration::from_secs(10);
+// Matches BytePacketBuffer::BUF_SIZE — RFC 1035 allows up to 65535 but our
+// buffer would silently truncate anything larger.
+const MAX_MSG_LEN: usize = 4096;
+
+/// Start the DNS-over-TCP listener on the same address as the UDP listener.
+pub async fn start_tcp(ctx: Arc<ServerCtx>, bind_addr: &str) {
+    let addr: SocketAddr = match bind_addr.parse() {
+        Ok(a) => a,
+        Err(e) => {
+            warn!(
+                "TCP: invalid bind_addr {:?} ({}) — TCP DNS disabled",
+                bind_addr, e
+            );
+            return;
+        }
+    };
+
+    let listener = match TcpListener::bind(addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            warn!("TCP: could not bind {} ({}) — TCP DNS disabled", addr, e);
+            return;
+        }
+    };
+    info!("TCP DNS listening on {}", addr);
+
+    accept_loop(listener, ctx).await;
+}
+
+async fn accept_loop(listener: TcpListener, ctx: Arc<ServerCtx>) {
+    let semaphore = Arc::new(Semaphore::new(MAX_CONNECTIONS));
+
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                error!("TCP: accept error: {}", e);
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                continue;
+            }
+        };
+
+        let permit = match semaphore.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => {
+                debug!("TCP: connection limit reached, rejecting {}", peer);
+                continue;
+            }
+        };
+        let ctx = Arc::clone(&ctx);
+
+        tokio::spawn(async move {
+            let _permit = permit;
+            handle_tcp_connection(stream, peer, &ctx).await;
+        });
+    }
+}
+
+/// Handle a single persistent TCP connection (RFC 7766 §6.2.1).
+/// Reads length-prefixed DNS queries until EOF, idle timeout, or error.
+async fn handle_tcp_connection<S>(mut stream: S, remote_addr: SocketAddr, ctx: &Arc<ServerCtx>)
+where
+    S: AsyncReadExt + AsyncWriteExt + Unpin,
+{
+    loop {
+        // Read 2-byte length prefix (RFC 1035 §4.2.2) with idle timeout.
+        let mut len_buf = [0u8; 2];
+        let Ok(Ok(_)) = tokio::time::timeout(IDLE_TIMEOUT, stream.read_exact(&mut len_buf)).await
+        else {
+            break;
+        };
+        let msg_len = u16::from_be_bytes(len_buf) as usize;
+        if msg_len > MAX_MSG_LEN {
+            debug!("TCP: oversized message {} from {}", msg_len, remote_addr);
+            break;
+        }
+
+        let mut buffer = BytePacketBuffer::new();
+        let Ok(Ok(_)) =
+            tokio::time::timeout(IDLE_TIMEOUT, stream.read_exact(&mut buffer.buf[..msg_len])).await
+        else {
+            break;
+        };
+
+        let query = match DnsPacket::from_buffer(&mut buffer) {
+            Ok(q) => q,
+            Err(e) => {
+                warn!("{} | PARSE ERROR | {}", remote_addr, e);
+                let query_id = u16::from_be_bytes([buffer.buf[0], buffer.buf[1]]);
+                let mut resp = DnsPacket::new();
+                resp.header.id = query_id;
+                resp.header.response = true;
+                resp.header.rescode = ResultCode::FORMERR;
+                if send_response(&mut stream, &resp, remote_addr)
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+                continue;
+            }
+        };
+
+        match resolve_query(
+            query.clone(),
+            &buffer.buf[..msg_len],
+            remote_addr,
+            ctx,
+            Transport::Tcp,
+        )
+        .await
+        {
+            Ok((resp_buffer, _)) => {
+                if write_framed(&mut stream, resp_buffer.filled())
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            Err(e) => {
+                warn!("{} | RESOLVE ERROR | {}", remote_addr, e);
+                let resp = DnsPacket::response_from(&query, ResultCode::SERVFAIL);
+                if send_response(&mut stream, &resp, remote_addr)
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn send_response<S>(
+    stream: &mut S,
+    resp: &DnsPacket,
+    remote_addr: SocketAddr,
+) -> std::io::Result<()>
+where
+    S: AsyncWriteExt + Unpin,
+{
+    let mut out_buf = BytePacketBuffer::new();
+    if resp.write(&mut out_buf).is_err() {
+        debug!(
+            "TCP: failed to serialize {:?} response for {}",
+            resp.header.rescode, remote_addr
+        );
+        return Err(std::io::Error::other("serialize failed"));
+    }
+    write_framed(stream, out_buf.filled()).await
+}
+
+/// Write a DNS message with its 2-byte length prefix, coalesced into one syscall.
+/// Bounded by WRITE_TIMEOUT so a stalled reader can't indefinitely hold a worker.
+async fn write_framed<S>(stream: &mut S, msg: &[u8]) -> std::io::Result<()>
+where
+    S: AsyncWriteExt + Unpin,
+{
+    let mut out = Vec::with_capacity(2 + msg.len());
+    out.extend_from_slice(&(msg.len() as u16).to_be_bytes());
+    out.extend_from_slice(msg);
+    match tokio::time::timeout(WRITE_TIMEOUT, async {
+        stream.write_all(&out).await?;
+        stream.flush().await
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(std::io::Error::other("write timeout")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    use crate::buffer::BytePacketBuffer;
+    use crate::header::ResultCode;
+    use crate::packet::DnsPacket;
+    use crate::question::QueryType;
+    use crate::record::DnsRecord;
+
+    async fn spawn_tcp_server() -> SocketAddr {
+        let upstream_addr = crate::testutil::blackhole_upstream();
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.zone_map = {
+            let mut m = HashMap::new();
+            let mut inner = HashMap::new();
+            inner.insert(
+                QueryType::A,
+                vec![DnsRecord::A {
+                    domain: "tcp-test.example".to_string(),
+                    addr: std::net::Ipv4Addr::new(10, 0, 0, 1),
+                    ttl: 300,
+                }],
+            );
+            m.insert("tcp-test.example".to_string(), inner);
+            m
+        };
+        ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
+            vec![crate::forward::Upstream::Udp(upstream_addr)],
+            vec![],
+        ));
+        let ctx = Arc::new(ctx);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(accept_loop(listener, ctx));
+        addr
+    }
+
+    async fn tcp_exchange(stream: &mut TcpStream, query: &DnsPacket) -> DnsPacket {
+        let mut buf = BytePacketBuffer::new();
+        query.write(&mut buf).unwrap();
+        let msg = buf.filled();
+
+        let mut out = Vec::with_capacity(2 + msg.len());
+        out.extend_from_slice(&(msg.len() as u16).to_be_bytes());
+        out.extend_from_slice(msg);
+        stream.write_all(&out).await.unwrap();
+
+        let mut len_buf = [0u8; 2];
+        stream.read_exact(&mut len_buf).await.unwrap();
+        let resp_len = u16::from_be_bytes(len_buf) as usize;
+
+        let mut data = vec![0u8; resp_len];
+        stream.read_exact(&mut data).await.unwrap();
+
+        let mut resp_buf = BytePacketBuffer::from_bytes(&data);
+        DnsPacket::from_buffer(&mut resp_buf).unwrap()
+    }
+
+    #[tokio::test]
+    async fn tcp_resolves_local_zone() {
+        let addr = spawn_tcp_server().await;
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+
+        let query = DnsPacket::query(0x1234, "tcp-test.example", QueryType::A);
+        let resp = tcp_exchange(&mut stream, &query).await;
+
+        assert_eq!(resp.header.id, 0x1234);
+        assert!(resp.header.response);
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert_eq!(resp.answers.len(), 1);
+        match &resp.answers[0] {
+            DnsRecord::A { domain, addr, ttl } => {
+                assert_eq!(domain, "tcp-test.example");
+                assert_eq!(*addr, std::net::Ipv4Addr::new(10, 0, 0, 1));
+                assert_eq!(*ttl, 300);
+            }
+            other => panic!("expected A record, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn tcp_multiple_queries_on_persistent_connection() {
+        // RFC 7766 §6.2.1: TCP connections must support multiple queries.
+        let addr = spawn_tcp_server().await;
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+
+        for i in 0..3u16 {
+            let query = DnsPacket::query(0xA000 + i, "tcp-test.example", QueryType::A);
+            let resp = tcp_exchange(&mut stream, &query).await;
+            assert_eq!(resp.header.id, 0xA000 + i);
+            assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+            assert_eq!(resp.answers.len(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn tcp_servfail_for_unreachable_upstream() {
+        let addr = spawn_tcp_server().await;
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+
+        let query = DnsPacket::query(0xBEEF, "nonexistent.test", QueryType::A);
+        let resp = tcp_exchange(&mut stream, &query).await;
+
+        assert_eq!(resp.header.id, 0xBEEF);
+        assert!(resp.header.response);
+        // Blackhole upstream → SERVFAIL with original question echoed back.
+        assert_eq!(resp.header.rescode, ResultCode::SERVFAIL);
+        assert_eq!(resp.questions.len(), 1);
+        assert_eq!(resp.questions[0].name, "nonexistent.test");
+    }
+
+    #[tokio::test]
+    async fn tcp_oversize_message_closes_connection() {
+        // A length prefix above MAX_MSG_LEN must drop the connection rather
+        // than allocate and read the whole message.
+        let addr = spawn_tcp_server().await;
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+
+        let oversize = (MAX_MSG_LEN + 1) as u16;
+        stream.write_all(&oversize.to_be_bytes()).await.unwrap();
+
+        let mut buf = [0u8; 2];
+        let n = stream.read(&mut buf).await.unwrap_or(0);
+        assert_eq!(n, 0, "server must close after an oversized length prefix");
+    }
+
+    #[tokio::test]
+    async fn tcp_concurrent_connections() {
+        let addr = spawn_tcp_server().await;
+
+        let mut handles = Vec::new();
+        for i in 0..5u16 {
+            handles.push(tokio::spawn(async move {
+                let mut stream = TcpStream::connect(addr).await.unwrap();
+                let query = DnsPacket::query(0xC000 + i, "tcp-test.example", QueryType::A);
+                let resp = tcp_exchange(&mut stream, &query).await;
+                assert_eq!(resp.header.id, 0xC000 + i);
+                assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+                assert_eq!(resp.answers.len(), 1);
+            }));
+        }
+
+        for h in handles {
+            h.await.unwrap();
+        }
+    }
+}

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -73,19 +73,24 @@ async fn accept_loop(listener: TcpListener, ctx: Arc<ServerCtx>) {
 
         tokio::spawn(async move {
             let _permit = permit;
-            handle_tcp_connection(stream, peer, &ctx).await;
+            handle_framed_dns_connection(stream, peer, &ctx, Transport::Tcp).await;
         });
     }
 }
 
-/// Handle a single persistent TCP connection (RFC 7766 §6.2.1).
-/// Reads length-prefixed DNS queries until EOF, idle timeout, or error.
-async fn handle_tcp_connection<S>(mut stream: S, remote_addr: SocketAddr, ctx: &Arc<ServerCtx>)
-where
+/// Drive a length-prefixed DNS-over-stream connection (RFC 1035 §4.2.2,
+/// RFC 7766 §6.2.1). Shared between plain TCP and DoT — DoT calls in after
+/// TLS termination with `Transport::Dot`.
+pub(crate) async fn handle_framed_dns_connection<S>(
+    mut stream: S,
+    remote_addr: SocketAddr,
+    ctx: &Arc<ServerCtx>,
+    transport: Transport,
+) where
     S: AsyncReadExt + AsyncWriteExt + Unpin,
 {
+    let proto = transport.as_str();
     loop {
-        // Read 2-byte length prefix (RFC 1035 §4.2.2) with idle timeout.
         let mut len_buf = [0u8; 2];
         let Ok(Ok(_)) = tokio::time::timeout(IDLE_TIMEOUT, stream.read_exact(&mut len_buf)).await
         else {
@@ -93,7 +98,10 @@ where
         };
         let msg_len = u16::from_be_bytes(len_buf) as usize;
         if msg_len > MAX_MSG_LEN {
-            debug!("TCP: oversized message {} from {}", msg_len, remote_addr);
+            debug!(
+                "{}: oversized message {} from {}",
+                proto, msg_len, remote_addr
+            );
             break;
         }
 
@@ -108,12 +116,14 @@ where
             Ok(q) => q,
             Err(e) => {
                 warn!("{} | PARSE ERROR | {}", remote_addr, e);
+                // BytePacketBuffer is zero-initialized, so buf[0..2] reads as
+                // 0x0000 for sub-2-byte messages — harmless FORMERR with id=0.
                 let query_id = u16::from_be_bytes([buffer.buf[0], buffer.buf[1]]);
                 let mut resp = DnsPacket::new();
                 resp.header.id = query_id;
                 resp.header.response = true;
                 resp.header.rescode = ResultCode::FORMERR;
-                if send_response(&mut stream, &resp, remote_addr)
+                if send_response(&mut stream, &resp, remote_addr, proto)
                     .await
                     .is_err()
                 {
@@ -128,7 +138,7 @@ where
             &buffer.buf[..msg_len],
             remote_addr,
             ctx,
-            Transport::Tcp,
+            transport,
         )
         .await
         {
@@ -143,7 +153,7 @@ where
             Err(e) => {
                 warn!("{} | RESOLVE ERROR | {}", remote_addr, e);
                 let resp = DnsPacket::response_from(&query, ResultCode::SERVFAIL);
-                if send_response(&mut stream, &resp, remote_addr)
+                if send_response(&mut stream, &resp, remote_addr, proto)
                     .await
                     .is_err()
                 {
@@ -158,6 +168,7 @@ async fn send_response<S>(
     stream: &mut S,
     resp: &DnsPacket,
     remote_addr: SocketAddr,
+    proto: &str,
 ) -> std::io::Result<()>
 where
     S: AsyncWriteExt + Unpin,
@@ -165,8 +176,8 @@ where
     let mut out_buf = BytePacketBuffer::new();
     if resp.write(&mut out_buf).is_err() {
         debug!(
-            "TCP: failed to serialize {:?} response for {}",
-            resp.header.rescode, remote_addr
+            "{}: failed to serialize {:?} response for {}",
+            proto, resp.header.rescode, remote_addr
         );
         return Err(std::io::Error::other("serialize failed"));
     }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -397,6 +397,26 @@ check "Non-local domain still resolves" \
     "$($DIG example.com A +short)"
 
 echo ""
+echo "=== DNS-over-TCP listener (RFC 1035 §4.2.2 / RFC 7766) ==="
+
+check "Local A over TCP (test.local)" \
+    "10.0.0.1" \
+    "$($DIG test.local A +tcp +short)"
+
+check "Local MX over TCP (mail.local)" \
+    "smtp.local" \
+    "$($DIG mail.local MX +tcp +short)"
+
+# Verifies the connection is tagged Transport::Tcp end-to-end (not just
+# that it resolved). transport.tcp lives inside the transport object.
+TCP_COUNT=$(curl -sf http://127.0.0.1:$API_PORT/stats 2>/dev/null \
+    | grep -o '"transport":{[^}]*}' \
+    | grep -o '"tcp":[0-9]*' | cut -d: -f2)
+check "transport.tcp counter > 0 after TCP queries" \
+    "[1-9]" \
+    "${TCP_COUNT:-0}"
+
+echo ""
 echo "=== Overrides API ==="
 
 # Create override


### PR DESCRIPTION
## Summary

- Adds `src/tcp.rs`: a plain DNS-over-TCP listener bound on the same `bind_addr` as the UDP socket. Closes the gap where clients retrying over TCP after a TC=1 truncated UDP response hit a closed port.
- Lifts the per-connection bytes-pumping into a shared `pub(crate) tcp::handle_framed_dns_connection<S>` and rewires `dot.rs` to call it after TLS termination — ~100 lines of near-verbatim duplication deleted from `dot.rs`. The helper is generic over `AsyncRead + AsyncWrite + Unpin`, so plain `TcpStream` and tokio-rustls's `TlsStream` plug in the same way.
- Adds `+tcp` integration coverage to `tests/integration.sh` Suite 4 (local zone, MX, `transport.tcp` counter increments).
- The `transport.tcp` counter already existed in `stats` and `api` — it just stops being permanently zero.

## Why

RFC 7766 makes TCP support mandatory for DNS servers, and it's the only path for answers that don't fit a UDP datagram (DNSSEC chains, large TXT, `ANY`). Until now, numa silently lost those queries.

No new config block: TCP binds wherever UDP binds (`config.server.bind_addr`), matching the RFC 1035 expectation that both protocols share one address. The shared handler also positions PR #156 (PROXY protocol v2) for a cleaner rebase: the `pp2::handshake` hook lives in each module's `accept_loop` above the shared helper, identical between TCP and DoT.

## Commits

| commit | what |
|---|---|
| `09fce6b` | feat: TCP listener (initial) |
| `9ceebd0` | style: trim verbose module/spawn comments to match `dot.rs` |
| `3db99e4` | test: Suite 4 integration coverage for the TCP listener |
| `ab4c98d` | refactor: share framed-DNS handler between TCP and DoT |

## Minor user-visible change

DoT debug-log lines that referenced "DoT:" inside the framed handler now read "DOT:" (the prefix derives from `Transport::as_str()` so TCP/DOT/UDP/DOH are consistent). The info-level "DoT listening on …" line is unchanged. No tests assert on log output.

## Test plan

- [x] `cargo test --lib tcp::` — 5 new tests
  - resolves a local zone over TCP
  - keepalive: 3 queries on one persistent connection (RFC 7766 §6.2.1)
  - oversized length prefix closes the connection
  - blackhole upstream → SERVFAIL with question echoed
  - 5 concurrent connections all resolve
- [x] `cargo test --lib dot::` — all 6 pre-existing DoT unit tests pass against the shared helper
- [x] `cargo test --lib` — full lib suite (365 tests) green
- [x] `cargo clippy --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `SUITES=4 ./tests/integration.sh release` — Suite 4 TCP checks (local A over TCP, local MX over TCP, `transport.tcp` counter > 0) all pass
- [x] `SUITES=5,6 ./tests/integration.sh release` — Suite 5 (DoT) + Suite 6 (Proxy + DoT coexistence): 14/14 pass after the refactor (kdig+TLS local zone, persistent multi-query connection, ALPN positive/negative, DoT+HTTPS-proxy coexistence, DoH POST roundtrip)