### PR TITLE
refactor: gate cognitive complexity and split 4 hot functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,6 @@ harness = false
 [[bench]]
 name = "recursive_compare"
 harness = false
+
+[lints.clippy]
+cognitive_complexity = "warn"

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -106,172 +106,13 @@ pub async fn resolve_query(
     //        -> .tld proxy -> blocklist -> cache -> forwarding -> recursive/upstream
     // Each lock is scoped to avoid holding MutexGuard across await points.
     let mut upstream_transport: Option<crate::stats::UpstreamTransport> = None;
-    let (response, path, dnssec) = {
-        let override_record = ctx.overrides.read().unwrap().lookup(&qname);
-        if let Some(record) = override_record {
-            let mut resp = DnsPacket::response_from(&query, ResultCode::NOERROR);
-            resp.answers.push(record);
-            (resp, QueryPath::Overridden, DnssecStatus::Indeterminate)
-        } else if qname == "localhost" || qname.ends_with(".localhost") {
-            // RFC 6761: .localhost always resolves to loopback
-            let mut resp = DnsPacket::response_from(&query, ResultCode::NOERROR);
-            resp.answers.push(sinkhole_record(
-                &qname,
-                qtype,
-                std::net::Ipv4Addr::LOCALHOST,
-                std::net::Ipv6Addr::LOCALHOST,
-                300,
-            ));
-            (resp, QueryPath::Local, DnssecStatus::Indeterminate)
-        } else if let Some(records) = ctx.zone_map.get(qname.as_str()).and_then(|m| m.get(&qtype)) {
-            let mut resp = DnsPacket::response_from(&query, ResultCode::NOERROR);
-            resp.answers = records.clone();
-            (resp, QueryPath::Local, DnssecStatus::Indeterminate)
-        } else if is_special_use_domain(&qname)
-            && crate::system_dns::match_forwarding_rule(&qname, &ctx.forwarding_rules).is_none()
-        {
-            // RFC 6761/8880: answer locally unless a forwarding rule covers this zone.
-            let resp = special_use_response(&query, &qname, qtype);
-            (resp, QueryPath::Local, DnssecStatus::Indeterminate)
-        } else if !ctx.proxy_tld_suffix.is_empty()
-            && (qname.ends_with(&ctx.proxy_tld_suffix) || qname == ctx.proxy_tld)
-        {
-            // Resolve .numa: remote clients get LAN IP (can't reach 127.0.0.1), local get loopback
-            let service_name = qname.strip_suffix(&ctx.proxy_tld_suffix).unwrap_or(&qname);
-            let is_remote = !src_addr.ip().is_loopback();
-            let resolve_ip = {
-                let local = ctx.services.lock().unwrap();
-                if local.lookup(service_name).is_some() {
-                    if is_remote {
-                        *ctx.lan_ip.lock().unwrap()
-                    } else {
-                        std::net::Ipv4Addr::LOCALHOST
-                    }
-                } else {
-                    let mut peers = ctx.lan_peers.lock().unwrap();
-                    peers
-                        .lookup(service_name)
-                        .and_then(|(ip, _)| match ip {
-                            std::net::IpAddr::V4(v4) => Some(v4),
-                            _ => None,
-                        })
-                        .unwrap_or(std::net::Ipv4Addr::LOCALHOST)
-                }
-            };
-            let v6 = if resolve_ip == std::net::Ipv4Addr::LOCALHOST {
-                std::net::Ipv6Addr::LOCALHOST
-            } else {
-                resolve_ip.to_ipv6_mapped()
-            };
-            let mut resp = DnsPacket::response_from(&query, ResultCode::NOERROR);
-            resp.answers
-                .push(sinkhole_record(&qname, qtype, resolve_ip, v6, 300));
-            (resp, QueryPath::Local, DnssecStatus::Indeterminate)
-        } else if ctx.blocklist.read().unwrap().is_blocked(&qname) {
-            let mut resp = DnsPacket::response_from(&query, ResultCode::NOERROR);
-            resp.answers.push(sinkhole_record(
-                &qname,
-                qtype,
-                std::net::Ipv4Addr::UNSPECIFIED,
-                std::net::Ipv6Addr::UNSPECIFIED,
-                60,
-            ));
-            (resp, QueryPath::Blocked, DnssecStatus::Indeterminate)
-        } else if qtype == QueryType::AAAA && ctx.filter_aaaa {
-            // RFC 2308 NODATA: NOERROR with empty answer section. Prevents
-            // Happy Eyeballs clients from waiting on an AAAA they'll never use
-            // on IPv4-only networks. NXDOMAIN would be wrong (it'd imply the
-            // name doesn't exist for A either).
-            let resp = DnsPacket::response_from(&query, ResultCode::NOERROR);
-            (resp, QueryPath::Local, DnssecStatus::Indeterminate)
-        } else {
-            let cached = ctx.cache.read().unwrap().lookup_with_status(&qname, qtype);
-            if let Some((cached, cached_dnssec, freshness)) = cached {
-                if freshness.needs_refresh() {
-                    let key = (qname.clone(), qtype);
-                    let already = !ctx.refreshing.lock().unwrap().insert(key.clone());
-                    if !already {
-                        let ctx = Arc::clone(ctx);
-                        tokio::spawn(async move {
-                            refresh_entry(&ctx, &key.0, key.1).await;
-                            ctx.refreshing.lock().unwrap().remove(&key);
-                        });
-                    }
-                }
-                let mut resp = cached;
-                resp.header.id = query.header.id;
-                if cached_dnssec == DnssecStatus::Secure {
-                    resp.header.authed_data = true;
-                }
-                (resp, QueryPath::Cached, cached_dnssec)
-            } else if let Some(pool) =
-                crate::system_dns::match_forwarding_rule(&qname, &ctx.forwarding_rules)
-            {
-                // Conditional forwarding takes priority over recursive mode
-                // (e.g. Tailscale .ts.net, VPC private zones)
-                let key = (qname.clone(), qtype);
-                let (resp, path, err) =
-                    resolve_coalesced(&ctx.inflight, key, &query, QueryPath::Forwarded, || async {
-                        let wire = forward_with_failover_raw(
-                            raw_wire,
-                            pool,
-                            &ctx.srtt,
-                            ctx.timeout,
-                            ctx.hedge_delay,
-                        )
-                        .await?;
-                        cache_and_parse(ctx, &qname, qtype, &wire)
-                    })
-                    .await;
-                log_coalesced_outcome(src_addr, qtype, &qname, path, err.as_deref(), "FORWARD");
-                if path == QueryPath::Forwarded {
-                    upstream_transport = pool.preferred().map(|u| u.transport());
-                }
-                (resp, path, DnssecStatus::Indeterminate)
-            } else if ctx.upstream_mode == UpstreamMode::Recursive {
-                // Recursive resolution makes UDP hops to roots/TLDs/auths;
-                // tag as Udp so the dashboard can aggregate plaintext-wire
-                // egress honestly. Only mark on success — errors stay None.
-                let key = (qname.clone(), qtype);
-                let (resp, path, err) =
-                    resolve_coalesced(&ctx.inflight, key, &query, QueryPath::Recursive, || {
-                        crate::recursive::resolve_recursive(
-                            &qname,
-                            qtype,
-                            &ctx.cache,
-                            &query,
-                            &ctx.root_hints,
-                            &ctx.srtt,
-                        )
-                    })
-                    .await;
-                log_coalesced_outcome(src_addr, qtype, &qname, path, err.as_deref(), "RECURSIVE");
-                if path == QueryPath::Recursive {
-                    upstream_transport = Some(crate::stats::UpstreamTransport::Udp);
-                }
-                (resp, path, DnssecStatus::Indeterminate)
-            } else {
-                let pool = ctx.upstream_pool.lock().unwrap().clone();
-                let key = (qname.clone(), qtype);
-                let (resp, path, err) =
-                    resolve_coalesced(&ctx.inflight, key, &query, QueryPath::Upstream, || async {
-                        let wire = forward_with_failover_raw(
-                            raw_wire,
-                            &pool,
-                            &ctx.srtt,
-                            ctx.timeout,
-                            ctx.hedge_delay,
-                        )
-                        .await?;
-                        cache_and_parse(ctx, &qname, qtype, &wire)
-                    })
-                    .await;
-                log_coalesced_outcome(src_addr, qtype, &qname, path, err.as_deref(), "UPSTREAM");
-                if path == QueryPath::Upstream {
-                    upstream_transport = pool.preferred().map(|u| u.transport());
-                }
-                (resp, path, DnssecStatus::Indeterminate)
-            }
+    let (response, path, dnssec) = match resolve_local(&query, src_addr, &qname, qtype, ctx) {
+        Some(result) => result,
+        None => {
+            let (resp, path, dnssec, ut) =
+                resolve_remote(&query, raw_wire, src_addr, &qname, qtype, ctx).await;
+            upstream_transport = ut;
+            (resp, path, dnssec)
         }
     };
 
@@ -388,6 +229,210 @@ pub async fn resolve_query(
     });
 
     Ok((resp_buffer, path))
+}
+
+/// Local resolution pipeline: overrides, .localhost, zones, special-use, .numa
+/// proxy TLD, blocklist, AAAA filter. Returns `None` to fall through to remote
+/// resolution (cache/forwarding/recursive/upstream).
+fn resolve_local(
+    query: &DnsPacket,
+    src_addr: SocketAddr,
+    qname: &str,
+    qtype: QueryType,
+    ctx: &ServerCtx,
+) -> Option<(DnsPacket, QueryPath, DnssecStatus)> {
+    if let Some(record) = ctx.overrides.read().unwrap().lookup(qname) {
+        let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
+        resp.answers.push(record);
+        return Some((resp, QueryPath::Overridden, DnssecStatus::Indeterminate));
+    }
+    if qname == "localhost" || qname.ends_with(".localhost") {
+        // RFC 6761: .localhost always resolves to loopback
+        let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
+        resp.answers.push(sinkhole_record(
+            qname,
+            qtype,
+            std::net::Ipv4Addr::LOCALHOST,
+            std::net::Ipv6Addr::LOCALHOST,
+            300,
+        ));
+        return Some((resp, QueryPath::Local, DnssecStatus::Indeterminate));
+    }
+    if let Some(records) = ctx.zone_map.get(qname).and_then(|m| m.get(&qtype)) {
+        let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
+        resp.answers = records.clone();
+        return Some((resp, QueryPath::Local, DnssecStatus::Indeterminate));
+    }
+    if is_special_use_domain(qname)
+        && crate::system_dns::match_forwarding_rule(qname, &ctx.forwarding_rules).is_none()
+    {
+        // RFC 6761/8880: answer locally unless a forwarding rule covers this zone.
+        let resp = special_use_response(query, qname, qtype);
+        return Some((resp, QueryPath::Local, DnssecStatus::Indeterminate));
+    }
+    if !ctx.proxy_tld_suffix.is_empty()
+        && (qname.ends_with(&ctx.proxy_tld_suffix) || qname == ctx.proxy_tld)
+    {
+        return Some(resolve_proxy_tld(query, src_addr, qname, qtype, ctx));
+    }
+    if ctx.blocklist.read().unwrap().is_blocked(qname) {
+        let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
+        resp.answers.push(sinkhole_record(
+            qname,
+            qtype,
+            std::net::Ipv4Addr::UNSPECIFIED,
+            std::net::Ipv6Addr::UNSPECIFIED,
+            60,
+        ));
+        return Some((resp, QueryPath::Blocked, DnssecStatus::Indeterminate));
+    }
+    if qtype == QueryType::AAAA && ctx.filter_aaaa {
+        // RFC 2308 NODATA: NOERROR with empty answer section. Prevents
+        // Happy Eyeballs clients from waiting on an AAAA they'll never use
+        // on IPv4-only networks.
+        let resp = DnsPacket::response_from(query, ResultCode::NOERROR);
+        return Some((resp, QueryPath::Local, DnssecStatus::Indeterminate));
+    }
+    None
+}
+
+/// Resolve .numa: remote clients get LAN IP (can't reach 127.0.0.1), local get loopback.
+fn resolve_proxy_tld(
+    query: &DnsPacket,
+    src_addr: SocketAddr,
+    qname: &str,
+    qtype: QueryType,
+    ctx: &ServerCtx,
+) -> (DnsPacket, QueryPath, DnssecStatus) {
+    let service_name = qname.strip_suffix(&ctx.proxy_tld_suffix).unwrap_or(qname);
+    let is_remote = !src_addr.ip().is_loopback();
+    let resolve_ip = {
+        let local = ctx.services.lock().unwrap();
+        if local.lookup(service_name).is_some() {
+            if is_remote {
+                *ctx.lan_ip.lock().unwrap()
+            } else {
+                std::net::Ipv4Addr::LOCALHOST
+            }
+        } else {
+            let mut peers = ctx.lan_peers.lock().unwrap();
+            peers
+                .lookup(service_name)
+                .and_then(|(ip, _)| match ip {
+                    std::net::IpAddr::V4(v4) => Some(v4),
+                    _ => None,
+                })
+                .unwrap_or(std::net::Ipv4Addr::LOCALHOST)
+        }
+    };
+    let v6 = if resolve_ip == std::net::Ipv4Addr::LOCALHOST {
+        std::net::Ipv6Addr::LOCALHOST
+    } else {
+        resolve_ip.to_ipv6_mapped()
+    };
+    let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
+    resp.answers
+        .push(sinkhole_record(qname, qtype, resolve_ip, v6, 300));
+    (resp, QueryPath::Local, DnssecStatus::Indeterminate)
+}
+
+/// Remote resolution: cache → conditional forwarding → recursive/upstream.
+async fn resolve_remote(
+    query: &DnsPacket,
+    raw_wire: &[u8],
+    src_addr: SocketAddr,
+    qname: &str,
+    qtype: QueryType,
+    ctx: &Arc<ServerCtx>,
+) -> (
+    DnsPacket,
+    QueryPath,
+    DnssecStatus,
+    Option<crate::stats::UpstreamTransport>,
+) {
+    let cached = ctx.cache.read().unwrap().lookup_with_status(qname, qtype);
+    if let Some((cached, cached_dnssec, freshness)) = cached {
+        if freshness.needs_refresh() {
+            let key = (qname.to_string(), qtype);
+            let already = !ctx.refreshing.lock().unwrap().insert(key.clone());
+            if !already {
+                let ctx = Arc::clone(ctx);
+                tokio::spawn(async move {
+                    refresh_entry(&ctx, &key.0, key.1).await;
+                    ctx.refreshing.lock().unwrap().remove(&key);
+                });
+            }
+        }
+        let mut resp = cached;
+        resp.header.id = query.header.id;
+        if cached_dnssec == DnssecStatus::Secure {
+            resp.header.authed_data = true;
+        }
+        return (resp, QueryPath::Cached, cached_dnssec, None);
+    }
+
+    if let Some(pool) = crate::system_dns::match_forwarding_rule(qname, &ctx.forwarding_rules) {
+        // Conditional forwarding takes priority over recursive mode
+        // (e.g. Tailscale .ts.net, VPC private zones)
+        let key = (qname.to_string(), qtype);
+        let (resp, path, err) =
+            resolve_coalesced(&ctx.inflight, key, query, QueryPath::Forwarded, || async {
+                let wire = forward_with_failover_raw(
+                    raw_wire,
+                    pool,
+                    &ctx.srtt,
+                    ctx.timeout,
+                    ctx.hedge_delay,
+                )
+                .await?;
+                cache_and_parse(ctx, qname, qtype, &wire)
+            })
+            .await;
+        log_coalesced_outcome(src_addr, qtype, qname, path, err.as_deref(), "FORWARD");
+        let upstream_transport = (path == QueryPath::Forwarded)
+            .then(|| pool.preferred().map(|u| u.transport()))
+            .flatten();
+        return (resp, path, DnssecStatus::Indeterminate, upstream_transport);
+    }
+
+    if ctx.upstream_mode == UpstreamMode::Recursive {
+        // Recursive resolution makes UDP hops to roots/TLDs/auths;
+        // tag as Udp so the dashboard can aggregate plaintext-wire
+        // egress honestly. Only mark on success — errors stay None.
+        let key = (qname.to_string(), qtype);
+        let (resp, path, err) =
+            resolve_coalesced(&ctx.inflight, key, query, QueryPath::Recursive, || {
+                crate::recursive::resolve_recursive(
+                    qname,
+                    qtype,
+                    &ctx.cache,
+                    query,
+                    &ctx.root_hints,
+                    &ctx.srtt,
+                )
+            })
+            .await;
+        log_coalesced_outcome(src_addr, qtype, qname, path, err.as_deref(), "RECURSIVE");
+        let upstream_transport =
+            (path == QueryPath::Recursive).then_some(crate::stats::UpstreamTransport::Udp);
+        return (resp, path, DnssecStatus::Indeterminate, upstream_transport);
+    }
+
+    let pool = ctx.upstream_pool.lock().unwrap().clone();
+    let key = (qname.to_string(), qtype);
+    let (resp, path, err) =
+        resolve_coalesced(&ctx.inflight, key, query, QueryPath::Upstream, || async {
+            let wire =
+                forward_with_failover_raw(raw_wire, &pool, &ctx.srtt, ctx.timeout, ctx.hedge_delay)
+                    .await?;
+            cache_and_parse(ctx, qname, qtype, &wire)
+        })
+        .await;
+    log_coalesced_outcome(src_addr, qtype, qname, path, err.as_deref(), "UPSTREAM");
+    let upstream_transport = (path == QueryPath::Upstream)
+        .then(|| pool.preferred().map(|u| u.transport()))
+        .flatten();
+    (resp, path, DnssecStatus::Indeterminate, upstream_transport)
 }
 
 fn cache_and_parse(

--- a/src/dnssec.rs
+++ b/src/dnssec.rs
@@ -61,6 +61,31 @@ static TRUST_ANCHORS: LazyLock<Vec<DnsRecord>> = LazyLock::new(|| {
     }]
 });
 
