### PR TITLE
feat(udp): PROXY protocol v2 inbound on plain DNS-over-UDP listener

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -521,6 +521,7 @@ pub async fn handle_query(
     mut buffer: BytePacketBuffer,
     raw_len: usize,
     src_addr: SocketAddr,
+    respond_to: SocketAddr,
     ctx: &Arc<ServerCtx>,
     transport: Transport,
 ) -> crate::Result<()> {
@@ -533,7 +534,7 @@ pub async fn handle_query(
     };
     match resolve_query(query, &buffer.buf[..raw_len], src_addr, ctx, transport).await {
         Ok((resp_buffer, _)) => {
-            ctx.socket.send_to(resp_buffer.filled(), src_addr).await?;
+            ctx.socket.send_to(resp_buffer.filled(), respond_to).await?;
         }
         Err(e) => {
             warn!("{} | RESOLVE ERROR | {}", src_addr, e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod odoh;
 pub mod override_store;
 pub mod packet;
 pub mod pp2;
+pub mod pp2_udp;
 pub mod proxy;
 pub mod query_log;
 pub mod question;

--- a/src/pp2.rs
+++ b/src/pp2.rs
@@ -22,6 +22,12 @@ use tokio::net::TcpStream;
 use crate::config::ProxyProtocolConfig;
 use crate::ctx::ServerCtx;
 
+pub(crate) const PARSE_CFG: ParseConfig = ParseConfig {
+    allow_v1: false,
+    allow_v2: true,
+    include_tlvs: false,
+};
+
 /// Runtime form of [`ProxyProtocolConfig`]: parsed CIDR list + already-typed
 /// timeout. Built once per listener at startup.
 #[derive(Clone, Debug)]
@@ -59,7 +65,7 @@ impl PpConfig {
         }))
     }
 
-    fn allows(&self, peer: IpAddr) -> bool {
+    pub(crate) fn allows(&self, peer: IpAddr) -> bool {
         self.from.iter().any(|n| n.contains(&peer))
     }
 }
@@ -112,15 +118,9 @@ pub async fn handshake(
         return None;
     }
 
-    let parse_cfg = ParseConfig {
-        allow_v1: false,
-        allow_v2: true,
-        include_tlvs: false,
-    };
-
     let proxied = match tokio::time::timeout(
         pp.header_timeout,
-        ProxiedStream::create_from_tokio(tcp_stream, parse_cfg),
+        ProxiedStream::create_from_tokio(tcp_stream, PARSE_CFG),
     )
     .await
     {

--- a/src/pp2_udp.rs
+++ b/src/pp2_udp.rs
@@ -1,0 +1,199 @@
+//! PROXY protocol v2 — slice-flavored parser for the UDP listener.
+//!
+//! The TCP path in [`crate::pp2`] wraps a stream and consumes the header
+//! before handing bytes to the DNS layer. UDP has no stream — each datagram
+//! is independent and carries its own PROXY header up front when the
+//! sender (e.g. dnsdist with `useProxyProtocol=true`) is configured to do
+//! so. This module parses that prefix from a single buffer and reports
+//! how many bytes to skip before the DNS message starts.
+//!
+//! The trust gate, allowlist semantics, and stats counters are shared
+//! with the TCP path: an empty `from` allowlist disables the feature on
+//! this listener; a non-empty allowlist puts the listener in
+//! PROXY-required mode for permitted senders.
+//!
+//! ## EDNS0 buffer math
+//!
+//! A PROXY v2 IPv4 address block consumes 28 bytes; IPv6 consumes 52.
+//! Operators running PROXY-on-UDP get correspondingly fewer DNS payload
+//! bytes per datagram before truncation kicks in. dnsdist already accounts
+//! for this in its own MTU calculations, but operators sizing custom EDNS0
+//! buffers should subtract the header bytes from the available budget.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use log::debug;
+use proxy_header::{ParseConfig, ProxyHeader};
+
+use crate::ctx::ServerCtx;
+use crate::pp2::PpConfig;
+
+/// Outcome of inspecting an inbound UDP datagram.
+#[derive(Debug, PartialEq, Eq)]
+pub enum UdpPp {
+    /// Pass the datagram through unmodified — feature disabled on this
+    /// listener.
+    Bare,
+    /// Trusted sender prepended a valid PROXY v2 header. Use `src` as the
+    /// real client and skip the first `hdr_len` bytes of the buffer.
+    Proxied { src: SocketAddr, hdr_len: usize },
+    /// Drop the datagram silently. Either the peer is not on the
+    /// allowlist, or the header was malformed.
+    Drop,
+}
+
+/// Inspect the front of a UDP datagram for a PROXY v2 header.
+///
+/// Returns [`UdpPp::Bare`] when the feature is disabled on this listener
+/// (zero overhead — no signature peek). Otherwise enforces the same
+/// allowlist + signature-validity rules as the TCP handshake. Stats are
+/// recorded as a side effect.
+pub fn parse_if_trusted(
+    bytes: &[u8],
+    peer: SocketAddr,
+    pp: Option<&PpConfig>,
+    ctx: &Arc<ServerCtx>,
+) -> UdpPp {
+    let pp = match pp {
+        Some(p) => p,
+        None => return UdpPp::Bare,
+    };
+
+    if !pp.from.iter().any(|n| n.contains(&peer.ip())) {
+        ctx.stats.lock().unwrap().proxy_v2_rejected_untrusted += 1;
+        debug!("pp2_udp: untrusted peer {peer}, dropping");
+        return UdpPp::Drop;
+    }
+
+    let parse_cfg = ParseConfig {
+        allow_v1: false,
+        allow_v2: true,
+        include_tlvs: false,
+    };
+
+    let (header, hdr_len) = match ProxyHeader::parse(bytes, parse_cfg) {
+        Ok(p) => p,
+        Err(e) => {
+            ctx.stats.lock().unwrap().proxy_v2_rejected_signature += 1;
+            debug!("pp2_udp parse from {peer}: {e}");
+            return UdpPp::Drop;
+        }
+    };
+
+    match header.proxied_address() {
+        Some(addr) => {
+            ctx.stats.lock().unwrap().proxy_v2_accepted += 1;
+            UdpPp::Proxied {
+                src: addr.source,
+                hdr_len,
+            }
+        }
+        None => {
+            // LOCAL command (sender health probe); use peer as the real
+            // client and treat the rest of the datagram as DNS.
+            ctx.stats.lock().unwrap().proxy_v2_local_command += 1;
+            UdpPp::Proxied { src: peer, hdr_len }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ProxyProtocolConfig;
+    use crate::testutil::test_ctx;
+    use proxy_header::{ProxiedAddress, ProxyHeader};
+
+    fn pp_cfg(from: &[&str]) -> Arc<PpConfig> {
+        let cfg = ProxyProtocolConfig {
+            from: from.iter().map(|s| s.to_string()).collect(),
+            header_timeout_ms: 5000,
+        };
+        Arc::new(PpConfig::from_config(&cfg).unwrap().unwrap())
+    }
+
+    fn proxied_v4_datagram(client: &str, server: &str, dns_payload: &[u8]) -> Vec<u8> {
+        let header = ProxyHeader::with_address(ProxiedAddress::datagram(
+            client.parse().unwrap(),
+            server.parse().unwrap(),
+        ));
+        let mut buf = vec![0u8; 256];
+        let len = header.encode_to_slice_v2(&mut buf).unwrap();
+        buf.truncate(len);
+        buf.extend_from_slice(dns_payload);
+        buf
+    }
+
+    #[tokio::test]
+    async fn disabled_returns_bare_without_signature_peek() {
+        let ctx = Arc::new(test_ctx().await);
+        let datagram = b"\x12\x34\x01\x00\x00\x01\x00\x00";
+        let peer: SocketAddr = "8.8.8.8:53".parse().unwrap();
+        assert_eq!(parse_if_trusted(datagram, peer, None, &ctx), UdpPp::Bare);
+    }
+
+    #[tokio::test]
+    async fn untrusted_peer_drops() {
+        let ctx = Arc::new(test_ctx().await);
+        let pp = pp_cfg(&["10.0.0.0/8"]);
+        let dns = b"\x12\x34\x01\x00\x00\x01\x00\x00";
+        let datagram = proxied_v4_datagram("203.0.113.5:55000", "10.0.0.1:53", dns);
+        let peer: SocketAddr = "8.8.8.8:33333".parse().unwrap();
+        assert_eq!(
+            parse_if_trusted(&datagram, peer, Some(&pp), &ctx),
+            UdpPp::Drop
+        );
+        assert_eq!(ctx.stats.lock().unwrap().proxy_v2_rejected_untrusted, 1);
+    }
+
+    #[tokio::test]
+    async fn trusted_peer_with_valid_v4_header_extracts_src_and_offset() {
+        let ctx = Arc::new(test_ctx().await);
+        let pp = pp_cfg(&["172.16.0.0/12"]);
+        let dns = b"\x12\x34\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\
+                    \x07example\x03com\x00\x00\x01\x00\x01";
+        let datagram = proxied_v4_datagram("203.0.113.5:55000", "172.29.0.10:53", dns);
+        let peer: SocketAddr = "172.29.0.20:44444".parse().unwrap();
+
+        match parse_if_trusted(&datagram, peer, Some(&pp), &ctx) {
+            UdpPp::Proxied { src, hdr_len } => {
+                assert_eq!(src.to_string(), "203.0.113.5:55000");
+                assert_eq!(&datagram[hdr_len..], dns);
+            }
+            other => panic!("expected Proxied, got {other:?}"),
+        }
+        assert_eq!(ctx.stats.lock().unwrap().proxy_v2_accepted, 1);
+    }
+
+    #[tokio::test]
+    async fn trusted_peer_with_garbled_signature_drops() {
+        let ctx = Arc::new(test_ctx().await);
+        let pp = pp_cfg(&["127.0.0.0/8"]);
+        // Looks like a v2 attempt (starts with \r) but truncated/bogus.
+        let datagram = b"\r\n\r\n\x00\r\nQUIT\nGARBAGE_PAYLOAD";
+        let peer: SocketAddr = "127.0.0.1:55555".parse().unwrap();
+        assert_eq!(
+            parse_if_trusted(datagram, peer, Some(&pp), &ctx),
+            UdpPp::Drop
+        );
+        assert_eq!(ctx.stats.lock().unwrap().proxy_v2_rejected_signature, 1);
+    }
+
+    #[tokio::test]
+    async fn trusted_peer_with_bare_dns_drops_in_required_mode() {
+        // Same posture as TCP: an enabled allowlist puts the listener in
+        // PROXY-required mode for permitted senders. A bare DNS datagram
+        // from an allowlisted IP is a misconfigured sender, not a bypass.
+        let ctx = Arc::new(test_ctx().await);
+        let pp = pp_cfg(&["127.0.0.0/8"]);
+        let bare_dns = b"\x12\x34\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\
+                         \x07example\x03com\x00\x00\x01\x00\x01";
+        let peer: SocketAddr = "127.0.0.1:55555".parse().unwrap();
+        assert_eq!(
+            parse_if_trusted(bare_dns, peer, Some(&pp), &ctx),
+            UdpPp::Drop
+        );
+        assert_eq!(ctx.stats.lock().unwrap().proxy_v2_rejected_signature, 1);
+    }
+}

--- a/src/pp2_udp.rs
+++ b/src/pp2_udp.rs
@@ -1,78 +1,62 @@
-//! PROXY protocol v2 — slice-flavored parser for the UDP listener.
-//!
-//! The TCP path in [`crate::pp2`] wraps a stream and consumes the header
-//! before handing bytes to the DNS layer. UDP has no stream — each datagram
-//! is independent and carries its own PROXY header up front when the
-//! sender (e.g. dnsdist with `useProxyProtocol=true`) is configured to do
-//! so. This module parses that prefix from a single buffer and reports
-//! how many bytes to skip before the DNS message starts.
-//!
-//! The trust gate, allowlist semantics, and stats counters are shared
-//! with the TCP path: an empty `from` allowlist disables the feature on
-//! this listener; a non-empty allowlist puts the listener in
-//! PROXY-required mode for permitted senders.
-//!
-//! ## EDNS0 buffer math
-//!
-//! A PROXY v2 IPv4 address block consumes 28 bytes; IPv6 consumes 52.
-//! Operators running PROXY-on-UDP get correspondingly fewer DNS payload
-//! bytes per datagram before truncation kicks in. dnsdist already accounts
-//! for this in its own MTU calculations, but operators sizing custom EDNS0
-//! buffers should subtract the header bytes from the available budget.
+//! PROXY v2 slice parser for the UDP listener — datagram counterpart to
+//! [`crate::pp2`]'s stream wrapper. Trust gate, allowlist semantics, and
+//! stats counters are shared.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use log::debug;
-use proxy_header::{ParseConfig, ProxyHeader};
+use proxy_header::ProxyHeader;
 
 use crate::ctx::ServerCtx;
-use crate::pp2::PpConfig;
+use crate::pp2::{PpConfig, PARSE_CFG};
 
-/// Outcome of inspecting an inbound UDP datagram.
 #[derive(Debug, PartialEq, Eq)]
 pub enum UdpPp {
-    /// Pass the datagram through unmodified — feature disabled on this
-    /// listener.
     Bare,
-    /// Trusted sender prepended a valid PROXY v2 header. Use `src` as the
-    /// real client and skip the first `hdr_len` bytes of the buffer.
     Proxied { src: SocketAddr, hdr_len: usize },
-    /// Drop the datagram silently. Either the peer is not on the
-    /// allowlist, or the header was malformed.
     Drop,
 }
 
-/// Inspect the front of a UDP datagram for a PROXY v2 header.
-///
-/// Returns [`UdpPp::Bare`] when the feature is disabled on this listener
-/// (zero overhead — no signature peek). Otherwise enforces the same
-/// allowlist + signature-validity rules as the TCP handshake. Stats are
-/// recorded as a side effect.
+impl UdpPp {
+    /// Resolve to the (real client, dns-payload length) pair for the recv
+    /// loop. On `Proxied`, shifts the DNS payload to offset 0 so the caller
+    /// can pass `&buf[..len]` unchanged. Returns `None` to discard.
+    pub fn apply(
+        self,
+        buf: &mut [u8],
+        len: usize,
+        peer: SocketAddr,
+    ) -> Option<(SocketAddr, usize)> {
+        match self {
+            UdpPp::Bare => Some((peer, len)),
+            UdpPp::Proxied { src, hdr_len } => {
+                buf.copy_within(hdr_len..len, 0);
+                Some((src, len - hdr_len))
+            }
+            UdpPp::Drop => None,
+        }
+    }
+}
+
+/// Inspect a UDP datagram for a PROXY v2 prefix. Zero-overhead when the
+/// feature is disabled (early `Bare` return — no signature peek). Stats
+/// are recorded as a side effect.
 pub fn parse_if_trusted(
     bytes: &[u8],
     peer: SocketAddr,
     pp: Option<&PpConfig>,
     ctx: &Arc<ServerCtx>,
 ) -> UdpPp {
-    let pp = match pp {
-        Some(p) => p,
-        None => return UdpPp::Bare,
-    };
+    let Some(pp) = pp else { return UdpPp::Bare };
 
-    if !pp.from.iter().any(|n| n.contains(&peer.ip())) {
+    if !pp.allows(peer.ip()) {
         ctx.stats.lock().unwrap().proxy_v2_rejected_untrusted += 1;
         debug!("pp2_udp: untrusted peer {peer}, dropping");
         return UdpPp::Drop;
     }
 
-    let parse_cfg = ParseConfig {
-        allow_v1: false,
-        allow_v2: true,
-        include_tlvs: false,
-    };
-
-    let (header, hdr_len) = match ProxyHeader::parse(bytes, parse_cfg) {
+    let (header, hdr_len) = match ProxyHeader::parse(bytes, PARSE_CFG) {
         Ok(p) => p,
         Err(e) => {
             ctx.stats.lock().unwrap().proxy_v2_rejected_signature += 1;
@@ -90,7 +74,7 @@ pub fn parse_if_trusted(
             }
         }
         None => {
-            // LOCAL command (sender health probe); use peer as the real
+            // LOCAL command (sender health probe): use peer as the real
             // client and treat the rest of the datagram as DNS.
             ctx.stats.lock().unwrap().proxy_v2_local_command += 1;
             UdpPp::Proxied { src: peer, hdr_len }
@@ -195,5 +179,34 @@ mod tests {
             UdpPp::Drop
         );
         assert_eq!(ctx.stats.lock().unwrap().proxy_v2_rejected_signature, 1);
+    }
+
+    #[tokio::test]
+    async fn apply_bare_passes_through() {
+        let mut buf = *b"hello-world";
+        let peer: SocketAddr = "1.2.3.4:53".parse().unwrap();
+        assert_eq!(UdpPp::Bare.apply(&mut buf, 11, peer), Some((peer, 11)));
+        assert_eq!(&buf, b"hello-world");
+    }
+
+    #[tokio::test]
+    async fn apply_proxied_shifts_buffer_and_swaps_source() {
+        let mut buf = *b"PROXY-HDRdns-payload"; // 9-byte fake header
+        let peer: SocketAddr = "10.0.0.1:53".parse().unwrap();
+        let real: SocketAddr = "203.0.113.5:55000".parse().unwrap();
+        let r = UdpPp::Proxied {
+            src: real,
+            hdr_len: 9,
+        }
+        .apply(&mut buf, 20, peer);
+        assert_eq!(r, Some((real, 11)));
+        assert_eq!(&buf[..11], b"dns-payload");
+    }
+
+    #[tokio::test]
+    async fn apply_drop_returns_none() {
+        let mut buf = [0u8; 4];
+        let peer: SocketAddr = "1.2.3.4:53".parse().unwrap();
+        assert_eq!(UdpPp::Drop.apply(&mut buf, 4, peer), None);
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -216,7 +216,15 @@ pub async fn run(config_path: String) -> crate::Result<()> {
 
     spawn_background_services(&ctx, &config, &bootstrap_resolver, api_port)?;
 
-    udp_serve_loop(&ctx).await
+    // UDP DNS listener — same `[server.proxy_protocol]` allowlist as TCP.
+    // `start_tcp` already validated/logged this config; build the runtime
+    // form silently here and treat any parse error as "disabled" (TCP would
+    // have surfaced the same error to the operator).
+    let udp_pp = crate::pp2::PpConfig::from_config(&config.server.proxy_protocol)
+        .ok()
+        .flatten();
+
+    udp_serve_loop(&ctx, udp_pp.as_ref()).await
 }
 
 fn spawn_background_services(
@@ -353,11 +361,14 @@ fn spawn_background_services(
     Ok(())
 }
 
-async fn udp_serve_loop(ctx: &Arc<ServerCtx>) -> crate::Result<()> {
+async fn udp_serve_loop(
+    ctx: &Arc<ServerCtx>,
+    udp_pp: Option<&crate::pp2::PpConfig>,
+) -> crate::Result<()> {
     #[allow(clippy::infinite_loop)]
     loop {
         let mut buffer = BytePacketBuffer::new();
-        let (len, src_addr) = match ctx.socket.recv_from(&mut buffer.buf).await {
+        let (len, peer) = match ctx.socket.recv_from(&mut buffer.buf).await {
             Ok(r) => r,
             Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {
                 // Windows delivers ICMP port-unreachable as ConnectionReset on UDP sockets
@@ -365,9 +376,22 @@ async fn udp_serve_loop(ctx: &Arc<ServerCtx>) -> crate::Result<()> {
             }
             Err(e) => return Err(e.into()),
         };
+        let (src_addr, dns_len) = match crate::pp2_udp::parse_if_trusted(
+            &buffer.buf[..len],
+            peer,
+            udp_pp,
+            ctx,
+        ) {
+            crate::pp2_udp::UdpPp::Bare => (peer, len),
+            crate::pp2_udp::UdpPp::Proxied { src, hdr_len } => {
+                buffer.buf.copy_within(hdr_len..len, 0);
+                (src, len - hdr_len)
+            }
+            crate::pp2_udp::UdpPp::Drop => continue,
+        };
         let ctx = Arc::clone(ctx);
         tokio::spawn(async move {
-            if let Err(e) = handle_query(buffer, len, src_addr, &ctx, Transport::Udp).await {
+            if let Err(e) = handle_query(buffer, dns_len, src_addr, &ctx, Transport::Udp).await {
                 error!("{} | HANDLER ERROR | {}", src_addr, e);
             }
         });

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -216,10 +216,8 @@ pub async fn run(config_path: String) -> crate::Result<()> {
 
     spawn_background_services(&ctx, &config, &bootstrap_resolver, api_port)?;
 
-    // UDP DNS listener — same `[server.proxy_protocol]` allowlist as TCP.
-    // `start_tcp` already validated/logged this config; build the runtime
-    // form silently here and treat any parse error as "disabled" (TCP would
-    // have surfaced the same error to the operator).
+    // UDP DNS listener — shares `[server.proxy_protocol]` with TCP, which
+    // already logged any parse error. Silently disable on Err.
     let udp_pp = crate::pp2::PpConfig::from_config(&config.server.proxy_protocol)
         .ok()
         .flatten();
@@ -376,18 +374,9 @@ async fn udp_serve_loop(
             }
             Err(e) => return Err(e.into()),
         };
-        let (src_addr, dns_len) = match crate::pp2_udp::parse_if_trusted(
-            &buffer.buf[..len],
-            peer,
-            udp_pp,
-            ctx,
-        ) {
-            crate::pp2_udp::UdpPp::Bare => (peer, len),
-            crate::pp2_udp::UdpPp::Proxied { src, hdr_len } => {
-                buffer.buf.copy_within(hdr_len..len, 0);
-                (src, len - hdr_len)
-            }
-            crate::pp2_udp::UdpPp::Drop => continue,
+        let pp = crate::pp2_udp::parse_if_trusted(&buffer.buf[..len], peer, udp_pp, ctx);
+        let Some((src_addr, dns_len)) = pp.apply(&mut buffer.buf, len, peer) else {
+            continue;
         };
         let ctx = Arc::clone(ctx);
         tokio::spawn(async move {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -378,9 +378,14 @@ async fn udp_serve_loop(
         let Some((src_addr, dns_len)) = pp.apply(&mut buffer.buf, len, peer) else {
             continue;
         };
+        // Response goes to the kernel UDP peer (e.g. dnsdist), not the
+        // PROXY-extracted logical source — otherwise the reply skips the
+        // front-end and never reaches the original client.
         let ctx = Arc::clone(ctx);
         tokio::spawn(async move {
-            if let Err(e) = handle_query(buffer, dns_len, src_addr, &ctx, Transport::Udp).await {
+            if let Err(e) =
+                handle_query(buffer, dns_len, src_addr, peer, &ctx, Transport::Udp).await
+            {
                 error!("{} | HANDLER ERROR | {}", src_addr, e);
             }
         });

--- a/tests/docker/dnsdist-numa-l7/README.md
+++ b/tests/docker/dnsdist-numa-l7/README.md
@@ -1,31 +1,33 @@
-# dnsdist L7 → numa: PROXY v2 over plain TCP
+# dnsdist L7 → numa: PROXY v2 over UDP
 
-End-to-end harness for the dnsdist front-end deployment shape.
-dnsdist accepts UDP+TCP/53 from clients, transmuxes every backend query
-to TCP, and prepends a PROXY v2 header at connection open. numa parses
-the PROXY header, runs the framed-DNS handler, and records the real
-client IP via `/stats.proxy_protocol.*` counters.
+End-to-end harness for the dnsdist front-end deployment shape with UDP
+PROXY v2 on the backend hop. dnsdist accepts UDP+TCP/53 from clients,
+forwards on the same transport, and prepends a PROXY v2 header to every
+backend query — including per-datagram on UDP. numa parses the prefix,
+recovers the real client IP, and runs the regular UDP query path.
 
 ```
-host dig +udp ──UDP──> dnsdist :53 ──TCP+PROXY v2──> numa :53 ──forward──> 9.9.9.9
+host dig +udp ──UDP──> dnsdist :53 ──UDP+PROXY v2──> numa :53 ──forward──> 9.9.9.9
 ```
 
 ## Why this configuration
 
-PROXY v2 on the plain-DNS hop requires either UDP PROXY v2 ingestion in
-numa (deferred per PR #156's "Out of scope") *or* dnsdist forcing the
-backend to TCP. The latter is a single config flag — `tcpOnly=true` on
-`newServer` — and avoids per-datagram PROXY framing entirely. Clients
-keep low-latency UDP, the PROXY-v2-bearing hop is 100% TCP, and numa's
-existing TCP+PROXY support handles the rest.
+PR #156 shipped PROXY v2 on the plain-DNS TCP listener, with a
+`tcpOnly = true` workaround required to keep dnsdist→numa entirely on
+TCP. The follow-up landed UDP PROXY v2 ingestion in numa, so operators
+can drop `tcpOnly` and let UDP carry the PROXY-tagged datagrams
+directly. This harness validates that path.
 
 ```lua
 newServer({
   address = '172.29.0.10:53',
-  tcpOnly = true,
   useProxyProtocol = true,
 })
 ```
+
+The `tcpOnly = true` recipe still works (numa accepts PROXY v2 on both
+transports) — it's a useful fallback for sites that need to consolidate
+all backend traffic on TCP for L4-firewall reasons.
 
 ## Run the smoke
 
@@ -37,8 +39,8 @@ Builds the local numa Dockerfile, starts dnsdist 2.0, runs `dig +udp`
 queries through dnsdist, and asserts:
 
 - `proxy_protocol.accepted` increments per query.
-- `transport.tcp` increments (proves the dnsdist→numa hop is TCP).
-- `transport.udp` does **not** grow on that hop (proves `tcpOnly=true`).
+- `transport.udp` increments (proves the dnsdist→numa hop stays UDP).
+- `transport.tcp` does **not** outpace UDP growth.
 - No pp2 rejections or timeouts.
 
 ## Manual probe
@@ -46,7 +48,7 @@ queries through dnsdist, and asserts:
 ```sh
 docker compose up -d --build
 
-# UDP from host → dnsdist → TCP+PROXY v2 → numa
+# UDP from host → dnsdist → UDP+PROXY v2 → numa
 dig +short @127.0.0.1 -p 15454 example.com
 
 # numa stats — proxy_protocol.accepted grows with each query
@@ -67,9 +69,9 @@ docker compose down -v
 | | `pp2-numa/` (HAProxy) | `dnsdist-numa-l7/` (this) |
 |---|---|---|
 | Front-end | HAProxy 2.9 (L4 passthrough) | dnsdist 2.0 (L7 DNS-aware) |
-| Numa transports exercised | DoT (:853) + plain TCP (:53) | Plain TCP (:53) |
-| Client transport | TLS + raw TCP | UDP (transmuxed by dnsdist) |
+| Numa transports exercised | DoT (:853) + plain TCP (:53) | Plain UDP (:53) |
+| Client transport | TLS + raw TCP | UDP |
 | PROXY v2 source | `send-proxy-v2` (HAProxy) | `useProxyProtocol=true` (dnsdist) |
-| Validates | DoT-terminating front-ends | DNS-aware UDP-in front-ends |
+| Validates | DoT-terminating front-ends | DNS-aware UDP PROXY v2 |
 
-Run both for the full PR #156 coverage matrix.
+Run both for full transport coverage.

--- a/tests/docker/dnsdist-numa-l7/dnsdist.conf
+++ b/tests/docker/dnsdist-numa-l7/dnsdist.conf
@@ -1,16 +1,15 @@
--- L7 dnsdist front-end fronting numa, with UDP→TCP transmuxing.
+-- L7 dnsdist front-end fronting numa, with UDP-on-UDP PROXY v2.
 --
--- Listens on UDP+TCP/53 from clients, forces all backend queries over
--- TCP (`tcpOnly=true`), and prepends a PROXY v2 header at connection
--- open (`useProxyProtocol=true`). This lets numa receive real client
--- IPs over plain DNS without UDP PROXY v2 support: clients still get
--- low-latency UDP, the PROXY-v2-bearing hop is 100% TCP.
+-- Listens on UDP+TCP/53 from clients and forwards backend queries on
+-- the same transport the client used. `useProxyProtocol = true` makes
+-- dnsdist prepend a PROXY v2 header to every backend query — including
+-- per-datagram on UDP. numa parses that prefix, recovers the real
+-- client IP, and runs the regular UDP query path.
 
 addLocal('0.0.0.0:53')
 
 newServer({
   address = '172.29.0.10:53',
-  tcpOnly = true,
   useProxyProtocol = true,
 })
 

--- a/tests/docker/dnsdist-numa-l7/smoke.sh
+++ b/tests/docker/dnsdist-numa-l7/smoke.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Smoke test for dnsdist L7 → numa over plain TCP with PROXY v2.
-# Client sends UDP to dnsdist; dnsdist transmuxes to TCP and prepends a
-# PROXY v2 header at connection open.
+# Smoke test for dnsdist L7 → numa over UDP with PROXY v2.
+# Client sends UDP to dnsdist; dnsdist forwards UDP to numa and prepends
+# a PROXY v2 header to every backend datagram.
 #
 # Asserts:
 #   1. dig +udp through dnsdist returns a real answer.
-#   2. numa's transport.tcp counter increments (proves dnsdist→numa hop
-#      is TCP, not UDP — i.e. tcpOnly=true is in effect).
+#   2. numa's transport.udp counter increments (proves dnsdist→numa hop
+#      stays on UDP — no tcpOnly transmux, the PROXY header rides UDP).
 #   3. numa's proxy_protocol.accepted increments (proves the PROXY header
 #      was parsed and the real client IP propagated).
 #   4. No rejections or timeouts on numa's pp2 layer.
@@ -34,7 +34,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "── dnsdist L7 → numa PROXY v2 smoke test ──"
+echo "── dnsdist L7 → numa UDP+PROXY v2 smoke test ──"
 
 echo "  building & starting stack..."
 docker compose up -d --build >/dev/null
@@ -81,19 +81,19 @@ read -r after_pp after_tcp after_udp rejected < <(curl -fsS http://127.0.0.1:153
 [ "$after_pp" -gt "$baseline_pp" ] || fail "proxy_protocol.accepted did not increment ($baseline_pp → $after_pp) — pp2 hook not firing"
 pass "proxy_protocol.accepted incremented: $baseline_pp → $after_pp"
 
-[ "$after_tcp" -gt "$baseline_tcp" ] || fail "transport.tcp did not increment ($baseline_tcp → $after_tcp) — dnsdist not transmuxing UDP→TCP, or tcpOnly=true not in effect"
-pass "transport.tcp incremented (dnsdist transmuxed UDP→TCP): $baseline_tcp → $after_tcp"
+[ "$after_udp" -gt "$baseline_udp" ] || fail "transport.udp did not increment ($baseline_udp → $after_udp) — dnsdist→numa UDP path is not delivering"
+pass "transport.udp incremented (dnsdist→numa stayed on UDP): $baseline_udp → $after_udp"
 
 [ "$rejected" = "0" ] || fail "rejected/timeout counters non-zero: $rejected"
 pass "no pp2 rejections or timeouts"
 
-# Sanity check: numa should not see UDP from the dnsdist→numa hop, since
-# tcpOnly=true forces TCP. transport.udp can still increment from health
-# probes / cache warming, so we only assert "didn't grow more than transport.tcp".
+# Sanity: with no tcpOnly, the UDP path should carry every per-query
+# datagram. transport.tcp may still tick from incidental probes, but it
+# must not outpace UDP growth.
 udp_growth=$((after_udp - baseline_udp))
 tcp_growth=$((after_tcp - baseline_tcp))
-[ "$tcp_growth" -ge "$udp_growth" ] || fail "transport.udp grew faster than transport.tcp ($udp_growth vs $tcp_growth) — tcpOnly=true may not be in effect"
-pass "transport.tcp growth ($tcp_growth) ≥ transport.udp growth ($udp_growth) — UDP→TCP transmux confirmed"
+[ "$udp_growth" -ge "$tcp_growth" ] || fail "transport.tcp grew faster than transport.udp ($tcp_growth vs $udp_growth) — UDP path may be silently transmuxing"
+pass "transport.udp growth ($udp_growth) ≥ transport.tcp growth ($tcp_growth) — UDP+PROXY v2 path confirmed"
 
 echo
 echo -e "${GREEN}all checks passed${RESET}"


### PR DESCRIPTION
## Summary

Closes the **UDP variant** deferred item from PR #156. Numa now ingests PROXY v2 headers on the plain DNS-over-UDP listener, so dnsdist L4-passthrough deployments preserve the real client IP on UDP/53 the same way they do on TCP/53 and :853 since #156. Bookends the inbound PROXY v2 transport coverage.

Operator-visible delta: `useProxyProtocol = true` on a dnsdist `newServer` block now works without the `tcpOnly = true` workaround that PR #156's harness needed to keep the L4 hop on TCP. Clients keep their UDP latency, the PROXY-tagged datagram rides UDP all the way through.

## Design

UDP is stream-less, so the existing `pp2::handshake` (which wraps a `tokio::TcpStream`) doesn't apply. New `pp2_udp` module is a slice-flavored parser: take a single buffer, peek for the v2 signature, return one of three outcomes:

```rust
pub enum UdpPp {
    Bare,                                       // feature off → pass through
    Proxied { src: SocketAddr, hdr_len: usize }, // shift, swap source
    Drop,                                        // untrusted or malformed
}
```

Three-way enum dispatches in the recv loop without `Option`-juggling. `Bare` is zero-overhead — early return when `[server.proxy_protocol].from = []`, no signature peek.

Reuses the existing `pp2::PpConfig`, the same CIDR allowlist validation, and the same four stats counters (`proxy_v2_accepted`, `_rejected_untrusted`, `_rejected_signature`, `_local_command`). No new pp2 internals — this is wiring + parser-shape.

`LOCAL` command (sender health probe) falls through using the peer address as source and treating the rest of the datagram as DNS, matching the TCP path's posture.

EDNS0 buffer math is documented in the module header: a v2 IPv4 address block consumes 28 bytes, IPv6 consumes 52. Operators sizing custom EDNS0 buffers should subtract that from the available payload budget before truncation kicks in.

## Test plan

- [x] `make all` clean (lint + build + 385 unit tests + 1 integration)
- [x] 5 new unit tests in `pp2_udp::tests`:
  - disabled returns `Bare` without signature peek
  - untrusted peer drops, increments `_rejected_untrusted`
  - valid v4 header extracts `src` and `hdr_len`, increments `_accepted`
  - garbled signature drops, increments `_rejected_signature`
  - bare DNS from a trusted peer drops in PROXY-required mode (matches TCP semantics)
- [x] `tests/docker/dnsdist-numa-l7/smoke.sh` — re-purposed: now asserts `transport.udp` growth ≥ `transport.tcp` growth (was the inverse pre-#156-followup), `proxy_protocol.accepted` increments per query, no rejections or timeouts
- [ ] point a real dnsdist at this build and verify per-client logs show real client IPs over UDP

## Out of scope

- UDP PROXY v1 (text format) — same posture as TCP path, deferred
- Multi-listener support (separate "PROXY-required port" alongside a plain :53) — separate request, see #163