### PR TITLE
chore(deps): bump hickory to 0.26.1 (unblocks CI from today's RustSec advisories)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,12 @@
+# cargo-audit configuration. Only ignore advisories that have NO upstream
+# fix yet — anything fixable should be addressed by bumping the dependency.
+[advisories]
+ignore = [
+    # hickory-proto NSEC3 closest-encloser proof unbounded loop on cross-zone
+    # responses. No fixed upgrade available as of 2026-05-01 (advisory itself
+    # filed today). Tracked upstream:
+    # https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-3v94-mw7p-v465
+    # Impact for numa: dev-dep only (benches + one integration test). The
+    # shipped numa binary does not link hickory.
+    "RUSTSEC-2026-0118",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -351,7 +351,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -361,7 +372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -446,6 +457,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,10 +484,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -588,7 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "rustc_version",
@@ -668,18 +714,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "env_filter"
@@ -903,6 +937,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -969,26 +1004,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
  "h2",
+ "hickory-proto",
  "http",
  "idna",
  "ipnet",
- "once_cell",
- "rand",
- "ring",
+ "jni",
+ "rand 0.10.1",
  "rustls",
  "thiserror 2.0.18",
  "tinyvec",
@@ -996,31 +1030,56 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "url",
- "webpki-roots 0.26.11",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
 ]
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.10.1",
  "resolv-conf",
  "rustls",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1143,7 +1202,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1376,6 +1435,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1613,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,7 +1697,7 @@ dependencies = [
  "tokio-rustls",
  "toml",
  "tower",
- "webpki-roots 1.0.6",
+ "webpki-roots",
  "windows-service",
  "x509-parser",
 ]
@@ -1733,7 +1847,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1745,7 +1859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1787,6 +1901,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -1868,7 +1993,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1926,6 +2051,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,6 +2088,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2061,7 +2203,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2270,7 +2412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2295,6 +2437,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2359,6 +2517,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2864,15 +3043,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ windows-service = "0.7"
 criterion = { version = "0.8", features = ["html_reports"] }
 tower = { version = "0.5", features = ["util"] }
 http = "1"
-hickory-resolver = { version = "0.25", features = ["https-ring", "webpki-roots"] }
-hickory-proto = "0.25"
+hickory-resolver = { version = "0.26", features = ["https-ring", "webpki-roots"] }
+hickory-proto = "0.26"
 x509-parser = "0.18"
 
 [[bench]]

--- a/benches/recursive_compare.rs
+++ b/benches/recursive_compare.rs
@@ -792,6 +792,7 @@ fn run_diag(rt: &tokio::runtime::Runtime) {
         match &result {
             Ok(lookup) => {
                 let first = lookup
+                    .answers()
                     .iter()
                     .next()
                     .map(|r| format!("{r}"))
@@ -962,15 +963,16 @@ async fn query_doh_server(
 
 async fn build_hickory_resolver() -> hickory_resolver::TokioResolver {
     use hickory_resolver::config::*;
-    let ns = NameServerConfig {
-        socket_addr: "9.9.9.9:443".parse().unwrap(),
-        protocol: hickory_proto::xfer::Protocol::Https,
-        tls_dns_name: Some("dns.quad9.net".to_string()),
-        trust_negative_responses: true,
-        bind_addr: None,
-        http_endpoint: Some("/dns-query".to_string()),
-    };
-    let config = ResolverConfig::from_parts(None, vec![], NameServerConfigGroup::from(vec![ns]));
+    use std::sync::Arc;
+    let ns = NameServerConfig::new(
+        "9.9.9.9".parse().unwrap(),
+        true,
+        vec![ConnectionConfig::https(
+            Arc::from("dns.quad9.net"),
+            Some(Arc::from("/dns-query")),
+        )],
+    );
+    let config = ResolverConfig::from_parts(None, vec![], vec![ns]);
     let mut opts = ResolverOpts::default();
     opts.cache_size = 0;
     opts.num_concurrent_reqs = 1;
@@ -978,6 +980,7 @@ async fn build_hickory_resolver() -> hickory_resolver::TokioResolver {
     hickory_resolver::TokioResolver::builder_with_config(config, Default::default())
         .with_options(opts)
         .build()
+        .expect("hickory resolver build failed")
 }
 
 async fn query_hickory_doh(resolver: &hickory_resolver::TokioResolver, domain: &str) -> Option<()> {

--- a/tests/soa_compression_bug.rs
+++ b/tests/soa_compression_bug.rs
@@ -79,13 +79,11 @@ fn compressed_soa_survives_numa_round_trip() {
 
     let hickory_in = hickory_proto::op::Message::from_vec(&upstream)
         .expect("hand-crafted upstream must be valid");
-    let soa_in_rd = hickory_in.name_servers()[0]
-        .data()
-        .clone()
-        .into_soa()
-        .expect("SOA rdata");
-    assert_eq!(soa_in_rd.mname().to_string(), "map.fastly.net.");
-    assert_eq!(soa_in_rd.rname().to_string(), "fastly.net.");
+    let hickory_proto::rr::RData::SOA(soa_in_rd) = hickory_in.authorities[0].data.clone() else {
+        panic!("expected SOA rdata");
+    };
+    assert_eq!(soa_in_rd.mname.to_string(), "map.fastly.net.");
+    assert_eq!(soa_in_rd.rname.to_string(), "fastly.net.");
 
     let mut in_buf = BytePacketBuffer::from_bytes(&upstream);
     let pkt = DnsPacket::from_buffer(&mut in_buf).expect("numa parses upstream");
@@ -99,17 +97,15 @@ fn compressed_soa_survives_numa_round_trip() {
     let hickory_out =
         hickory_proto::op::Message::from_vec(&out).expect("numa re-emission must parse strictly");
 
-    let soa_out_rd = hickory_out.name_servers()[0]
-        .data()
-        .clone()
-        .into_soa()
-        .expect("SOA rdata on output");
+    let hickory_proto::rr::RData::SOA(soa_out_rd) = hickory_out.authorities[0].data.clone() else {
+        panic!("expected SOA rdata on output");
+    };
 
-    assert_eq!(soa_out_rd.mname().to_string(), "map.fastly.net.");
-    assert_eq!(soa_out_rd.rname().to_string(), "fastly.net.");
-    assert_eq!(soa_out_rd.serial(), 1);
-    assert_eq!(soa_out_rd.refresh(), 7200);
-    assert_eq!(soa_out_rd.retry(), 3600);
-    assert_eq!(soa_out_rd.expire(), 1209600);
-    assert_eq!(soa_out_rd.minimum(), 1800);
+    assert_eq!(soa_out_rd.mname.to_string(), "map.fastly.net.");
+    assert_eq!(soa_out_rd.rname.to_string(), "fastly.net.");
+    assert_eq!(soa_out_rd.serial, 1);
+    assert_eq!(soa_out_rd.refresh, 7200);
+    assert_eq!(soa_out_rd.retry, 3600);
+    assert_eq!(soa_out_rd.expire, 1209600);
+    assert_eq!(soa_out_rd.minimum, 1800);
 }


### PR DESCRIPTION
## Summary

Today's advisory drop hit `hickory-proto 0.25.2`:

- **RUSTSEC-2026-0119** — O(n²) name compression → CPU exhaustion. **Fixed by bumping to `hickory-proto >=0.26.1`.**
- **RUSTSEC-2026-0118** — NSEC3 closest-encloser proof unbounded loop on cross-zone responses. **No fixed upgrade available.** Ignored via `.cargo/audit.toml` with a comment + upstream tracker link.

Both trip `cargo audit`, which made every CI run on every branch red. hickory is `[dev-dependencies]` only — the shipped numa binary doesn't link it — so user-facing impact is zero, but CI is load-bearing for PR review.

## What changed

- `Cargo.toml` / `Cargo.lock`: hickory-resolver / hickory-proto `0.25` → `0.26`.
- `.cargo/audit.toml` (new): ignore-list policy = "only advisories with no upstream fix available." Currently lists just RUSTSEC-2026-0118.
- `tests/soa_compression_bug.rs`: API migration — `Message::name_servers()` → `.authorities`, `Record::data()` → `.data`, `RData::SOA::into_soa()` removed (let-else pattern match), SOA fields now public (`mname`/`rname`/`serial`/etc.).
- `benches/recursive_compare.rs`: API migration — `NameServerConfig` non-exhaustive, use `ConnectionConfig::https` builder; `NameServerConfigGroup` removed (use `Vec<NameServerConfig>`); `Lookup::iter()` → `.answers().iter()`; build now returns `Result`.

## Test plan

- [x] `cargo audit` exits 0 (RUSTSEC-2026-0119 gone, only the unfixable -0118 remains and is ignored)
- [x] `make all` green (lint + build + 380 unit tests + 1 integration test + audit)
- [x] `cargo build --benches` green
- [ ] CI green on this branch (will run on push)

## Notes

- This unblocks #166 (Windows DNS install/uninstall corruption) and any other open PRs.
- The two pre-existing audit *warnings* (`rustls-pemfile` unmaintained, `rand` unsound) are not in scope here — they don't fail the audit, and addressing them is a separate dep-bump cycle.