### PR TITLE
fix(windows): split IPv4/IPv6 on uninstall restore (#182)

### DIFF
--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -637,6 +637,115 @@ fn backup_has_real_upstream_windows(
         .any(|iface| iface.servers.iter().any(|s| !is_loopback_or_stub(s)))
 }
 
+#[cfg(any(windows, test))]
+#[derive(Debug, PartialEq, Eq)]
+enum SkipReason {
+    AdapterNotPresent,
+}
+
+#[cfg(any(windows, test))]
+#[derive(Debug, PartialEq, Eq)]
+enum ConfigKind {
+    Static {
+        primary: String,
+        secondaries: Vec<String>,
+    },
+    Dhcp,
+}
+
+#[cfg(any(windows, test))]
+#[derive(Debug, PartialEq, Eq)]
+enum RestoreAction {
+    Configure {
+        name: String,
+        if_index: u32,
+        family: AddressFamily,
+        kind: ConfigKind,
+    },
+    Skip {
+        name: String,
+        reason: SkipReason,
+    },
+}
+
+#[cfg(any(windows, test))]
+fn plan_windows_restore(
+    backup: &std::collections::HashMap<String, WindowsInterfaceDns>,
+    live: &std::collections::HashMap<String, WindowsInterfaceDns>,
+) -> Vec<RestoreAction> {
+    let mut actions = Vec::new();
+    let mut names: Vec<&String> = backup.keys().collect();
+    names.sort();
+    for name in names {
+        let dns = &backup[name];
+        let Some(live_iface) = live.get(name) else {
+            actions.push(RestoreAction::Skip {
+                name: name.clone(),
+                reason: SkipReason::AdapterNotPresent,
+            });
+            continue;
+        };
+        let if_index = live_iface.if_index;
+
+        let (v4, v6): (Vec<String>, Vec<String>) = dns
+            .servers
+            .iter()
+            .filter(|s| !is_loopback_or_stub(s))
+            .cloned()
+            .partition(|s| s.parse::<std::net::Ipv4Addr>().is_ok());
+
+        actions.push(configure(name, if_index, AddressFamily::V4, v4));
+        actions.push(configure(name, if_index, AddressFamily::V6, v6));
+    }
+    actions
+}
+
+#[cfg(any(windows, test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AddressFamily {
+    V4,
+    V6,
+}
+
+#[cfg(windows)]
+impl AddressFamily {
+    fn netsh_arg(self) -> &'static str {
+        match self {
+            AddressFamily::V4 => "ipv4",
+            AddressFamily::V6 => "ipv6",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            AddressFamily::V4 => "IPv4",
+            AddressFamily::V6 => "IPv6",
+        }
+    }
+}
+
+#[cfg(any(windows, test))]
+fn configure(
+    name: &str,
+    if_index: u32,
+    family: AddressFamily,
+    servers: Vec<String>,
+) -> RestoreAction {
+    let kind = match servers.split_first() {
+        None => ConfigKind::Dhcp,
+        Some((primary, rest)) => ConfigKind::Static {
+            primary: primary.clone(),
+            secondaries: rest.to_vec(),
+        },
+    };
+    RestoreAction::Configure {
+        name: name.to_string(),
+        if_index,
+        family,
+        kind,
+    }
+}
+
 /// Capture pre-numa DNS state for `uninstall` to restore. Returns `Ok(true)`
 /// when a fresh backup was written; `Ok(false)` when an existing useful
 /// backup was preserved (re-install on numa-managed state).
@@ -769,10 +878,10 @@ pub fn redirect_dns_to_localhost() -> Result<(), String> {
 }
 
 #[cfg(windows)]