+struct ValidationCtx<'a> {
+    cache: &'a RwLock<DnsCache>,
+    root_hints: &'a [std::net::SocketAddr],
+    srtt: &'a RwLock<SrttCache>,
+    trust_anchors: &'a [DnsRecord],
+    stats: &'a Mutex<ValidationStats>,
+}
+
+enum RrsetVerdict {
+    Verified,
+    Bogus,
+}
+
+enum RrsigOutcome {
+    Verified,
+    ChainBogus,
+    NoMatchingKey,
+}
+
+enum KeyOutcome {
+    Verified,
+    ChainBogus,
+    Skip,
+}
+
 /// Top-level validation: verify the DNSSEC chain of trust for a response.
 pub async fn validate_response(
     response: &DnsPacket,
@@ -82,180 +107,33 @@ pub async fn validate_response(
         .collect();
 
     if all_rrsigs.is_empty() {
-        let mut s = stats.into_inner().unwrap_or_else(|e| e.into_inner());
-        s.elapsed_ms = start.elapsed().as_millis() as u64;
-        return (DnssecStatus::Insecure, s);
+        return finish(start, stats, DnssecStatus::Insecure);
     }
 
-    // Prefetch DNSKEYs for all signer zones
-    let mut signer_zones: Vec<String> = Vec::new();
-    for r in &all_rrsigs {
-        if let DnsRecord::RRSIG { signer_name, .. } = r {
-            let lower = signer_name.to_lowercase();
-            if !signer_zones.contains(&lower) {
-                signer_zones.push(lower);
-            }
-        }
-    }
-    for zone in &signer_zones {
-        fetch_dnskeys(zone, cache, root_hints, srtt, &stats).await;
-    }
+    let ctx = ValidationCtx {
+        cache,
+        root_hints,
+        srtt,
+        trust_anchors,
+        stats: &stats,
+    };
 
-    // Group answer records into RRsets (by domain + type, excluding RRSIGs)
+    prefetch_signer_dnskeys(&all_rrsigs, &ctx).await;
+
     let rrsets = group_rrsets(&response.answers);
 
     for (name, qtype, rrset) in &rrsets {
-        let matching_rrsigs: Vec<&&DnsRecord> = all_rrsigs
-            .iter()
-            .filter(|r| {
-                if let DnsRecord::RRSIG {
-                    domain,
-                    type_covered,
-                    ..
-                } = r
-                {
-                    domain.eq_ignore_ascii_case(name)
-                        && QueryType::from_num(*type_covered) == *qtype
-                } else {
-                    false
-                }
-            })
-            .collect();
-
+        let matching_rrsigs = matching_rrsigs_for(&all_rrsigs, name, *qtype);
         if matching_rrsigs.is_empty() {
             continue; // No RRSIG for this RRset — might be Insecure
         }
-
-        let mut any_verified = false;
-        for rrsig in &matching_rrsigs {
-            if let DnsRecord::RRSIG {
-                signer_name,
-                key_tag,
-                algorithm,
-                ..
-            } = rrsig
-            {
-                let dnskey_response =
-                    fetch_dnskeys(signer_name, cache, root_hints, srtt, &stats).await;
-                let dnskeys: Vec<&DnsRecord> = dnskey_response
-                    .iter()
-                    .filter(|r| matches!(r, DnsRecord::DNSKEY { .. }))
-                    .collect();
-                if dnskeys.is_empty() {
-                    trace!("dnssec: no DNSKEY found for signer '{}'", signer_name);
-                    continue;
-                }
-
-                trace!(
-                    "dnssec: verifying {} {:?} | signer={} key_tag={} algo={} | {} DNSKEYs available",
-                    name, qtype, signer_name, key_tag, algorithm, dnskeys.len()
-                );
-
-                for dk in &dnskeys {
-                    if let DnsRecord::DNSKEY {
-                        flags,
-                        protocol,
-                        algorithm: dk_algo,
-                        public_key,
-                        ..
-                    } = dk
-                    {
-                        let tag = compute_key_tag(*flags, *protocol, *dk_algo, public_key);
-                        if *dk_algo != *algorithm {
-                            trace!(
-                                "dnssec:   DNSKEY tag={} algo={} — algo mismatch (want {})",
-                                tag,
-                                dk_algo,
-                                algorithm
-                            );
-                            continue;
-                        }
-                        if tag != *key_tag {
-                            trace!(
-                                "dnssec:   DNSKEY tag={} — tag mismatch (want {})",
-                                tag,
-                                key_tag
-                            );
-                            continue;
-                        }
-
-                        // Check RRSIG time validity (RFC 4035 §5.3.1)
-                        if let DnsRecord::RRSIG {
-                            expiration,
-                            inception,
-                            ..
-                        } = rrsig
-                        {
-                            if !is_rrsig_time_valid(*expiration, *inception) {
-                                trace!("dnssec:   RRSIG expired or not yet valid (inception={} expiration={})", inception, expiration);
-                                continue;
-                            }
-                        }
-
-                        trace!("dnssec:   DNSKEY tag={} algo={} flags={} — matched, verifying signature ({} bytes)", tag, dk_algo, flags, public_key.len());
-                        let signed_data = build_signed_data(rrsig, rrset);
-                        if let DnsRecord::RRSIG { signature, .. } = rrsig {
-                            let ok =
-                                verify_signature(*algorithm, public_key, &signed_data, signature);
-                            trace!(
-                                "dnssec:   verify result: {} (signed_data={} bytes, sig={} bytes)",
-                                ok,
-                                signed_data.len(),
-                                signature.len()
-                            );
-                            if ok {
-                                // Validate the DNSKEY itself via chain of trust
-                                let chain_status = validate_chain(
-                                    signer_name,
-                                    &dnskey_response,
-                                    cache,
-                                    root_hints,
-                                    srtt,
-                                    trust_anchors,
-                                    0,
-                                    &stats,
-                                )
-                                .await;
-
-                                trace!(
-                                    "dnssec:   chain_status for '{}': {:?}",
-                                    signer_name,
-                                    chain_status
-                                );
-                                match chain_status {
-                                    DnssecStatus::Secure => {
-                                        any_verified = true;
-                                        break;
-                                    }
-                                    DnssecStatus::Bogus => {
-                                        let mut s =
-                                            stats.into_inner().unwrap_or_else(|e| e.into_inner());
-                                        s.elapsed_ms = start.elapsed().as_millis() as u64;
-                                        return (DnssecStatus::Bogus, s);
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            if any_verified {
-                break;
-            }
-        }
-
-        if !any_verified && !matching_rrsigs.is_empty() {
+        if let RrsetVerdict::Bogus = verify_rrset(name, *qtype, rrset, &matching_rrsigs, &ctx).await
+        {
             debug!("dnssec: no valid signature for {} {:?}", name, qtype);
-            let mut s = stats.into_inner().unwrap_or_else(|e| e.into_inner());
-            s.elapsed_ms = start.elapsed().as_millis() as u64;
-            return (DnssecStatus::Bogus, s);
+            return finish(start, stats, DnssecStatus::Bogus);
         }
     }
 
-    let mut s = stats.into_inner().unwrap_or_else(|e| e.into_inner());
-    s.elapsed_ms = start.elapsed().as_millis() as u64;
     if rrsets.is_empty() {
         // NXDOMAIN or NODATA — check authority section for NSEC/NSEC3 proofs
         let (qname, qtype_num) = response
@@ -273,10 +151,222 @@ pub async fn validate_response(
             is_nxdomain,
             cache,
         );
-        return (denial, s);
+        return finish(start, stats, denial);
     }
 
-    (DnssecStatus::Secure, s)
+    finish(start, stats, DnssecStatus::Secure)
+}
+
+fn finish(
+    start: Instant,
+    stats: Mutex<ValidationStats>,
+    status: DnssecStatus,
+) -> (DnssecStatus, ValidationStats) {
+    let mut s = stats.into_inner().unwrap_or_else(|e| e.into_inner());
+    s.elapsed_ms = start.elapsed().as_millis() as u64;
+    (status, s)
+}
+
+async fn prefetch_signer_dnskeys(all_rrsigs: &[&DnsRecord], ctx: &ValidationCtx<'_>) {
+    let mut signer_zones: Vec<String> = Vec::new();
+    for r in all_rrsigs {
+        if let DnsRecord::RRSIG { signer_name, .. } = r {
+            let lower = signer_name.to_lowercase();
+            if !signer_zones.contains(&lower) {
+                signer_zones.push(lower);
+            }
+        }
+    }
+    for zone in &signer_zones {
+        fetch_dnskeys(zone, ctx.cache, ctx.root_hints, ctx.srtt, ctx.stats).await;
+    }
+}
+
+fn matching_rrsigs_for<'a>(
+    all_rrsigs: &[&'a DnsRecord],
+    name: &str,
+    qtype: QueryType,
+) -> Vec<&'a DnsRecord> {
+    all_rrsigs
+        .iter()
+        .copied()
+        .filter(|r| {
+            if let DnsRecord::RRSIG {
+                domain,
+                type_covered,
+                ..
+            } = r
+            {
+                domain.eq_ignore_ascii_case(name) && QueryType::from_num(*type_covered) == qtype
+            } else {
+                false
+            }
+        })
+        .collect()
+}
+
+async fn verify_rrset(
+    name: &str,
+    qtype: QueryType,
+    rrset: &[&DnsRecord],
+    matching_rrsigs: &[&DnsRecord],
+    ctx: &ValidationCtx<'_>,
+) -> RrsetVerdict {
+    for rrsig in matching_rrsigs {
+        match try_verify_rrsig(rrsig, name, qtype, rrset, ctx).await {
+            RrsigOutcome::Verified => return RrsetVerdict::Verified,
+            RrsigOutcome::ChainBogus => return RrsetVerdict::Bogus,
+            RrsigOutcome::NoMatchingKey => continue,
+        }
+    }
+    RrsetVerdict::Bogus
+}
+
+async fn try_verify_rrsig(
+    rrsig: &DnsRecord,
+    name: &str,
+    qtype: QueryType,
+    rrset: &[&DnsRecord],
+    ctx: &ValidationCtx<'_>,
+) -> RrsigOutcome {
+    let DnsRecord::RRSIG {
+        signer_name,
+        key_tag,
+        algorithm,
+        ..
+    } = rrsig
+    else {
+        return RrsigOutcome::NoMatchingKey;
+    };
+
+    let dnskey_response =
+        fetch_dnskeys(signer_name, ctx.cache, ctx.root_hints, ctx.srtt, ctx.stats).await;
+    let dnskeys: Vec<&DnsRecord> = dnskey_response
+        .iter()
+        .filter(|r| matches!(r, DnsRecord::DNSKEY { .. }))
+        .collect();
+    if dnskeys.is_empty() {
+        trace!("dnssec: no DNSKEY found for signer '{}'", signer_name);
+        return RrsigOutcome::NoMatchingKey;
+    }
+
+    trace!(
+        "dnssec: verifying {} {:?} | signer={} key_tag={} algo={} | {} DNSKEYs available",
+        name,
+        qtype,
+        signer_name,
+        key_tag,
+        algorithm,
+        dnskeys.len()
+    );
+
+    for dk in &dnskeys {
+        match try_verify_with_key(dk, rrsig, rrset, signer_name, &dnskey_response, ctx).await {
+            KeyOutcome::Verified => return RrsigOutcome::Verified,
+            KeyOutcome::ChainBogus => return RrsigOutcome::ChainBogus,
+            KeyOutcome::Skip => continue,
+        }
+    }
+    RrsigOutcome::NoMatchingKey
+}
+
+async fn try_verify_with_key(
+    dk: &DnsRecord,
+    rrsig: &DnsRecord,
+    rrset: &[&DnsRecord],
+    signer_name: &str,
+    dnskey_response: &[DnsRecord],
+    ctx: &ValidationCtx<'_>,
+) -> KeyOutcome {
+    let DnsRecord::DNSKEY {
+        flags,
+        protocol,
+        algorithm: dk_algo,
+        public_key,
+        ..
+    } = dk
+    else {
+        return KeyOutcome::Skip;
+    };
+    let DnsRecord::RRSIG {
+        algorithm,
+        key_tag,
+        expiration,
+        inception,
+        signature,
+        ..
+    } = rrsig
+    else {
+        return KeyOutcome::Skip;
+    };
+
+    let tag = compute_key_tag(*flags, *protocol, *dk_algo, public_key);
+    if *dk_algo != *algorithm {
+        trace!(
+            "dnssec:   DNSKEY tag={} algo={} — algo mismatch (want {})",
+            tag,
+            dk_algo,
+            algorithm
+        );
+        return KeyOutcome::Skip;
+    }
+    if tag != *key_tag {
+        trace!(
+            "dnssec:   DNSKEY tag={} — tag mismatch (want {})",
+            tag,
+            key_tag
+        );
+        return KeyOutcome::Skip;
+    }
+    if !is_rrsig_time_valid(*expiration, *inception) {
+        trace!(
+            "dnssec:   RRSIG expired or not yet valid (inception={} expiration={})",
+            inception,
+            expiration
+        );
+        return KeyOutcome::Skip;
+    }
+
+    trace!(
+        "dnssec:   DNSKEY tag={} algo={} flags={} — matched, verifying signature ({} bytes)",
+        tag,
+        dk_algo,
+        flags,
+        public_key.len()
+    );
+    let signed_data = build_signed_data(rrsig, rrset);
+    let ok = verify_signature(*algorithm, public_key, &signed_data, signature);
+    trace!(
+        "dnssec:   verify result: {} (signed_data={} bytes, sig={} bytes)",
+        ok,
+        signed_data.len(),
+        signature.len()
+    );
+    if !ok {
+        return KeyOutcome::Skip;
+    }
+
+    let chain_status = validate_chain(
+        signer_name,
+        dnskey_response,
+        ctx.cache,
+        ctx.root_hints,
+        ctx.srtt,
+        ctx.trust_anchors,
+        0,
+        ctx.stats,
+    )
+    .await;
+    trace!(
+        "dnssec:   chain_status for '{}': {:?}",
+        signer_name,
+        chain_status
+    );
+    match chain_status {
+        DnssecStatus::Secure => KeyOutcome::Verified,
+        DnssecStatus::Bogus => KeyOutcome::ChainBogus,
+        _ => KeyOutcome::Skip,
+    }
 }
 
 /// Walk the chain of trust from zone DNSKEY up to root trust anchor.

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -44,11 +44,6 @@ pub async fn run(config_path: String) -> crate::Result<()> {
 
     let root_hints = crate::recursive::parse_root_hints(&config.upstream.root_hints);
 
-    let recursive_pool = || {
-        let dummy = UpstreamPool::new(vec![Upstream::Udp("0.0.0.0:0".parse().unwrap())], vec![]);
-        (dummy, "recursive (root hints)".to_string())
-    };
-
     // Routes numa-originated HTTPS (DoH upstream, ODoH relay/target, blocklist
     // CDN) away from the system resolver so lookups don't loop back through
     // numa when it's its own system DNS.
@@ -65,87 +60,8 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         resolver_overrides,
     ));
 
-    let (resolved_mode, upstream_auto, pool, upstream_label) = match config.upstream.mode {
-        crate::config::UpstreamMode::Auto => {
-            info!("auto mode: probing recursive resolution...");
-            if crate::recursive::probe_recursive(&root_hints).await {
-                info!("recursive probe succeeded — self-sovereign mode");
-                let (pool, label) = recursive_pool();
-                (crate::config::UpstreamMode::Recursive, false, pool, label)
-            } else {
-                log::warn!("recursive probe failed — falling back to Quad9 DoH");
-                let client = build_https_client_with_resolver(1, Some(bootstrap_resolver.clone()));
-                let url = DOH_FALLBACK.to_string();
-                let label = url.clone();
-                let pool = UpstreamPool::new(vec![Upstream::Doh { url, client }], vec![]);
-                (crate::config::UpstreamMode::Forward, false, pool, label)
-            }
-        }
-        crate::config::UpstreamMode::Recursive => {
-            let (pool, label) = recursive_pool();
-            (crate::config::UpstreamMode::Recursive, false, pool, label)
-        }
-        crate::config::UpstreamMode::Forward => {
-            let addrs = if config.upstream.address.is_empty() {
-                let detected = system_dns
-                    .default_upstream
-                    .or_else(crate::system_dns::detect_dhcp_dns)
-                    .unwrap_or_else(|| {
-                        info!("could not detect system DNS, falling back to Quad9 DoH");
-                        DOH_FALLBACK.to_string()
-                    });
-                vec![detected]
-            } else {
-                config.upstream.address.clone()
-            };
-
-            let primary = parse_upstream_list(
-                &addrs,
-                config.upstream.port,
-                Some(bootstrap_resolver.clone()),
-            )?;
-            let fallback = parse_upstream_list(
-                &config.upstream.fallback,
-                config.upstream.port,
-                Some(bootstrap_resolver.clone()),
-            )?;
-
-            let pool = UpstreamPool::new(primary, fallback);
-            let label = pool.label();
-            (
-                crate::config::UpstreamMode::Forward,
-                config.upstream.address.is_empty(),
-                pool,
-                label,
-            )
-        }
-        crate::config::UpstreamMode::Odoh => {
-            let odoh = config.upstream.odoh_upstream()?;
-            let client = build_https_client_with_resolver(1, Some(bootstrap_resolver.clone()));
-            let target_config = Arc::new(OdohConfigCache::new(
-                odoh.target_host.clone(),
-                client.clone(),
-            ));
-            let primary = vec![Upstream::Odoh {
-                relay_url: odoh.relay_url,
-                target_path: odoh.target_path,
-                client,
-                target_config,
-            }];
-            let fallback = if odoh.strict {
-                Vec::new()
-            } else {
-                parse_upstream_list(
-                    &config.upstream.fallback,
-                    config.upstream.port,
-                    Some(bootstrap_resolver.clone()),
-                )?
-            };
-            let pool = UpstreamPool::new(primary, fallback);
-            let label = pool.label();
-            (crate::config::UpstreamMode::Odoh, false, pool, label)
-        }
-    };
+    let (resolved_mode, upstream_auto, pool, upstream_label) =
+        resolve_upstream_pool(&config, &system_dns, &root_hints, &bootstrap_resolver).await?;
     let api_port = config.server.api_port;
 
     let mut blocklist = BlocklistStore::new();
@@ -283,8 +199,189 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     });
 
     let zone_count: usize = ctx.zone_map.values().map(|m| m.len()).sum();
-    // Build banner rows, then size the box to fit the longest value
     let api_url = format!("http://localhost:{}", api_port);
+    print_banner(
+        &config,
+        &ctx,
+        &api_url,
+        &upstream_label,
+        zone_count,
+        doh_enabled,
+    );
+
+    info!(
+        "numa listening on {}, upstream {}, {} zone records, cache max {}, API on port {}",
+        config.server.bind_addr, upstream_label, zone_count, config.cache.max_entries, api_port,
+    );
+
+    spawn_background_services(&ctx, &config, &bootstrap_resolver, api_port)?;
+
+    udp_serve_loop(&ctx).await
+}
+
+fn spawn_background_services(
+    ctx: &Arc<ServerCtx>,
+    config: &crate::config::Config,
+    bootstrap_resolver: &Arc<NumaResolver>,
+    api_port: u16,
+) -> crate::Result<()> {
+    let blocklist_lists = config.blocking.lists.clone();
+    let refresh_hours = config.blocking.refresh_hours;
+    if config.blocking.enabled && !blocklist_lists.is_empty() {
+        let bl_ctx = Arc::clone(ctx);
+        let bl_resolver = bootstrap_resolver.clone();
+        tokio::spawn(async move {
+            load_blocklists(&bl_ctx, &blocklist_lists, Some(bl_resolver.clone())).await;
+
+            let mut interval = tokio::time::interval(Duration::from_secs(refresh_hours * 3600));
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                info!("refreshing blocklists...");
+                load_blocklists(&bl_ctx, &blocklist_lists, Some(bl_resolver.clone())).await;
+            }
+        });
+    }
+
+    if ctx.upstream_mode == crate::config::UpstreamMode::Recursive {
+        let prime_ctx = Arc::clone(ctx);
+        let prime_tlds = config.upstream.prime_tlds.clone();
+        tokio::spawn(async move {
+            crate::recursive::prime_tld_cache(
+                &prime_ctx.cache,
+                &prime_ctx.root_hints,
+                &prime_tlds,
+                &prime_ctx.srtt,
+            )
+            .await;
+        });
+    }
+
+    if !config.cache.warm.is_empty() {
+        let warm_ctx = Arc::clone(ctx);
+        let warm_domains = config.cache.warm.clone();
+        tokio::spawn(async move {
+            cache_warm_loop(warm_ctx, warm_domains).await;
+        });
+    }
+
+    {
+        let keepalive_ctx = Arc::clone(ctx);
+        tokio::spawn(async move {
+            doh_keepalive_loop(keepalive_ctx).await;
+        });
+    }
+
+    let api_ctx = Arc::clone(ctx);
+    let api_addr: SocketAddr = format!("{}:{}", config.server.api_bind_addr, api_port).parse()?;
+    tokio::spawn(async move {
+        let app = crate::api::router(api_ctx);
+        let listener = tokio::net::TcpListener::bind(api_addr).await.unwrap();
+        info!("HTTP API listening on {}", api_addr);
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Mobile API: read-only subset for iOS/Android companion apps, LAN-bound
+    // by default. Only idempotent GETs; no state-mutating routes regardless
+    // of the main API's bind address.
+    if config.mobile.enabled {
+        let mobile_ctx = Arc::clone(ctx);
+        let mobile_bind = config.mobile.bind_addr.clone();
+        let mobile_port = config.mobile.port;
+        tokio::spawn(async move {
+            if let Err(e) = crate::mobile_api::start(mobile_ctx, mobile_bind, mobile_port).await {
+                log::warn!("Mobile API listener failed: {}", e);
+            }
+        });
+    }
+
+    let proxy_bind: std::net::Ipv4Addr = config
+        .proxy
+        .bind_addr
+        .parse()
+        .unwrap_or(std::net::Ipv4Addr::LOCALHOST);
+
+    if config.proxy.enabled {
+        let proxy_ctx = Arc::clone(ctx);
+        let proxy_port = config.proxy.port;
+        tokio::spawn(async move {
+            crate::proxy::start_proxy(proxy_ctx, proxy_port, proxy_bind).await;
+        });
+    }
+
+    if config.proxy.enabled && config.proxy.tls_port > 0 && ctx.tls_config.is_some() {
+        let proxy_ctx = Arc::clone(ctx);
+        let tls_port = config.proxy.tls_port;
+        let pp_cfg = config.proxy.proxy_protocol.clone();
+        tokio::spawn(async move {
+            crate::proxy::start_proxy_tls(proxy_ctx, tls_port, proxy_bind, &pp_cfg).await;
+        });
+    }
+
+    {
+        let watch_ctx = Arc::clone(ctx);
+        tokio::spawn(async move {
+            network_watch_loop(watch_ctx).await;
+        });
+    }
+
+    if config.lan.enabled {
+        let lan_ctx = Arc::clone(ctx);
+        let lan_config = config.lan.clone();
+        tokio::spawn(async move {
+            crate::lan::start_lan_discovery(lan_ctx, &lan_config).await;
+        });
+    }
+
+    if config.dot.enabled {
+        let dot_ctx = Arc::clone(ctx);
+        let dot_config = config.dot.clone();
+        tokio::spawn(async move {
+            crate::dot::start_dot(dot_ctx, &dot_config).await;
+        });
+    }
+
+    {
+        let tcp_ctx = Arc::clone(ctx);
+        let tcp_bind = config.server.bind_addr.clone();
+        let tcp_pp = config.server.proxy_protocol.clone();
+        tokio::spawn(async move {
+            crate::tcp::start_tcp(tcp_ctx, &tcp_bind, &tcp_pp).await;
+        });
+    }
+
+    Ok(())
+}
+
+async fn udp_serve_loop(ctx: &Arc<ServerCtx>) -> crate::Result<()> {
+    #[allow(clippy::infinite_loop)]
+    loop {
+        let mut buffer = BytePacketBuffer::new();
+        let (len, src_addr) = match ctx.socket.recv_from(&mut buffer.buf).await {
+            Ok(r) => r,
+            Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {
+                // Windows delivers ICMP port-unreachable as ConnectionReset on UDP sockets
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+        };
+        let ctx = Arc::clone(ctx);
+        tokio::spawn(async move {
+            if let Err(e) = handle_query(buffer, len, src_addr, &ctx, Transport::Udp).await {
+                error!("{} | HANDLER ERROR | {}", src_addr, e);
+            }
+        });
+    }
+}
+
+fn print_banner(
+    config: &crate::config::Config,
+    ctx: &ServerCtx,
+    api_url: &str,
+    upstream_label: &str,
+    zone_count: usize,
+    doh_enabled: bool,
+) {
     let proxy_label = if config.proxy.enabled {
         if config.proxy.tls_port > 0 {
             Some(format!(
@@ -321,14 +418,14 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     .chain(proxy_label.as_ref().map(|s| s.len()))
     .max()
     .unwrap_or(30);
-    let w = (val_w + 12).max(42); // 10 label + 2 padding, min 42 for title
+    let w = (val_w + 12).max(42);
 
-    let o = "\x1b[38;2;192;98;58m"; // orange
-    let g = "\x1b[38;2;107;124;78m"; // green
-    let d = "\x1b[38;2;163;152;136m"; // dim
-    let r = "\x1b[0m"; // reset
-    let b = "\x1b[1;38;2;192;98;58m"; // bold orange
-    let it = "\x1b[3;38;2;163;152;136m"; // italic dim
+    let o = "\x1b[38;2;192;98;58m";
+    let g = "\x1b[38;2;107;124;78m";
+    let d = "\x1b[38;2;163;152;136m";
+    let r = "\x1b[0m";
+    let b = "\x1b[1;38;2;192;98;58m";
+    let it = "\x1b[3;38;2;163;152;136m";
 
     let bar_top = "═".repeat(w);
     let bar_mid = "─".repeat(w);
@@ -341,13 +438,11 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         );
     };
 
-    // Title row: center within the box
     let tag_line = "DNS that governs itself";
     let title = format!(
         "{b}NUMA{r}  {it}{tag_line}{r}  {d}v{}{r}",
         env!("CARGO_PKG_VERSION")
     );
-    // The title contains ANSI codes; visible length is ~38 chars. Pad to fill the box.
     let title_visible_len = 4 + 2 + tag_line.len() + 2 + 1 + env!("CARGO_PKG_VERSION").len() + 1;
     let title_pad = w.saturating_sub(title_visible_len);
     eprintln!("\n{o}  ╔{bar_top}╗{r}");
@@ -355,15 +450,15 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     eprintln!("{}{o}║{r}", " ".repeat(title_pad));
     eprintln!("{o}  ╠{bar_top}╣{r}");
     row("DNS", g, &config.server.bind_addr);
-    row("API", g, &api_url);
-    row("Dashboard", g, &api_url);
+    row("API", g, api_url);
+    row("Dashboard", g, api_url);
     row(
         "Upstream",
         g,
         if ctx.upstream_mode == crate::config::UpstreamMode::Recursive {
             "recursive (root hints)"
         } else {
-            &upstream_label
+            upstream_label
         },
     );
     row("Zones", g, &format!("{} records", zone_count));
@@ -387,7 +482,7 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     if let Some(ref label) = proxy_label {
         row("Proxy", g, label);
         if config.proxy.bind_addr == "127.0.0.1" {
-            let y = "\x1b[38;2;204;176;59m"; // yellow
+            let y = "\x1b[38;2;204;176;59m";
             row(
                 "",
                 y,
@@ -423,170 +518,101 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     row("Data", d, &data_label);
     row("Services", d, &services_label);
     eprintln!("{o}  ╚{bar_top}╝{r}\n");
+}
 
-    info!(
-        "numa listening on {}, upstream {}, {} zone records, cache max {}, API on port {}",
-        config.server.bind_addr, upstream_label, zone_count, config.cache.max_entries, api_port,
-    );
+async fn resolve_upstream_pool(
+    config: &crate::config::Config,
+    system_dns: &crate::system_dns::SystemDnsInfo,
+    root_hints: &[SocketAddr],
+    bootstrap_resolver: &Arc<NumaResolver>,
+) -> crate::Result<(crate::config::UpstreamMode, bool, UpstreamPool, String)> {
+    let recursive_pool = || {
+        let dummy = UpstreamPool::new(vec![Upstream::Udp("0.0.0.0:0".parse().unwrap())], vec![]);
+        (dummy, "recursive (root hints)".to_string())
+    };
 
-    // Download blocklists on startup
-    let blocklist_lists = config.blocking.lists.clone();
-    let refresh_hours = config.blocking.refresh_hours;
-    if config.blocking.enabled && !blocklist_lists.is_empty() {
-        let bl_ctx = Arc::clone(&ctx);
-        let bl_lists = blocklist_lists.clone();
-        let bl_resolver = bootstrap_resolver.clone();
-        tokio::spawn(async move {
-            load_blocklists(&bl_ctx, &bl_lists, Some(bl_resolver.clone())).await;
-
-            // Periodic refresh
-            let mut interval = tokio::time::interval(Duration::from_secs(refresh_hours * 3600));
-            interval.tick().await; // skip immediate tick
-            loop {
-                interval.tick().await;
-                info!("refreshing blocklists...");
-                load_blocklists(&bl_ctx, &bl_lists, Some(bl_resolver.clone())).await;
+    Ok(match config.upstream.mode {
+        crate::config::UpstreamMode::Auto => {
+            info!("auto mode: probing recursive resolution...");
+            if crate::recursive::probe_recursive(root_hints).await {
+                info!("recursive probe succeeded — self-sovereign mode");
+                let (pool, label) = recursive_pool();
+                (crate::config::UpstreamMode::Recursive, false, pool, label)
+            } else {
+                log::warn!("recursive probe failed — falling back to Quad9 DoH");
+                let client = build_https_client_with_resolver(1, Some(bootstrap_resolver.clone()));
+                let url = DOH_FALLBACK.to_string();
+                let label = url.clone();
+                let pool = UpstreamPool::new(vec![Upstream::Doh { url, client }], vec![]);
+                (crate::config::UpstreamMode::Forward, false, pool, label)
             }
-        });
-    }
+        }
+        crate::config::UpstreamMode::Recursive => {
+            let (pool, label) = recursive_pool();
+            (crate::config::UpstreamMode::Recursive, false, pool, label)
+        }
+        crate::config::UpstreamMode::Forward => {
+            let addrs = if config.upstream.address.is_empty() {
+                let detected = system_dns
+                    .default_upstream
+                    .clone()
+                    .or_else(crate::system_dns::detect_dhcp_dns)
+                    .unwrap_or_else(|| {
+                        info!("could not detect system DNS, falling back to Quad9 DoH");
+                        DOH_FALLBACK.to_string()
+                    });
+                vec![detected]
+            } else {
+                config.upstream.address.clone()
+            };
 
-    // Prime TLD cache (recursive mode only)
-    if ctx.upstream_mode == crate::config::UpstreamMode::Recursive {
-        let prime_ctx = Arc::clone(&ctx);
-        let prime_tlds = config.upstream.prime_tlds;
-        tokio::spawn(async move {
-            crate::recursive::prime_tld_cache(
-                &prime_ctx.cache,
-                &prime_ctx.root_hints,
-                &prime_tlds,
-                &prime_ctx.srtt,
+            let primary = parse_upstream_list(
+                &addrs,
+                config.upstream.port,
+                Some(bootstrap_resolver.clone()),
+            )?;
+            let fallback = parse_upstream_list(
+                &config.upstream.fallback,
+                config.upstream.port,
+                Some(bootstrap_resolver.clone()),
+            )?;
+
+            let pool = UpstreamPool::new(primary, fallback);
+            let label = pool.label();
+            (
+                crate::config::UpstreamMode::Forward,
+                config.upstream.address.is_empty(),
+                pool,
+                label,
             )
-            .await;
-        });
-    }
-
-    // Spawn cache warming for user-configured domains
-    if !config.cache.warm.is_empty() {
-        let warm_ctx = Arc::clone(&ctx);
-        let warm_domains = config.cache.warm.clone();
-        tokio::spawn(async move {
-            cache_warm_loop(warm_ctx, warm_domains).await;
-        });
-    }
-
-    // Spawn DoH connection keepalive — prevents idle TLS teardown
-    {
-        let keepalive_ctx = Arc::clone(&ctx);
-        tokio::spawn(async move {
-            doh_keepalive_loop(keepalive_ctx).await;
-        });
-    }
-
-    // Spawn HTTP API server
-    let api_ctx = Arc::clone(&ctx);
-    let api_addr: SocketAddr = format!("{}:{}", config.server.api_bind_addr, api_port).parse()?;
-    tokio::spawn(async move {
-        let app = crate::api::router(api_ctx);
-        let listener = tokio::net::TcpListener::bind(api_addr).await.unwrap();
-        info!("HTTP API listening on {}", api_addr);
-        axum::serve(listener, app).await.unwrap();
-    });
-
-    // Spawn Mobile API listener (read-only subset for iOS/Android companion
-    // apps, LAN-bound by default so phones can reach it). Only idempotent
-    // GETs; no state-mutating routes are exposed here regardless of
-    // the main API's bind address.
-    if config.mobile.enabled {
-        let mobile_ctx = Arc::clone(&ctx);
-        let mobile_bind = config.mobile.bind_addr.clone();
-        let mobile_port = config.mobile.port;
-        tokio::spawn(async move {
-            if let Err(e) = crate::mobile_api::start(mobile_ctx, mobile_bind, mobile_port).await {
-                log::warn!("Mobile API listener failed: {}", e);
-            }
-        });
-    }
-
-    let proxy_bind: std::net::Ipv4Addr = config
-        .proxy
-        .bind_addr
-        .parse()
-        .unwrap_or(std::net::Ipv4Addr::LOCALHOST);
-
-    // Spawn HTTP reverse proxy for .numa domains
-    if config.proxy.enabled {
-        let proxy_ctx = Arc::clone(&ctx);
-        let proxy_port = config.proxy.port;
-        tokio::spawn(async move {
-            crate::proxy::start_proxy(proxy_ctx, proxy_port, proxy_bind).await;
-        });
-    }
-
-    // Spawn HTTPS reverse proxy with TLS termination
-    if config.proxy.enabled && config.proxy.tls_port > 0 && ctx.tls_config.is_some() {
-        let proxy_ctx = Arc::clone(&ctx);
-        let tls_port = config.proxy.tls_port;
-        let pp_cfg = config.proxy.proxy_protocol.clone();
-        tokio::spawn(async move {
-            crate::proxy::start_proxy_tls(proxy_ctx, tls_port, proxy_bind, &pp_cfg).await;
-        });
-    }
-
-    // Spawn network change watcher (upstream re-detection, LAN IP update, peer flush)
-    {
-        let watch_ctx = Arc::clone(&ctx);
-        tokio::spawn(async move {
-            network_watch_loop(watch_ctx).await;
-        });
-    }
-
-    // Spawn LAN service discovery
-    if config.lan.enabled {
-        let lan_ctx = Arc::clone(&ctx);
-        let lan_config = config.lan.clone();
-        tokio::spawn(async move {
-            crate::lan::start_lan_discovery(lan_ctx, &lan_config).await;
-        });
-    }
-
-    // Spawn DNS-over-TLS listener (RFC 7858)
-    if config.dot.enabled {
-        let dot_ctx = Arc::clone(&ctx);
-        let dot_config = config.dot.clone();
-        tokio::spawn(async move {
-            crate::dot::start_dot(dot_ctx, &dot_config).await;
-        });
-    }
-
-    // Spawn DNS-over-TCP listener (RFC 1035 / RFC 7766)
-    {
-        let tcp_ctx = Arc::clone(&ctx);
-        let tcp_bind = config.server.bind_addr.clone();
-        let tcp_pp = config.server.proxy_protocol.clone();
-        tokio::spawn(async move {
-            crate::tcp::start_tcp(tcp_ctx, &tcp_bind, &tcp_pp).await;
-        });
-    }
-
-    // UDP DNS listener
-    #[allow(clippy::infinite_loop)]
-    loop {
-        let mut buffer = BytePacketBuffer::new();
-        let (len, src_addr) = match ctx.socket.recv_from(&mut buffer.buf).await {
-            Ok(r) => r,
-            Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {
-                // Windows delivers ICMP port-unreachable as ConnectionReset on UDP sockets
-                continue;
-            }
-            Err(e) => return Err(e.into()),
-        };
-        let ctx = Arc::clone(&ctx);
-        tokio::spawn(async move {
-            if let Err(e) = handle_query(buffer, len, src_addr, &ctx, Transport::Udp).await {
-                error!("{} | HANDLER ERROR | {}", src_addr, e);
-            }
-        });
-    }
+        }
+        crate::config::UpstreamMode::Odoh => {
+            let odoh = config.upstream.odoh_upstream()?;
+            let client = build_https_client_with_resolver(1, Some(bootstrap_resolver.clone()));
+            let target_config = Arc::new(OdohConfigCache::new(
+                odoh.target_host.clone(),
+                client.clone(),
+            ));
+            let primary = vec![Upstream::Odoh {
+                relay_url: odoh.relay_url,
+                target_path: odoh.target_path,
+                client,
+                target_config,
+            }];
+            let fallback = if odoh.strict {
+                Vec::new()
+            } else {
+                parse_upstream_list(
+                    &config.upstream.fallback,
+                    config.upstream.port,
+                    Some(bootstrap_resolver.clone()),
+                )?
+            };
+            let pool = UpstreamPool::new(primary, fallback);
+            let label = pool.label();
+            (crate::config::UpstreamMode::Odoh, false, pool, label)
+        }
+    })
 }
 
 async fn network_watch_loop(ctx: Arc<ServerCtx>) {

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -128,6 +128,77 @@ fn is_port_53(bind_addr: &str) -> bool {
 }
 
 #[cfg(target_os = "macos")]
+#[derive(Default)]
+struct ScutilState {
+    rules: Vec<ForwardingRule>,
+    default_upstream: Option<String>,
+    current_domain: Option<String>,
+    current_nameserver: Option<String>,
+    is_supplemental: bool,
+}
+
+#[cfg(target_os = "macos")]
+impl ScutilState {
+    fn flush(&mut self) {
+        if let (Some(domain), Some(ns), true) = (
+            self.current_domain.take(),
+            self.current_nameserver.take(),
+            self.is_supplemental,
+        ) {
+            if let Some(rule) = make_rule(&domain, &ns) {
+                self.rules.push(rule);
+            }
+        }
+        self.is_supplemental = false;
+    }
+
+    fn set_domain(&mut self, line: &str) {
+        let Some(val) = line.split(':').nth(1) else {
+            return;
+        };
+        let domain = val.trim().trim_end_matches('.').to_lowercase();
+        if !domain.is_empty()
+            && domain != "local"
+            && !domain.ends_with("in-addr.arpa")
+            && !domain.ends_with("ip6.arpa")
+        {
+            self.current_domain = Some(domain);
+        }
+    }
+
+    fn set_nameserver(&mut self, line: &str) {
+        let Some(val) = line.split(':').nth(1) else {
+            return;
+        };
+        let ns = val.trim().to_string();
+        if ns.parse::<std::net::Ipv4Addr>().is_err() {
+            return;
+        }
+        if !self.is_supplemental && self.default_upstream.is_none() && !is_loopback_or_stub(&ns) {
+            self.default_upstream = Some(ns.clone());
+        }
+        self.current_nameserver = Some(ns);
+    }
+
+    /// Returns true when the parser should stop.
+    fn handle_line(&mut self, line: &str) -> bool {
+        if line.starts_with("resolver #") {
+            self.flush();
+        } else if line.starts_with("domain") && line.contains(':') {
+            self.set_domain(line);
+        } else if line.starts_with("nameserver[0]") && line.contains(':') {
+            self.set_nameserver(line);
+        } else if line.starts_with("flags") && line.contains("Supplemental") {
+            self.is_supplemental = true;
+        } else if line.starts_with("DNS configuration (for scoped") {
+            self.flush();
+            return true;
+        }
+        false
+    }
+}
+
+#[cfg(target_os = "macos")]
 fn discover_macos() -> SystemDnsInfo {
     use log::{debug, warn};
 
@@ -143,76 +214,19 @@ fn discover_macos() -> SystemDnsInfo {
     };
 
     let text = String::from_utf8_lossy(&output.stdout);
-    let mut rules = Vec::new();
-    let mut default_upstream: Option<String> = None;
-
-    let mut current_domain: Option<String> = None;
-    let mut current_nameserver: Option<String> = None;
-    let mut is_supplemental = false;
-
+    let mut state = ScutilState::default();
     for line in text.lines() {
-        let line = line.trim();
-
-        if line.starts_with("resolver #") {
-            // Emit previous supplemental block as forwarding rule
-            if let (Some(domain), Some(ns), true) = (
-                current_domain.take(),
-                current_nameserver.take(),
-                is_supplemental,
-            ) {
-                if let Some(rule) = make_rule(&domain, &ns) {
-                    rules.push(rule);
-                }
-            }
-            current_domain = None;
-            current_nameserver = None;
-            is_supplemental = false;
-        } else if line.starts_with("domain") && line.contains(':') {
-            if let Some(val) = line.split(':').nth(1) {
-                let domain = val.trim().trim_end_matches('.').to_lowercase();
-                if !domain.is_empty()
-                    && domain != "local"
-                    && !domain.ends_with("in-addr.arpa")
-                    && !domain.ends_with("ip6.arpa")
-                {
-                    current_domain = Some(domain);
-                }
-            }
-        } else if line.starts_with("nameserver[0]") && line.contains(':') {
-            if let Some(val) = line.split(':').nth(1) {
-                let ns = val.trim().to_string();
-                if ns.parse::<std::net::Ipv4Addr>().is_ok() {
-                    current_nameserver = Some(ns.clone());
-                    // Capture first non-supplemental, non-loopback nameserver as default upstream
-                    if !is_supplemental && default_upstream.is_none() && !is_loopback_or_stub(&ns) {
-                        default_upstream = Some(ns);
-                    }
-                }
-            }
-        } else if line.starts_with("flags") && line.contains("Supplemental") {
-            is_supplemental = true;
-        } else if line.starts_with("DNS configuration (for scoped") {
-            if let (Some(domain), Some(ns), true) = (
-                current_domain.take(),
-                current_nameserver.take(),
-                is_supplemental,
-            ) {
-                if let Some(rule) = make_rule(&domain, &ns) {
-                    rules.push(rule);
-                }
-            }
+        if state.handle_line(line.trim()) {
             break;
         }
     }
+    state.flush();
 
-    // Emit last block
-    if let (Some(domain), Some(ns), true) = (current_domain, current_nameserver, is_supplemental) {
-        if let Some(rule) = make_rule(&domain, &ns) {
-            rules.push(rule);
-        }
-    }
-
-    // Sort longest suffix first for most-specific matching
+    let ScutilState {
+        mut rules,
+        default_upstream,
+        ..
+    } = state;
     rules.sort_by_key(|r| std::cmp::Reverse(r.suffix.len()));
 
     for rule in &rules {


### PR DESCRIPTION
## Summary

- Adds `[lints.clippy] cognitive_complexity = "warn"` so CI's existing `cargo clippy -- -D warnings` blocks any new function above the default threshold (25).
- Splits the four existing offenders into smaller helpers, no behavior change:
  - `serve.rs::run` (46) → extracted `resolve_upstream_pool`, `print_banner`, `spawn_background_services`, `udp_serve_loop`
  - `ctx.rs::resolve_query` (36) → split into `resolve_local` + `resolve_remote`
  - `dnssec.rs::validate_response` (33) → split into `verify_rrset` + `try_verify_rrsig` + `try_verify_with_key` with a small `ValidationCtx`
  - `system_dns.rs::discover_macos` (26) → scutil parser state machine extracted into `ScutilState`

## Test plan

- [x] `make all` green (fmt, clippy, audit, build, 380 lib tests + 1 integration test)
- [x] `cargo clippy -- -D warnings` clean (CI's exact command)
- [x] No behavior change — refactor-only; all existing tests pass