### PR TITLE
fix(windows): preserve manually-configured DNS on uninstall (#160)

### DIFF
--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -962,10 +962,12 @@ fn uninstall_windows() -> Result<(), String> {
         serde_json::from_str(&json).map_err(|e| format!("invalid backup file: {}", e))?;
 
     let live = get_windows_interfaces()?;
+    let mut skipped: Vec<&str> = Vec::new();
 
     for (name, dns_info) in &original {
         let Some(idx) = live.get(name).map(|i| i.if_index.to_string()) else {
             eprintln!("  warning: adapter \"{}\" not currently up; skipped", name);
+            skipped.push(name.as_str());
             continue;
         };
 
@@ -1019,11 +1021,23 @@ fn uninstall_windows() -> Result<(), String> {
         }
     }
 
-    std::fs::remove_file(&path).ok();
-
-    // Re-enable Dnscache
+    // Keep the backup if any adapter from it wasn't reachable — without
+    // this, an offline `numa uninstall` (laptop undocked, all NICs down)
+    // would silently delete the only record of the user's pre-numa DNS,
+    // leaving the per-adapter NameServer registry pinned at 127.0.0.1
+    // with nothing to recover from when the network returns.
     enable_dnscache();
-    eprintln!("\n  System DNS restored. DNS Client re-enabled.");
+    if skipped.is_empty() {
+        std::fs::remove_file(&path).ok();
+        eprintln!("\n  System DNS restored. DNS Client re-enabled.");
+    } else {
+        eprintln!(
+            "\n  Partial restore. Backup kept at {} — re-run 'numa uninstall' after reconnecting: {}",
+            path.display(),
+            skipped.join(", ")
+        );
+        eprintln!("  DNS Client re-enabled.");
+    }
     eprintln!("  Reboot to fully restore the DNS Client service.\n");
     Ok(())
 }

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -488,12 +488,14 @@ fn discover_windows() -> SystemDnsInfo {
 }
 
 #[cfg(any(windows, test))]
-#[derive(serde::Serialize, serde::Deserialize, Debug, Default, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
 struct WindowsInterfaceDns {
-    // Live adapter index, populated only by the in-memory enumeration. Not
-    // persisted: ifIndex isn't stable across reboots, so the on-disk backup
-    // stays keyed by the friendly name and looks the index up live at
-    // restore time.
+    // Live adapter index, resolved fresh from `Get-NetAdapter` and passed to
+    // netsh as the [name=] argument — friendly names round-trip badly on
+    // non-English locales (#160: "Ethernet" returned ERROR_INVALID_NAME on
+    // ru-RU), the integer ifIndex doesn't. Skipped during serialize because
+    // ifIndex isn't stable across reboots; the on-disk backup stays keyed
+    // by friendly name and looks the index up live at restore time.
     #[serde(default, skip_serializing)]
     if_index: u32,
     servers: Vec<String>,
@@ -749,28 +751,21 @@ pub fn redirect_dns_to_localhost() -> Result<(), String> {
 }
 
 #[cfg(windows)]
+fn run_netsh_ipv4(args: &[&str]) -> std::io::Result<std::process::ExitStatus> {
+    std::process::Command::new("netsh")
+        .arg("interface")
+        .arg("ipv4")
+        .args(args)
+        .status()
+}
+
+#[cfg(windows)]
 fn redirect_dns_with_interfaces(
     interfaces: &std::collections::HashMap<String, WindowsInterfaceDns>,
 ) -> Result<(), String> {
     for (name, iface) in interfaces {
-        // netsh accepts either the friendly name or the interface index in
-        // the [name=] slot. Friendly names round-trip badly through
-        // ipconfig/PowerShell on non-English locales (#160 saw "Ethernet"
-        // returning ERROR_INVALID_NAME on Russian Win11) — ifIndex is an
-        // integer and locale-invariant.
         let idx = iface.if_index.to_string();
-        let status = std::process::Command::new("netsh")
-            .args([
-                "interface",
-                "ipv4",
-                "set",
-                "dnsservers",
-                &idx,
-                "static",
-                "127.0.0.1",
-                "primary",
-            ])
-            .status()
+        let status = run_netsh_ipv4(&["set", "dnsservers", &idx, "static", "127.0.0.1", "primary"])
             .map_err(|e| format!("failed to set DNS for {}: {}", name, e))?;
 
         if status.success() {
@@ -966,17 +961,11 @@ fn uninstall_windows() -> Result<(), String> {
     let original: std::collections::HashMap<String, WindowsInterfaceDns> =
         serde_json::from_str(&json).map_err(|e| format!("invalid backup file: {}", e))?;
 
-    // Re-enumerate live adapters to get current ifIndex per name. The on-disk
-    // backup is keyed by friendly name (human-readable, stable across boots);
-    // ifIndex isn't stable, so we resolve it fresh and pass the integer to
-    // netsh — friendly names round-trip badly on non-English locales (#160).
     let live = get_windows_interfaces()?;
 
     for (name, dns_info) in &original {
         let Some(idx) = live.get(name).map(|i| i.if_index.to_string()) else {
-            // Adapter from the backup is no longer up — skip silently. netsh
-            // would have refused with "service not running" anyway, and the
-            // user's active interfaces are the only ones worth restoring.
+            eprintln!("  warning: adapter \"{}\" not currently up; skipped", name);
             continue;
         };
 
@@ -988,9 +977,7 @@ fn uninstall_windows() -> Result<(), String> {
             .collect();
 
         if real_servers.is_empty() {
-            let status = std::process::Command::new("netsh")
-                .args(["interface", "ipv4", "set", "dnsservers", &idx, "dhcp"])
-                .status()
+            let status = run_netsh_ipv4(&["set", "dnsservers", &idx, "dhcp"])
                 .map_err(|e| format!("failed to restore DNS for {}: {}", name, e))?;
 
             if status.success() {
@@ -999,19 +986,15 @@ fn uninstall_windows() -> Result<(), String> {
                 eprintln!("  warning: failed to restore DNS for \"{}\"", name);
             }
         } else {
-            let status = std::process::Command::new("netsh")
-                .args([
-                    "interface",
-                    "ipv4",
-                    "set",
-                    "dnsservers",
-                    &idx,
-                    "static",
-                    real_servers[0],
-                    "primary",
-                ])
-                .status()
-                .map_err(|e| format!("failed to restore DNS for {}: {}", name, e))?;
+            let status = run_netsh_ipv4(&[
+                "set",
+                "dnsservers",
+                &idx,
+                "static",
+                real_servers[0],
+                "primary",
+            ])
+            .map_err(|e| format!("failed to restore DNS for {}: {}", name, e))?;
 
             if !status.success() {
                 eprintln!("  warning: failed to restore primary DNS for \"{}\"", name);
@@ -1019,17 +1002,13 @@ fn uninstall_windows() -> Result<(), String> {
             }
 
             for (i, server) in real_servers.iter().skip(1).enumerate() {
-                let _ = std::process::Command::new("netsh")
-                    .args([
-                        "interface",
-                        "ipv4",
-                        "add",
-                        "dnsservers",
-                        &idx,
-                        server,
-                        &format!("index={}", i + 2),
-                    ])
-                    .status();
+                let _ = run_netsh_ipv4(&[
+                    "add",
+                    "dnsservers",
+                    &idx,
+                    server,
+                    &format!("index={}", i + 2),
+                ]);
             }
 
             eprintln!(
@@ -2076,10 +2055,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_powershell_skips_missing_if_index_for_legacy_backup() {
-        // Backups written by pre-fix versions have no `if_index`; deserialize
-        // must succeed and default the field. Uninstall re-enumerates live
-        // adapters anyway, so a 0 here is harmless.
+    fn parse_powershell_legacy_backup_without_if_index() {
         let sample = r#"{"Ethernet":{"servers":["8.8.8.8"]}}"#;
         let result = parse_powershell_interfaces(sample).expect("parse failed");
         assert_eq!(result["Ethernet"].if_index, 0);
@@ -2164,14 +2140,14 @@ mod tests {
             "Wi-Fi".into(),
             WindowsInterfaceDns {
                 servers: vec!["127.0.0.1".into()],
-                ..Default::default()
+                if_index: 0,
             },
         );
         map.insert(
             "Ethernet".into(),
             WindowsInterfaceDns {
                 servers: vec!["::1".into(), "0.0.0.0".into()],
-                ..Default::default()
+                if_index: 0,
             },
         );
         assert!(!backup_has_real_upstream_windows(&map));
@@ -2186,7 +2162,7 @@ mod tests {
                     "fec0:0:0:ffff::2".into(),
                     "fec0:0:0:ffff::3".into(),
                 ],
-                ..Default::default()
+                if_index: 0,
             },
         );
         assert!(!backup_has_real_upstream_windows(&map));
@@ -2196,7 +2172,7 @@ mod tests {
             "Ethernet 2".into(),
             WindowsInterfaceDns {
                 servers: vec!["192.168.1.1".into()],
-                ..Default::default()
+                if_index: 0,
             },
         );
         assert!(backup_has_real_upstream_windows(&map));

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -488,8 +488,14 @@ fn discover_windows() -> SystemDnsInfo {
 }
 
 #[cfg(any(windows, test))]
-#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Default, PartialEq)]
 struct WindowsInterfaceDns {
+    // Live adapter index, populated only by the in-memory enumeration. Not
+    // persisted: ifIndex isn't stable across reboots, so the on-disk backup
+    // stays keyed by the friendly name and looks the index up live at
+    // restore time.
+    #[serde(default, skip_serializing)]
+    if_index: u32,
     servers: Vec<String>,
 }
 
@@ -510,7 +516,7 @@ foreach ($a in $adapters) {
     # configured DNS for one family, and `$v4 + $null` appends a literal
     # null entry that ConvertTo-Json emits as JSON `null`, breaking the
     # `Vec<String>` deserialize on the Rust side.
-    $result[$a.Name] = @{ servers = @(($v4 + $v6) | Where-Object { $_ }) }
+    $result[$a.Name] = @{ if_index = $a.ifIndex; servers = @(($v4 + $v6) | Where-Object { $_ }) }
 }
 $result | ConvertTo-Json -Compress -Depth 4
 "#;
@@ -746,14 +752,20 @@ pub fn redirect_dns_to_localhost() -> Result<(), String> {
 fn redirect_dns_with_interfaces(
     interfaces: &std::collections::HashMap<String, WindowsInterfaceDns>,
 ) -> Result<(), String> {
-    for name in interfaces.keys() {
+    for (name, iface) in interfaces {
+        // netsh accepts either the friendly name or the interface index in
+        // the [name=] slot. Friendly names round-trip badly through
+        // ipconfig/PowerShell on non-English locales (#160 saw "Ethernet"
+        // returning ERROR_INVALID_NAME on Russian Win11) — ifIndex is an
+        // integer and locale-invariant.
+        let idx = iface.if_index.to_string();
         let status = std::process::Command::new("netsh")
             .args([
                 "interface",
                 "ipv4",
                 "set",
                 "dnsservers",
-                name,
+                &idx,
                 "static",
                 "127.0.0.1",
                 "primary",
@@ -954,7 +966,20 @@ fn uninstall_windows() -> Result<(), String> {
     let original: std::collections::HashMap<String, WindowsInterfaceDns> =
         serde_json::from_str(&json).map_err(|e| format!("invalid backup file: {}", e))?;
 
+    // Re-enumerate live adapters to get current ifIndex per name. The on-disk
+    // backup is keyed by friendly name (human-readable, stable across boots);
+    // ifIndex isn't stable, so we resolve it fresh and pass the integer to
+    // netsh — friendly names round-trip badly on non-English locales (#160).
+    let live = get_windows_interfaces()?;
+
     for (name, dns_info) in &original {
+        let Some(idx) = live.get(name).map(|i| i.if_index.to_string()) else {
+            // Adapter from the backup is no longer up — skip silently. netsh
+            // would have refused with "service not running" anyway, and the
+            // user's active interfaces are the only ones worth restoring.
+            continue;
+        };
+
         let real_servers: Vec<&str> = dns_info
             .servers
             .iter()
@@ -964,7 +989,7 @@ fn uninstall_windows() -> Result<(), String> {
 
         if real_servers.is_empty() {
             let status = std::process::Command::new("netsh")
-                .args(["interface", "ipv4", "set", "dnsservers", name, "dhcp"])
+                .args(["interface", "ipv4", "set", "dnsservers", &idx, "dhcp"])
                 .status()
                 .map_err(|e| format!("failed to restore DNS for {}: {}", name, e))?;
 
@@ -980,7 +1005,7 @@ fn uninstall_windows() -> Result<(), String> {
                     "ipv4",
                     "set",
                     "dnsservers",
-                    name,
+                    &idx,
                     "static",
                     real_servers[0],
                     "primary",
@@ -1000,7 +1025,7 @@ fn uninstall_windows() -> Result<(), String> {
                         "ipv4",
                         "add",
                         "dnsservers",
-                        name,
+                        &idx,
                         server,
                         &format!("index={}", i + 2),
                     ])
@@ -2028,23 +2053,37 @@ mod tests {
     #[test]
     fn parse_powershell_servers() {
         // Shape emitted by ENUMERATE_INTERFACES_PS — adapter name keys, each
-        // value carries a merged IPv4+IPv6 server list. Legacy `dhcp` field
-        // (in pre-fix backups on disk) is silently ignored on read.
-        let sample = r#"{"Ethernet":{"servers":["8.8.8.8","8.8.4.4"]},"Wi-Fi":{"dhcp":true,"servers":["1.1.1.1"]}}"#;
+        // value carries the live ifIndex and a merged IPv4+IPv6 server list.
+        // Legacy `dhcp` field (in pre-fix backups on disk) is silently
+        // ignored on read.
+        let sample = r#"{"Ethernet":{"if_index":12,"servers":["8.8.8.8","8.8.4.4"]},"Wi-Fi":{"dhcp":true,"if_index":7,"servers":["1.1.1.1"]}}"#;
         let result = parse_powershell_interfaces(sample).expect("parse failed");
         assert_eq!(result.len(), 2);
         assert_eq!(
             result["Ethernet"],
             WindowsInterfaceDns {
+                if_index: 12,
                 servers: vec!["8.8.8.8".into(), "8.8.4.4".into()],
             }
         );
         assert_eq!(
             result["Wi-Fi"],
             WindowsInterfaceDns {
+                if_index: 7,
                 servers: vec!["1.1.1.1".into()],
             }
         );
+    }
+
+    #[test]
+    fn parse_powershell_skips_missing_if_index_for_legacy_backup() {
+        // Backups written by pre-fix versions have no `if_index`; deserialize
+        // must succeed and default the field. Uninstall re-enumerates live
+        // adapters anyway, so a 0 here is harmless.
+        let sample = r#"{"Ethernet":{"servers":["8.8.8.8"]}}"#;
+        let result = parse_powershell_interfaces(sample).expect("parse failed");
+        assert_eq!(result["Ethernet"].if_index, 0);
+        assert_eq!(result["Ethernet"].servers, vec!["8.8.8.8".to_string()]);
     }
 
     #[test]
@@ -2125,12 +2164,14 @@ mod tests {
             "Wi-Fi".into(),
             WindowsInterfaceDns {
                 servers: vec!["127.0.0.1".into()],
+                ..Default::default()
             },
         );
         map.insert(
             "Ethernet".into(),
             WindowsInterfaceDns {
                 servers: vec!["::1".into(), "0.0.0.0".into()],
+                ..Default::default()
             },
         );
         assert!(!backup_has_real_upstream_windows(&map));
@@ -2145,6 +2186,7 @@ mod tests {
                     "fec0:0:0:ffff::2".into(),
                     "fec0:0:0:ffff::3".into(),
                 ],
+                ..Default::default()
             },
         );
         assert!(!backup_has_real_upstream_windows(&map));
@@ -2154,6 +2196,7 @@ mod tests {
             "Ethernet 2".into(),
             WindowsInterfaceDns {
                 servers: vec!["192.168.1.1".into()],
+                ..Default::default()
             },
         );
         assert!(backup_has_real_upstream_windows(&map));

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -490,12 +490,9 @@ fn discover_windows() -> SystemDnsInfo {
 #[cfg(any(windows, test))]
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
 struct WindowsInterfaceDns {
-    // Live adapter index, resolved fresh from `Get-NetAdapter` and passed to
-    // netsh as the [name=] argument — friendly names round-trip badly on
-    // non-English locales (#160: "Ethernet" returned ERROR_INVALID_NAME on
-    // ru-RU), the integer ifIndex doesn't. Skipped during serialize because
-    // ifIndex isn't stable across reboots; the on-disk backup stays keyed
-    // by friendly name and looks the index up live at restore time.
+    // Passed to netsh's [name=] slot since friendly names fail with
+    // ERROR_INVALID_NAME on non-English locales (#160). Resolved live at
+    // restore time — ifIndex isn't stable across reboots.
     #[serde(default, skip_serializing)]
     if_index: u32,
     servers: Vec<String>,
@@ -1021,11 +1018,9 @@ fn uninstall_windows() -> Result<(), String> {
         }
     }
 
-    // Keep the backup if any adapter from it wasn't reachable — without
-    // this, an offline `numa uninstall` (laptop undocked, all NICs down)
-    // would silently delete the only record of the user's pre-numa DNS,
-    // leaving the per-adapter NameServer registry pinned at 127.0.0.1
-    // with nothing to recover from when the network returns.
+    // Keep the backup if any adapter wasn't reachable — an offline
+    // uninstall would otherwise leave the registry pinned at 127.0.0.1
+    // with no recovery state for when the network returns.
     enable_dnscache();
     if skipped.is_empty() {
         std::fs::remove_file(&path).ok();

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -18,7 +18,20 @@ fn print_recursive_hint() {
 }
 
 fn is_loopback_or_stub(addr: &str) -> bool {
-    matches!(addr, "127.0.0.1" | "127.0.0.53" | "0.0.0.0" | "::1" | "")
+    // fec0:0:0:ffff::1/2/3 are the deprecated IPv6 site-local stubs that
+    // Get-DnsClientServerAddress returns for any IPv6-enabled adapter
+    // without explicit DNS — they're not real upstreams.
+    matches!(
+        addr,
+        "127.0.0.1"
+            | "127.0.0.53"
+            | "0.0.0.0"
+            | "::1"
+            | "fec0:0:0:ffff::1"
+            | "fec0:0:0:ffff::2"
+            | "fec0:0:0:ffff::3"
+            | ""
+    )
 }
 
 /// A conditional forwarding rule: domains matching `suffix` are forwarded to `upstream`.
@@ -477,7 +490,6 @@ fn discover_windows() -> SystemDnsInfo {
 #[cfg(any(windows, test))]
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
 struct WindowsInterfaceDns {
-    dhcp: bool,
     servers: Vec<String>,
 }
 
@@ -494,13 +506,11 @@ $adapters = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' }
 foreach ($a in $adapters) {
     $v4 = @(Get-DnsClientServerAddress -InterfaceIndex $a.ifIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue).ServerAddresses
     $v6 = @(Get-DnsClientServerAddress -InterfaceIndex $a.ifIndex -AddressFamily IPv6 -ErrorAction SilentlyContinue).ServerAddresses
-    $iface = Get-NetIPInterface -InterfaceIndex $a.ifIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue
-    $dhcp = if ($iface) { $iface.Dhcp -eq 'Enabled' } else { $false }
     # Drop nulls: ServerAddresses can be $null when an adapter has no
     # configured DNS for one family, and `$v4 + $null` appends a literal
     # null entry that ConvertTo-Json emits as JSON `null`, breaking the
     # `Vec<String>` deserialize on the Rust side.
-    $result[$a.Name] = @{ dhcp = $dhcp; servers = @(($v4 + $v6) | Where-Object { $_ }) }
+    $result[$a.Name] = @{ servers = @(($v4 + $v6) | Where-Object { $_ }) }
 }
 $result | ConvertTo-Json -Compress -Depth 4
 "#;
@@ -945,7 +955,14 @@ fn uninstall_windows() -> Result<(), String> {
         serde_json::from_str(&json).map_err(|e| format!("invalid backup file: {}", e))?;
 
     for (name, dns_info) in &original {
-        if dns_info.dhcp || dns_info.servers.is_empty() {
+        let real_servers: Vec<&str> = dns_info
+            .servers
+            .iter()
+            .map(String::as_str)
+            .filter(|s| !is_loopback_or_stub(s))
+            .collect();
+
+        if real_servers.is_empty() {
             let status = std::process::Command::new("netsh")
                 .args(["interface", "ipv4", "set", "dnsservers", name, "dhcp"])
                 .status()
@@ -965,7 +982,7 @@ fn uninstall_windows() -> Result<(), String> {
                     "dnsservers",
                     name,
                     "static",
-                    &dns_info.servers[0],
+                    real_servers[0],
                     "primary",
                 ])
                 .status()
@@ -976,7 +993,7 @@ fn uninstall_windows() -> Result<(), String> {
                 continue;
             }
 
-            for (i, server) in dns_info.servers.iter().skip(1).enumerate() {
+            for (i, server) in real_servers.iter().skip(1).enumerate() {
                 let _ = std::process::Command::new("netsh")
                     .args([
                         "interface",
@@ -993,7 +1010,7 @@ fn uninstall_windows() -> Result<(), String> {
             eprintln!(
                 "  restored DNS for \"{}\" -> {}",
                 name,
-                dns_info.servers.join(", ")
+                real_servers.join(", ")
             );
         }
     }
@@ -2009,23 +2026,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_powershell_dhcp_and_static() {
+    fn parse_powershell_servers() {
         // Shape emitted by ENUMERATE_INTERFACES_PS — adapter name keys, each
-        // value carries DHCP state and merged IPv4+IPv6 server list.
-        let sample = r#"{"Ethernet":{"dhcp":true,"servers":["8.8.8.8","8.8.4.4"]},"Wi-Fi":{"dhcp":false,"servers":["1.1.1.1"]}}"#;
+        // value carries a merged IPv4+IPv6 server list. Legacy `dhcp` field
+        // (in pre-fix backups on disk) is silently ignored on read.
+        let sample = r#"{"Ethernet":{"servers":["8.8.8.8","8.8.4.4"]},"Wi-Fi":{"dhcp":true,"servers":["1.1.1.1"]}}"#;
         let result = parse_powershell_interfaces(sample).expect("parse failed");
         assert_eq!(result.len(), 2);
         assert_eq!(
             result["Ethernet"],
             WindowsInterfaceDns {
-                dhcp: true,
                 servers: vec!["8.8.8.8".into(), "8.8.4.4".into()],
             }
         );
         assert_eq!(
             result["Wi-Fi"],
             WindowsInterfaceDns {
-                dhcp: false,
                 servers: vec!["1.1.1.1".into()],
             }
         );
@@ -2052,7 +2068,7 @@ mod tests {
         // Locks in the PS-side null filter (Where-Object { $_ }) — a real
         // install on a dual-stack adapter without IPv6 DNS used to emit
         // `["10.0.0.1", null]`, failing deserialize at install time.
-        let sample = r#"{"Wi-Fi":{"dhcp":true,"servers":["1.1.1.1",null]}}"#;
+        let sample = r#"{"Wi-Fi":{"servers":["1.1.1.1",null]}}"#;
         assert!(parse_powershell_interfaces(sample).is_err());
     }
 
@@ -2108,15 +2124,27 @@ mod tests {
         map.insert(
             "Wi-Fi".into(),
             WindowsInterfaceDns {
-                dhcp: false,
                 servers: vec!["127.0.0.1".into()],
             },
         );
         map.insert(
             "Ethernet".into(),
             WindowsInterfaceDns {
-                dhcp: false,
                 servers: vec!["::1".into(), "0.0.0.0".into()],
+            },
+        );
+        assert!(!backup_has_real_upstream_windows(&map));
+
+        // fec0:0:0:ffff::1/2/3 leak into every VPN/virtual adapter via
+        // Get-DnsClientServerAddress.
+        map.insert(
+            "Tailscale".into(),
+            WindowsInterfaceDns {
+                servers: vec![
+                    "fec0:0:0:ffff::1".into(),
+                    "fec0:0:0:ffff::2".into(),
+                    "fec0:0:0:ffff::3".into(),
+                ],
             },
         );
         assert!(!backup_has_real_upstream_windows(&map));
@@ -2125,7 +2153,6 @@ mod tests {
         map.insert(
             "Ethernet 2".into(),
             WindowsInterfaceDns {
-                dhcp: false,
                 servers: vec!["192.168.1.1".into()],
             },
         );


### PR DESCRIPTION
## Summary

Compounding Windows bugs let `numa install` capture a corrupt backup that `numa uninstall` then used to wipe the user's manually-configured DNS, leaving them offline until they edited the registry by hand. Reported and reproduced on Russian Win11 26100 in #160 (independently corroborated by a second user).

- **Filter the deprecated IPv6 site-local stubs** `fec0:0:0:ffff::1/2/3` in `is_loopback_or_stub`. `Get-DnsClientServerAddress` returns these for any IPv6-enabled adapter without explicit DNS, so every VPN/virtual interface ended up with identical garbage in the backup.
- **Drop the `dhcp` field from `WindowsInterfaceDns`.** It was sourced from `Get-NetIPInterface.Dhcp` (IPv4 lease mode), not DNS source — so "DHCP IP + manual DoH resolvers" was stamped `dhcp=true` and the user's manual servers were wiped on uninstall. Decide DHCP-vs-static on `real_servers.is_empty()` instead. Old backup files on disk deserialize fine — the unknown `dhcp` field is silently ignored.
- **Pass ifIndex to netsh instead of the friendly adapter name.** Friendly names fail with `ERROR_INVALID_NAME` on non-English locales (the ru-RU `Ethernet` failure in #160). ifIndex is locale-invariant and resolved live at restore time (`if_index` is `skip_serializing` since it's not stable across reboots). A small `run_netsh_ipv4` helper consolidates the four call sites.
- **Preserve the backup when an adapter isn't currently up at uninstall.** Previously the backup was always deleted, so an offline-during-uninstall adapter could never be recovered. Now the backup is kept and the user is told to re-run `numa uninstall` after reconnecting; only adapters that were successfully restored advance toward backup deletion.

Closes four of the six checklist items in #160: fec0 filter, dhcp misclassification, ru-RU `ERROR_INVALID_NAME`, and the install-side disconnected-adapter guard (already filtered by `Get-NetAdapter | Status -eq 'Up'`; this PR adds the symmetric uninstall-side preserve-on-offline path). Two items remain on the umbrella issue and need a Russian-locale repro: the `netsh` exit-code mismatch on ru-RU, and the three uninstall-hardening sub-items (always-re-enable Dnscache on backup-read failure, force-revert orphan 127.0.0.1 adapters, defer `disable_dnscache` until Numa binds :53).

## Test plan

- [x] `make all` green (lint + build + 380 unit tests + 1 integration test)
- [x] `windows_backup_filters_loopback` extended with the fec0 stub case (Tailscale-style virtual adapter)
- [x] `parse_powershell_servers` (renamed from `parse_powershell_dhcp_and_static`) confirms the stripped JSON shape parses
- [x] `parse_powershell_legacy_backup_without_if_index` confirms pre-fix backups on disk deserialize with `if_index = 0` (re-resolved live at restore time)
- [x] Manual upgrade smoke: en-US Windows, `numa install` over an existing 0.14.2 install upgrades cleanly to 0.14.3 (legacy backup with `dhcp` field is preserved unchanged, no read-side errors)
- [x] Manual install/uninstall round-trip on a Windows box with DHCP IP + manual DNS — verified on a machine carrying a 0.14.2-written backup; 0.14.3 uninstall correctly read the legacy backup, ignored the now-removed `dhcp:true` field, took the `real_servers.is_empty() == false` static branch, and restored Wi-Fi to its original `213.154.124.1, 193.231.252.1` (pre-fix would have wiped to DHCP)
- [ ] Manual install/uninstall on a Windows box with VPN/virtual adapters — verify those interfaces are restored to DHCP rather than pinned to fec0 stubs
- [x] Manual install/uninstall on Win11 with regional settings switched to RU — ifIndex path completed end-to-end for `Wi-Fi` and `Ethernet 4`, both DNS-set and DNS-restore. Caveat: netsh emitted English (system display language fell back to en-US), so the original `Команда выполнена успешно` / `ERROR_INVALID_NAME` reproduction conditions weren't fully present. New code path validated; full ru-RU display-language reproduction still pending.
- [ ] Manual offline-adapter path — disconnect Wi-Fi between install and uninstall, verify backup is kept; reconnect and re-run uninstall, verify restore completes and backup is removed