-fn run_netsh_ipv4(args: &[&str]) -> std::io::Result<std::process::ExitStatus> {
+fn run_netsh(family: AddressFamily, args: &[&str]) -> std::io::Result<std::process::ExitStatus> {
     std::process::Command::new("netsh")
         .arg("interface")
-        .arg("ipv4")
+        .arg(family.netsh_arg())
         .args(args)
         .status()
 }
@@ -783,8 +892,11 @@ fn redirect_dns_with_interfaces(
 ) -> Result<(), String> {
     for (name, iface) in interfaces {
         let idx = iface.if_index.to_string();
-        let status = run_netsh_ipv4(&["set", "dnsservers", &idx, "static", "127.0.0.1", "primary"])
-            .map_err(|e| format!("failed to set DNS for {}: {}", name, e))?;
+        let status = run_netsh(
+            AddressFamily::V4,
+            &["set", "dnsservers", &idx, "static", "127.0.0.1", "primary"],
+        )
+        .map_err(|e| format!("failed to set DNS for {}: {}", name, e))?;
 
         if status.success() {
             eprintln!("  set DNS for \"{}\" -> 127.0.0.1", name);
@@ -796,6 +908,131 @@ fn redirect_dns_with_interfaces(
         }
     }
     Ok(())
+}
+
+#[cfg(windows)]
+fn apply_restore_action(action: &RestoreAction) -> Result<String, String> {
+    match action {
+        RestoreAction::Configure {
+            name,
+            if_index,
+            family,
+            kind:
+                ConfigKind::Static {
+                    primary,
+                    secondaries,
+                },
+        } => apply_static(*family, name, *if_index, primary, secondaries),
+        RestoreAction::Configure {
+            name,
+            if_index,
+            family,
+            kind: ConfigKind::Dhcp,
+        } => apply_dhcp(*family, name, *if_index),
+        RestoreAction::Skip {
+            name,
+            reason: SkipReason::AdapterNotPresent,
+        } => Err(format!("adapter \"{}\" not currently up; skipped", name)),
+    }
+}
+
+#[cfg(windows)]
+fn apply_static(
+    family: AddressFamily,
+    name: &str,
+    if_index: u32,
+    primary: &str,
+    secondaries: &[String],
+) -> Result<String, String> {
+    let idx = if_index.to_string();
+    // validate=no — we trust the backup; validation issues an outbound DNS
+    // probe that fails on UDP-restricted networks (#147) and aborts the set.
+    let status = run_netsh(
+        family,
+        &[
+            "set",
+            "dnsservers",
+            &idx,
+            "static",
+            primary,
+            "primary",
+            "validate=no",
+        ],
+    )
+    .map_err(|e| {
+        format!(
+            "failed to set {} DNS for \"{}\": {}",
+            family.label(),
+            name,
+            e
+        )
+    })?;
+    if !status.success() {
+        return Err(format!(
+            "netsh failed to set {} primary {} for \"{}\"",
+            family.label(),
+            primary,
+            name
+        ));
+    }
+
+    for (i, server) in secondaries.iter().enumerate() {
+        let idx_arg = format!("index={}", i + 2);
+        let status = run_netsh(
+            family,
+            &["add", "dnsservers", &idx, server, &idx_arg, "validate=no"],
+        )
+        .map_err(|e| {
+            format!(
+                "failed to add {} DNS for \"{}\": {}",
+                family.label(),
+                name,
+                e
+            )
+        })?;
+        if !status.success() {
+            return Err(format!(
+                "netsh failed to add {} {} for \"{}\"",
+                family.label(),
+                server,
+                name
+            ));
+        }
+    }
+
+    let mut all = vec![primary.to_string()];
+    all.extend_from_slice(secondaries);
+    Ok(format!(
+        "restored {} DNS for \"{}\" -> {}",
+        family.label(),
+        name,
+        all.join(", ")
+    ))
+}
+
+#[cfg(windows)]
+fn apply_dhcp(family: AddressFamily, name: &str, if_index: u32) -> Result<String, String> {
+    let idx = if_index.to_string();
+    let status = run_netsh(family, &["set", "dnsservers", &idx, "dhcp"]).map_err(|e| {
+        format!(
+            "failed to reset {} DNS for \"{}\": {}",
+            family.label(),
+            name,
+            e
+        )
+    })?;
+    if !status.success() {
+        return Err(format!(
+            "netsh failed to reset {} DNS for \"{}\"",
+            family.label(),
+            name
+        ));
+    }
+    Ok(format!(
+        "reset {} DNS for \"{}\" -> DHCP",
+        family.label(),
+        name
+    ))
 }
 
 /// Copy the currently-running binary to the service install location. SCM
@@ -997,62 +1234,16 @@ fn uninstall_windows() -> Result<(), String> {
         serde_json::from_str(&json).map_err(|e| format!("invalid backup file: {}", e))?;
 
     let live = get_windows_interfaces()?;
-    let mut skipped: Vec<&str> = Vec::new();
+    let plan = plan_windows_restore(&original, &live);
+    let mut skipped: Vec<String> = Vec::new();
 
-    for (name, dns_info) in &original {
-        let Some(idx) = live.get(name).map(|i| i.if_index.to_string()) else {
-            eprintln!("  warning: adapter \"{}\" not currently up; skipped", name);
-            skipped.push(name.as_str());
-            continue;
-        };
-
-        let real_servers: Vec<&str> = dns_info
-            .servers
-            .iter()
-            .map(String::as_str)
-            .filter(|s| !is_loopback_or_stub(s))
-            .collect();
-
-        if real_servers.is_empty() {
-            let status = run_netsh_ipv4(&["set", "dnsservers", &idx, "dhcp"])
-                .map_err(|e| format!("failed to restore DNS for {}: {}", name, e))?;
-
-            if status.success() {
-                eprintln!("  restored DNS for \"{}\" -> DHCP", name);
-            } else {
-                eprintln!("  warning: failed to restore DNS for \"{}\"", name);
-            }
-        } else {
-            let status = run_netsh_ipv4(&[
-                "set",
-                "dnsservers",
-                &idx,
-                "static",
-                real_servers[0],
-                "primary",
-            ])
-            .map_err(|e| format!("failed to restore DNS for {}: {}", name, e))?;
-
-            if !status.success() {
-                eprintln!("  warning: failed to restore primary DNS for \"{}\"", name);
-                continue;
-            }
-
-            for (i, server) in real_servers.iter().skip(1).enumerate() {
-                let _ = run_netsh_ipv4(&[
-                    "add",
-                    "dnsservers",
-                    &idx,
-                    server,
-                    &format!("index={}", i + 2),
-                ]);
-            }
-
-            eprintln!(
-                "  restored DNS for \"{}\" -> {}",
-                name,
-                real_servers.join(", ")
-            );
+    for action in &plan {
+        match apply_restore_action(action) {
+            Ok(msg) => eprintln!("  {}", msg),
+            Err(e) => eprintln!("  warning: {}", e),
+        }
+        if let RestoreAction::Skip { name, .. } = action {
+            skipped.push(name.clone());
         }
     }
 
@@ -2347,6 +2538,153 @@ mod tests {
             },
         );
         assert!(backup_has_real_upstream_windows(&map));
+    }
+
+    fn iface(if_index: u32, servers: &[&str]) -> WindowsInterfaceDns {
+        WindowsInterfaceDns {
+            if_index,
+            servers: servers.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    fn static_action(
+        name: &str,
+        if_index: u32,
+        family: AddressFamily,
+        primary: &str,
+        secondaries: &[&str],
+    ) -> RestoreAction {
+        RestoreAction::Configure {
+            name: name.into(),
+            if_index,
+            family,
+            kind: ConfigKind::Static {
+                primary: primary.into(),
+                secondaries: secondaries.iter().map(|s| (*s).to_string()).collect(),
+            },
+        }
+    }
+
+    fn dhcp_action(name: &str, if_index: u32, family: AddressFamily) -> RestoreAction {
+        RestoreAction::Configure {
+            name: name.into(),
+            if_index,
+            family,
+            kind: ConfigKind::Dhcp,
+        }
+    }
+
+    #[test]
+    fn plan_restore_splits_v4_and_v6_families() {
+        let mut backup = std::collections::HashMap::new();
+        backup.insert(
+            "Ethernet".into(),
+            iface(
+                0,
+                &[
+                    "8.8.8.8",
+                    "1.1.1.1",
+                    "2001:4860:4860::8888",
+                    "2606:4700:4700::1111",
+                ],
+            ),
+        );
+        let mut live = std::collections::HashMap::new();
+        live.insert("Ethernet".into(), iface(12, &[]));
+
+        assert_eq!(
+            plan_windows_restore(&backup, &live),
+            vec![
+                static_action("Ethernet", 12, AddressFamily::V4, "8.8.8.8", &["1.1.1.1"]),
+                static_action(
+                    "Ethernet",
+                    12,
+                    AddressFamily::V6,
+                    "2001:4860:4860::8888",
+                    &["2606:4700:4700::1111"],
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_restore_empty_backup_resets_both_families_to_dhcp() {
+        let mut backup = std::collections::HashMap::new();
+        backup.insert("Tailscale".into(), iface(0, &[]));
+        let mut live = std::collections::HashMap::new();
+        live.insert("Tailscale".into(), iface(7, &[]));
+
+        assert_eq!(
+            plan_windows_restore(&backup, &live),
+            vec![
+                dhcp_action("Tailscale", 7, AddressFamily::V4),
+                dhcp_action("Tailscale", 7, AddressFamily::V6),
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_restore_v4_only_backup_dhcps_v6() {
+        let mut backup = std::collections::HashMap::new();
+        backup.insert("Ethernet".into(), iface(0, &["192.168.1.1"]));
+        let mut live = std::collections::HashMap::new();
+        live.insert("Ethernet".into(), iface(12, &[]));
+
+        assert_eq!(
+            plan_windows_restore(&backup, &live),
+            vec![
+                static_action("Ethernet", 12, AddressFamily::V4, "192.168.1.1", &[]),
+                dhcp_action("Ethernet", 12, AddressFamily::V6),
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_restore_skips_adapter_not_present() {
+        let mut backup = std::collections::HashMap::new();
+        backup.insert("Tailscale".into(), iface(0, &["100.100.100.100"]));
+        let live = std::collections::HashMap::new();
+
+        assert_eq!(
+            plan_windows_restore(&backup, &live),
+            vec![RestoreAction::Skip {
+                name: "Tailscale".into(),
+                reason: SkipReason::AdapterNotPresent,
+            }]
+        );
+    }
+
+    #[test]
+    fn plan_restore_filters_loopback_and_stub_addresses() {
+        let mut backup = std::collections::HashMap::new();
+        backup.insert(
+            "Ethernet".into(),
+            iface(
+                0,
+                &[
+                    "127.0.0.1",
+                    "8.8.8.8",
+                    "fec0:0:0:ffff::1",
+                    "2001:4860:4860::8888",
+                ],
+            ),
+        );
+        let mut live = std::collections::HashMap::new();
+        live.insert("Ethernet".into(), iface(12, &[]));
+
+        assert_eq!(
+            plan_windows_restore(&backup, &live),
+            vec![
+                static_action("Ethernet", 12, AddressFamily::V4, "8.8.8.8", &[]),
+                static_action(
+                    "Ethernet",
+                    12,
+                    AddressFamily::V6,
+                    "2001:4860:4860::8888",
+                    &[]
+                ),
+            ]
+        );
     }
 
     #[test]

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -638,69 +638,6 @@ fn backup_has_real_upstream_windows(
 }
 
 #[cfg(any(windows, test))]
-#[derive(Debug, PartialEq, Eq)]
-enum SkipReason {
-    AdapterNotPresent,
-}
-
-#[cfg(any(windows, test))]
-#[derive(Debug, PartialEq, Eq)]
-enum ConfigKind {
-    Static {
-        primary: String,
-        secondaries: Vec<String>,
-    },
-    Dhcp,
-}
-
-#[cfg(any(windows, test))]
-#[derive(Debug, PartialEq, Eq)]
-enum RestoreAction {
-    Configure {
-        name: String,
-        if_index: u32,
-        family: AddressFamily,
-        kind: ConfigKind,
-    },
-    Skip {
-        name: String,
-        reason: SkipReason,
-    },
-}
-
-#[cfg(any(windows, test))]
-fn plan_windows_restore(
-    backup: &std::collections::HashMap<String, WindowsInterfaceDns>,
-    live: &std::collections::HashMap<String, WindowsInterfaceDns>,
-) -> Vec<RestoreAction> {
-    let mut actions = Vec::new();
-    let mut names: Vec<&String> = backup.keys().collect();
-    names.sort();
-    for name in names {
-        let dns = &backup[name];
-        let Some(live_iface) = live.get(name) else {
-            actions.push(RestoreAction::Skip {
-                name: name.clone(),
-                reason: SkipReason::AdapterNotPresent,
-            });
-            continue;
-        };
-        let if_index = live_iface.if_index;
-
-        let (v4, v6): (Vec<String>, Vec<String>) = dns
-            .servers
-            .iter()
-            .filter(|s| !is_loopback_or_stub(s))
-            .cloned()
-            .partition(|s| s.parse::<std::net::Ipv4Addr>().is_ok());
-
-        actions.push(configure(name, if_index, AddressFamily::V4, v4));
-        actions.push(configure(name, if_index, AddressFamily::V6, v6));
-    }
-    actions
-}
-
-#[cfg(any(windows, test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AddressFamily {
     V4,
@@ -725,25 +662,50 @@ impl AddressFamily {
 }
 
 #[cfg(any(windows, test))]
-fn configure(
-    name: &str,
+#[derive(Debug, PartialEq, Eq)]
+struct RestorePlan {
+    name: String,
     if_index: u32,
     family: AddressFamily,
+    // Empty list means "reset this family to DHCP" — see apply_restore.
     servers: Vec<String>,
-) -> RestoreAction {
-    let kind = match servers.split_first() {
-        None => ConfigKind::Dhcp,
-        Some((primary, rest)) => ConfigKind::Static {
-            primary: primary.clone(),
-            secondaries: rest.to_vec(),
-        },
-    };
-    RestoreAction::Configure {
-        name: name.to_string(),
-        if_index,
-        family,
-        kind,
+}
+
+#[cfg(any(windows, test))]
+fn plan_windows_restore(
+    backup: &std::collections::HashMap<String, WindowsInterfaceDns>,
+    live: &std::collections::HashMap<String, WindowsInterfaceDns>,
+) -> (Vec<RestorePlan>, Vec<String>) {
+    let mut plans = Vec::new();
+    let mut missing = Vec::new();
+    let mut names: Vec<&String> = backup.keys().collect();
+    names.sort();
+    for name in names {
+        let Some(live_iface) = live.get(name) else {
+            missing.push(name.clone());
+            continue;
+        };
+        let if_index = live_iface.if_index;
+        let (v4, v6): (Vec<String>, Vec<String>) = backup[name]
+            .servers
+            .iter()
+            .filter(|s| !is_loopback_or_stub(s))
+            .cloned()
+            .partition(|s| s.parse::<std::net::Ipv4Addr>().is_ok());
+        plans.push(RestorePlan {
+            name: name.clone(),
+            if_index,
+            family: AddressFamily::V4,
+            servers: v4,
+        });
+        plans.push(RestorePlan {
+            name: name.clone(),
+            if_index,
+            family: AddressFamily::V6,
+            servers: v6,
+        });
     }
+    (plans, missing)
 }
 
 /// Capture pre-numa DNS state for `uninstall` to restore. Returns `Ok(true)`
@@ -911,28 +873,12 @@ fn redirect_dns_with_interfaces(
 }
 
 #[cfg(windows)]
-fn apply_restore_action(action: &RestoreAction) -> Result<String, String> {
-    match action {
-        RestoreAction::Configure {
-            name,
-            if_index,
-            family,
-            kind:
-                ConfigKind::Static {
-                    primary,
-                    secondaries,
-                },
-        } => apply_static(*family, name, *if_index, primary, secondaries),
-        RestoreAction::Configure {
-            name,
-            if_index,
-            family,
-            kind: ConfigKind::Dhcp,
-        } => apply_dhcp(*family, name, *if_index),
-        RestoreAction::Skip {
-            name,
-            reason: SkipReason::AdapterNotPresent,
-        } => Err(format!("adapter \"{}\" not currently up; skipped", name)),
+fn apply_restore(plan: &RestorePlan) -> Result<String, String> {
+    match plan.servers.split_first() {
+        Some((primary, rest)) => {
+            apply_static(plan.family, &plan.name, plan.if_index, primary, rest)
+        }
+        None => apply_dhcp(plan.family, &plan.name, plan.if_index),
     }
 }
 
@@ -1234,16 +1180,15 @@ fn uninstall_windows() -> Result<(), String> {
         serde_json::from_str(&json).map_err(|e| format!("invalid backup file: {}", e))?;
 
     let live = get_windows_interfaces()?;
-    let plan = plan_windows_restore(&original, &live);
-    let mut skipped: Vec<String> = Vec::new();
+    let (plan, skipped) = plan_windows_restore(&original, &live);
 
+    for name in &skipped {
+        eprintln!("  warning: adapter \"{}\" not currently up; skipped", name);
+    }
     for action in &plan {
-        match apply_restore_action(action) {
+        match apply_restore(action) {
             Ok(msg) => eprintln!("  {}", msg),
             Err(e) => eprintln!("  warning: {}", e),
-        }
-        if let RestoreAction::Skip { name, .. } = action {
-            skipped.push(name.clone());
         }
     }
 
@@ -2547,30 +2492,12 @@ mod tests {
         }
     }
 
-    fn static_action(
-        name: &str,
-        if_index: u32,
-        family: AddressFamily,
-        primary: &str,
-        secondaries: &[&str],
-    ) -> RestoreAction {
-        RestoreAction::Configure {
+    fn plan(name: &str, if_index: u32, family: AddressFamily, servers: &[&str]) -> RestorePlan {
+        RestorePlan {
             name: name.into(),
             if_index,
             family,
-            kind: ConfigKind::Static {
-                primary: primary.into(),
-                secondaries: secondaries.iter().map(|s| (*s).to_string()).collect(),
-            },
-        }
-    }
-
-    fn dhcp_action(name: &str, if_index: u32, family: AddressFamily) -> RestoreAction {
-        RestoreAction::Configure {
-            name: name.into(),
-            if_index,
-            family,
-            kind: ConfigKind::Dhcp,
+            servers: servers.iter().map(|s| (*s).to_string()).collect(),
         }
     }
 
@@ -2594,63 +2521,30 @@ mod tests {
 
         assert_eq!(
             plan_windows_restore(&backup, &live),
-            vec![
-                static_action("Ethernet", 12, AddressFamily::V4, "8.8.8.8", &["1.1.1.1"]),
-                static_action(
-                    "Ethernet",
-                    12,
-                    AddressFamily::V6,
-                    "2001:4860:4860::8888",
-                    &["2606:4700:4700::1111"],
-                ),
-            ]
+            (
+                vec![
+                    plan("Ethernet", 12, AddressFamily::V4, &["8.8.8.8", "1.1.1.1"]),
+                    plan(
+                        "Ethernet",
+                        12,
+                        AddressFamily::V6,
+                        &["2001:4860:4860::8888", "2606:4700:4700::1111"],
+                    ),
+                ],
+                vec![],
+            ),
         );
     }
 
     #[test]
-    fn plan_restore_empty_backup_resets_both_families_to_dhcp() {
-        let mut backup = std::collections::HashMap::new();
-        backup.insert("Tailscale".into(), iface(0, &[]));
-        let mut live = std::collections::HashMap::new();
-        live.insert("Tailscale".into(), iface(7, &[]));
-
-        assert_eq!(
-            plan_windows_restore(&backup, &live),
-            vec![
-                dhcp_action("Tailscale", 7, AddressFamily::V4),
-                dhcp_action("Tailscale", 7, AddressFamily::V6),
-            ]
-        );
-    }
-
-    #[test]
-    fn plan_restore_v4_only_backup_dhcps_v6() {
-        let mut backup = std::collections::HashMap::new();
-        backup.insert("Ethernet".into(), iface(0, &["192.168.1.1"]));
-        let mut live = std::collections::HashMap::new();
-        live.insert("Ethernet".into(), iface(12, &[]));
-
-        assert_eq!(
-            plan_windows_restore(&backup, &live),
-            vec![
-                static_action("Ethernet", 12, AddressFamily::V4, "192.168.1.1", &[]),
-                dhcp_action("Ethernet", 12, AddressFamily::V6),
-            ]
-        );
-    }
-
-    #[test]
-    fn plan_restore_skips_adapter_not_present() {
+    fn plan_restore_returns_missing_adapter_names() {
         let mut backup = std::collections::HashMap::new();
         backup.insert("Tailscale".into(), iface(0, &["100.100.100.100"]));
         let live = std::collections::HashMap::new();
 
         assert_eq!(
             plan_windows_restore(&backup, &live),
-            vec![RestoreAction::Skip {
-                name: "Tailscale".into(),
-                reason: SkipReason::AdapterNotPresent,
-            }]
+            (vec![], vec!["Tailscale".into()]),
         );
     }
 
@@ -2674,16 +2568,13 @@ mod tests {
 
         assert_eq!(
             plan_windows_restore(&backup, &live),
-            vec![
-                static_action("Ethernet", 12, AddressFamily::V4, "8.8.8.8", &[]),
-                static_action(
-                    "Ethernet",
-                    12,
-                    AddressFamily::V6,
-                    "2001:4860:4860::8888",
-                    &[]
-                ),
-            ]
+            (
+                vec![
+                    plan("Ethernet", 12, AddressFamily::V4, &["8.8.8.8"]),
+                    plan("Ethernet", 12, AddressFamily::V6, &["2001:4860:4860::8888"]),
+                ],
+                vec![],
+            ),
         );
     }
 

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -667,7 +667,6 @@ struct RestorePlan {
     name: String,
     if_index: u32,
     family: AddressFamily,
-    // Empty list means "reset this family to DHCP" — see apply_restore.
     servers: Vec<String>,
 }
 
@@ -686,17 +685,16 @@ fn plan_windows_restore(
             continue;
         };
         let if_index = live_iface.if_index;
+        let servers = &backup[name].servers;
         // v6 emission gates on the *unfiltered* backup having any v6 entries —
         // even the fec0:0:0:ffff::1/2/3 stubs count, since they're returned
         // only when v6 is enabled on the adapter. No v6 entries at all
         // means v6 was disabled, and `netsh interface ipv6 set ... dhcp`
         // would error on disabled adapters.
-        let v6_was_enabled = backup[name]
-            .servers
+        let v6_was_enabled = servers
             .iter()
             .any(|s| s.parse::<std::net::Ipv6Addr>().is_ok());
-        let (v4, v6): (Vec<String>, Vec<String>) = backup[name]
-            .servers
+        let (v4, v6): (Vec<String>, Vec<String>) = servers
             .iter()
             .filter(|s| !is_loopback_or_stub(s))
             .cloned()
@@ -957,13 +955,15 @@ fn apply_static(
         }
     }
 
-    let mut all = vec![primary.to_string()];
-    all.extend_from_slice(secondaries);
+    let all = std::iter::once(primary)
+        .chain(secondaries.iter().map(String::as_str))
+        .collect::<Vec<_>>()
+        .join(", ");
     Ok(format!(
         "restored {} DNS for \"{}\" -> {}",
         family.label(),
         name,
-        all.join(", ")
+        all
     ))
 }
 

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -686,6 +686,15 @@ fn plan_windows_restore(
             continue;
         };
         let if_index = live_iface.if_index;
+        // v6 emission gates on the *unfiltered* backup having any v6 entries —
+        // even the fec0:0:0:ffff::1/2/3 stubs count, since they're returned
+        // only when v6 is enabled on the adapter. No v6 entries at all
+        // means v6 was disabled, and `netsh interface ipv6 set ... dhcp`
+        // would error on disabled adapters.
+        let v6_was_enabled = backup[name]
+            .servers
+            .iter()
+            .any(|s| s.parse::<std::net::Ipv6Addr>().is_ok());
         let (v4, v6): (Vec<String>, Vec<String>) = backup[name]
             .servers
             .iter()
@@ -698,12 +707,14 @@ fn plan_windows_restore(
             family: AddressFamily::V4,
             servers: v4,
         });
-        plans.push(RestorePlan {
-            name: name.clone(),
-            if_index,
-            family: AddressFamily::V6,
-            servers: v6,
-        });
+        if v6_was_enabled {
+            plans.push(RestorePlan {
+                name: name.clone(),
+                if_index,
+                family: AddressFamily::V6,
+                servers: v6,
+            });
+        }
     }
     (plans, missing)
 }
@@ -1185,25 +1196,36 @@ fn uninstall_windows() -> Result<(), String> {
     for name in &skipped {
         eprintln!("  warning: adapter \"{}\" not currently up; skipped", name);
     }
+    let mut apply_failed = false;
     for action in &plan {
         match apply_restore(action) {
             Ok(msg) => eprintln!("  {}", msg),
-            Err(e) => eprintln!("  warning: {}", e),
+            Err(e) => {
+                eprintln!("  warning: {}", e);
+                apply_failed = true;
+            }
         }
     }
 
-    // Keep the backup if any adapter wasn't reachable — an offline
-    // uninstall would otherwise leave the registry pinned at 127.0.0.1
-    // with no recovery state for when the network returns.
+    // Keep the backup if anything went wrong — adapter offline (re-runnable
+    // after reconnect) or netsh non-zero exit (re-runnable after manual
+    // diagnosis). Removing it would leave the registry pinned at 127.0.0.1
+    // with no recovery state.
     enable_dnscache();
-    if skipped.is_empty() {
+    if skipped.is_empty() && !apply_failed {
         std::fs::remove_file(&path).ok();
         eprintln!("\n  System DNS restored. DNS Client re-enabled.");
-    } else {
+    } else if !skipped.is_empty() {
         eprintln!(
             "\n  Partial restore. Backup kept at {} — re-run 'numa uninstall' after reconnecting: {}",
             path.display(),
             skipped.join(", ")
+        );
+        eprintln!("  DNS Client re-enabled.");
+    } else {
+        eprintln!(
+            "\n  Partial restore. Backup kept at {} — check the warnings above and re-run 'numa uninstall'.",
+            path.display()
         );
         eprintln!("  DNS Client re-enabled.");
     }
@@ -2545,6 +2567,44 @@ mod tests {
         assert_eq!(
             plan_windows_restore(&backup, &live),
             (vec![], vec!["Tailscale".into()]),
+        );
+    }
+
+    #[test]
+    fn plan_restore_skips_v6_when_disabled_in_backup() {
+        let mut backup = std::collections::HashMap::new();
+        backup.insert("Ethernet".into(), iface(0, &["192.168.1.1"]));
+        let mut live = std::collections::HashMap::new();
+        live.insert("Ethernet".into(), iface(12, &[]));
+
+        assert_eq!(
+            plan_windows_restore(&backup, &live),
+            (
+                vec![plan("Ethernet", 12, AddressFamily::V4, &["192.168.1.1"])],
+                vec![],
+            ),
+        );
+    }
+
+    #[test]
+    fn plan_restore_emits_v6_dhcp_when_only_v6_stubs_in_backup() {
+        let mut backup = std::collections::HashMap::new();
+        backup.insert(
+            "Ethernet".into(),
+            iface(0, &["192.168.1.1", "fec0:0:0:ffff::1"]),
+        );
+        let mut live = std::collections::HashMap::new();
+        live.insert("Ethernet".into(), iface(12, &[]));
+
+        assert_eq!(
+            plan_windows_restore(&backup, &live),
+            (
+                vec![
+                    plan("Ethernet", 12, AddressFamily::V4, &["192.168.1.1"]),
+                    plan("Ethernet", 12, AddressFamily::V6, &[]),
+                ],
+                vec![],
+            ),
         );
     }
 


### PR DESCRIPTION
## Summary

- Restore IPv4 and IPv6 DNS independently on `numa uninstall` — fixes #182 where HighPolygon's `original-dns.json` had four servers but only one came back.
- Extract pure `plan_windows_restore(backup, live)` planner that emits a `Configure { family, kind }` action per (adapter, family), so v4 and v6 dispatch to `netsh interface ipv4` / `ipv6` separately.
- Add `validate=no` to all netsh `set/add dnsservers` calls so secondary entries don't drop on UDP-restricted networks.
- Stop silently discarding `add dnsservers` exit codes — surface a `warning:` line.

Bugs visible in #182's data:
- IPv6 entries from the backup got fed into `netsh interface ipv4` and silently failed.
- Secondary IPv4 (`1.1.1.1` in HighPolygon's case) dropped when validate-by-probe failed — likely interaction with Win11 DoH-aware single-server mode after the primary set.
- Empty IPv6 backup left v6 stuck on numa-managed state instead of resetting to DHCP.

## Test plan

- [x] 5 new unit tests in `system_dns::tests::plan_restore_*` covering: family split, empty backup → DHCP both, v4-only, adapter-not-present, loopback/stub filter
- [x] `make all` (fmt + check + audit + test) passes locally — 395 lib tests + 1 integration test
- [ ] CI `check-windows` job verifies Windows compile (cross-compile from macOS blocked by aws-lc-sys C deps, so windows-only branches confirmed by CI on push)
- [ ] Manual: install/uninstall round-trip on Windows with mixed v4+v6 DNS adapter — verify all entries restored
- [ ] Manual: install/uninstall on UDP-restricted network — verify secondary entries don't drop

## Not in this PR

- `--no-system-dns` flag (HighPolygon's feature ask) — separate, smaller PR
- GUID-stable adapter matching (handles "Ethernet" → "Ethernet 2" rename across reboots) — separate, needs install-side backup-format change