### PR TITLE
fix: --version + banner show full build version (with SHA suffix)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn main() -> numa::Result<()> {
             };
         }
         "version" | "--version" | "-V" => {
-            eprintln!("numa {}", env!("CARGO_PKG_VERSION"));
+            eprintln!("numa {}", numa::version());
             return Ok(());
         }
         "help" | "--help" | "-h" => {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -405,7 +405,13 @@ fn print_banner(
     let data_label = ctx.data_dir.display().to_string();
     let services_label = ctx.config_dir.join("services.json").display().to_string();
 
-    // label (10) + value + padding (2) = inner width; minimum 40 for the title row
+    let tag_line = "DNS that governs itself";
+    let v = crate::version();
+    let title_plain = format!("NUMA  {tag_line}  v{v}");
+
+    // label (10) + value + padding (2) = inner width; widen further if the
+    // title row (variable-length once the version carries a +SHA suffix)
+    // would overflow.
     let val_w = [
         config.server.bind_addr.len(),
         api_url.len(),
@@ -418,7 +424,7 @@ fn print_banner(
     .chain(proxy_label.as_ref().map(|s| s.len()))
     .max()
     .unwrap_or(30);
-    let w = (val_w + 12).max(42);
+    let w = (val_w + 12).max(42).max(1 + title_plain.chars().count());
 
     let o = "\x1b[38;2;192;98;58m";
     let g = "\x1b[38;2;107;124;78m";
@@ -438,11 +444,8 @@ fn print_banner(
         );
     };
 
-    let tag_line = "DNS that governs itself";
-    let v = crate::version();
     let title = format!("{b}NUMA{r}  {it}{tag_line}{r}  {d}v{v}{r}");
-    let title_plain = format!("NUMA  {tag_line}  v{v}");
-    let title_pad = w.saturating_sub(1 + title_plain.chars().count());
+    let title_pad = w - 1 - title_plain.chars().count();
     eprintln!("\n{o}  ╔{bar_top}╗{r}");
     eprint!("{o}  ║{r} {title}");
     eprintln!("{}{o}║{r}", " ".repeat(title_pad));

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -439,12 +439,10 @@ fn print_banner(
     };
 
     let tag_line = "DNS that governs itself";
-    let title = format!(
-        "{b}NUMA{r}  {it}{tag_line}{r}  {d}v{}{r}",
-        env!("CARGO_PKG_VERSION")
-    );
-    let title_visible_len = 4 + 2 + tag_line.len() + 2 + 1 + env!("CARGO_PKG_VERSION").len() + 1;
-    let title_pad = w.saturating_sub(title_visible_len);
+    let v = crate::version();
+    let title = format!("{b}NUMA{r}  {it}{tag_line}{r}  {d}v{v}{r}");
+    let title_plain = format!("NUMA  {tag_line}  v{v}");
+    let title_pad = w.saturating_sub(1 + title_plain.chars().count());
     eprintln!("\n{o}  ╔{bar_top}╗{r}");
     eprint!("{o}  ║{r} {title}");
     eprintln!("{}{o}║{r}", " ".repeat(title_pad));


### PR DESCRIPTION
## Summary

`numa --version` and the startup banner read `env!(\"CARGO_PKG_VERSION\")` directly, so they showed `0.14.3` while `/health`, `/stats`, and the dashboard showed `0.14.3+92686b9` (via `crate::version()` → `NUMA_BUILD_VERSION` from `build.rs`'s git describe). All four surfaces now route through `crate::version()`, so the git-describe suffix (`+SHA`, `+SHA-dirty`) renders consistently regardless of where the version is read.

While in there, the banner's padding math:

```rust
// before
let title_visible_len = 4 + 2 + tag_line.len() + 2 + 1 + v.len() + 1;
let title_pad = w.saturating_sub(title_visible_len);
```

was six magic integers that silently drifted out of sync with the `format!` template if anyone tweaked spacing, and `tag_line.len()` was byte-length (latent footgun if the tag line ever takes a non-ASCII char). Replaced with a parallel plain-text title that stays in lockstep by construction:

```rust
// after
let title = format!(\"{b}NUMA{r}  {it}{tag_line}{r}  {d}v{v}{r}\");
let title_plain = format!(\"NUMA  {tag_line}  v{v}\");
let title_pad = w.saturating_sub(1 + title_plain.chars().count());
```

The only remaining magic constant is `1` for the leading space inside the box, which is structural.

## Test plan

- [x] `make all` green (lint + 380 unit tests)
- [x] `./target/debug/numa --version` → `numa 0.14.3+92686b9-dirty` (was `numa 0.14.3`)
- [ ] Visual: confirm startup banner padding still aligns with the `+SHA` suffix