### PR TITLE
feat(install): --no-system-dns flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@ use numa::system_dns::{
     uninstall_service,
 };
 
+const NO_SYSTEM_DNS_FLAG: &str = "--no-system-dns";
+
 fn main() -> numa::Result<()> {
     // Handle CLI subcommands
     let arg1 = std::env::args().nth(1).unwrap_or_default();
@@ -29,10 +31,12 @@ fn main() -> numa::Result<()> {
         .format_timestamp_millis()
         .init();
 
+    let skip_system_dns = std::env::args().any(|a| a == NO_SYSTEM_DNS_FLAG);
+
     match arg1.as_str() {
         "install" => {
             eprintln!("\x1b[1;38;2;192;98;58mNuma\x1b[0m — installing\n");
-            return install_service().map_err(|e| e.into());
+            return install_service(skip_system_dns).map_err(|e| e.into());
         }
         "uninstall" => {
             eprintln!("\x1b[1;38;2;192;98;58mNuma\x1b[0m — uninstalling\n");
@@ -42,7 +46,7 @@ fn main() -> numa::Result<()> {
             let sub = std::env::args().nth(2).unwrap_or_default();
             eprintln!("\x1b[1;38;2;192;98;58mNuma\x1b[0m — service management\n");
             return match sub.as_str() {
-                "start" => start_service().map_err(|e| e.into()),
+                "start" => start_service(skip_system_dns).map_err(|e| e.into()),
                 "stop" => stop_service().map_err(|e| e.into()),
                 "restart" => restart_service().map_err(|e| e.into()),
                 "status" => service_status().map_err(|e| e.into()),
@@ -110,8 +114,16 @@ fn main() -> numa::Result<()> {
             eprintln!("Commands:");
             eprintln!("  (none)          Start the DNS server (default)");
             eprintln!("  install         Set system DNS to 127.0.0.1 (requires sudo)");
+            eprintln!(
+                "                  {}  Install service only; leave system DNS alone",
+                NO_SYSTEM_DNS_FLAG
+            );
             eprintln!("  uninstall       Restore original system DNS settings");
             eprintln!("  service start   Install as system service (auto-start on boot)");
+            eprintln!(
+                "                  {}  Same as 'install {}'",
+                NO_SYSTEM_DNS_FLAG, NO_SYSTEM_DNS_FLAG
+            );
             eprintln!("  service stop    Uninstall the system service");
             eprintln!("  service restart Restart the service with updated binary");
             eprintln!("  service status  Check if the service is running");

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -637,14 +637,14 @@ fn backup_has_real_upstream_windows(
         .any(|iface| iface.servers.iter().any(|s| !is_loopback_or_stub(s)))
 }
 
+/// Capture pre-numa DNS state for `uninstall` to restore. Returns `Ok(true)`
+/// when a fresh backup was written; `Ok(false)` when an existing useful
+/// backup was preserved (re-install on numa-managed state).
 #[cfg(windows)]
-fn install_windows() -> Result<(), String> {
-    let mut interfaces = get_windows_interfaces()?;
-    if interfaces.is_empty() {
-        return Err("no active network interfaces found".to_string());
-    }
-
-    let path = windows_backup_path();
+fn write_windows_backup(
+    path: &std::path::Path,
+    interfaces: &mut std::collections::HashMap<String, WindowsInterfaceDns>,
+) -> Result<bool, String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("failed to create {}: {}", parent.display(), e))?;
@@ -653,7 +653,7 @@ fn install_windows() -> Result<(), String> {
     // Preserve an existing useful backup rather than overwriting it with
     // numa-managed state (which would be self-referential after uninstall).
     let existing: Option<std::collections::HashMap<String, WindowsInterfaceDns>> =
-        std::fs::read_to_string(&path)
+        std::fs::read_to_string(path)
             .ok()
             .and_then(|json| serde_json::from_str(&json).ok());
     let has_useful_existing = existing
@@ -663,16 +663,33 @@ fn install_windows() -> Result<(), String> {
 
     if has_useful_existing {
         eprintln!("  Existing DNS backup preserved at {}", path.display());
-    } else {
-        // Filter loopback/stub addresses before saving so a fresh backup
-        // captured from already-numa-managed state isn't self-referential.
-        for iface in interfaces.values_mut() {
-            iface.servers.retain(|s| !is_loopback_or_stub(s));
-        }
-        let json = serde_json::to_string_pretty(&interfaces)
-            .map_err(|e| format!("failed to serialize backup: {}", e))?;
-        std::fs::write(&path, json).map_err(|e| format!("failed to write backup: {}", e))?;
+        return Ok(false);
     }
+
+    // Filter loopback/stub addresses before saving so a fresh backup
+    // captured from already-numa-managed state isn't self-referential.
+    for iface in interfaces.values_mut() {
+        iface.servers.retain(|s| !is_loopback_or_stub(s));
+    }
+    let json = serde_json::to_string_pretty(&interfaces)
+        .map_err(|e| format!("failed to serialize backup: {}", e))?;
+    std::fs::write(path, json).map_err(|e| format!("failed to write backup: {}", e))?;
+    Ok(true)
+}
+
+#[cfg(windows)]
+fn install_windows(skip_system_dns: bool) -> Result<(), String> {
+    let mut interfaces = get_windows_interfaces()?;
+    if interfaces.is_empty() {
+        return Err("no active network interfaces found".to_string());
+    }
+
+    let path = windows_backup_path();
+    let wrote_fresh_backup = if skip_system_dns {
+        false
+    } else {
+        write_windows_backup(&path, &mut interfaces)?
+    };
 
     // On re-install, stop the running service first so the binary can be
     // overwritten and port 53 is released for the Dnscache probe.
@@ -694,7 +711,9 @@ fn install_windows() -> Result<(), String> {
         // would kill DNS. The service will call redirect_dns_to_localhost()
         // on its first startup after reboot.
     } else {
-        redirect_dns_with_interfaces(&interfaces)?;
+        if !skip_system_dns {
+            redirect_dns_with_interfaces(&interfaces)?;
+        }
 
         match start_service_scm() {
             Ok(_) => eprintln!("  Service started."),
@@ -706,7 +725,9 @@ fn install_windows() -> Result<(), String> {
     }
 
     eprintln!();
-    if !has_useful_existing {
+    if skip_system_dns {
+        eprintln!("{}", SKIP_DNS_NOTICE);
+    } else if wrote_fresh_backup {
         eprintln!("  Original DNS saved to {}", path.display());
     }
     eprintln!("  Run 'numa uninstall' to restore.\n");
@@ -953,8 +974,25 @@ fn uninstall_windows() -> Result<(), String> {
     delete_service_scm();
     remove_service_binary();
     let path = windows_backup_path();
-    let json = std::fs::read_to_string(&path)
-        .map_err(|e| format!("no backup found at {}: {}", path.display(), e))?;
+    let json = match std::fs::read_to_string(&path) {
+        Ok(j) => j,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Install was --no-system-dns (or backup never written): there
+            // is nothing to restore. Still re-enable Dnscache so the host
+            // is back to a stock configuration.
+            enable_dnscache();
+            eprintln!("  No system DNS backup found — system DNS was not managed by numa.");
+            eprintln!("  DNS Client re-enabled. Reboot to fully restore the DNS Client service.\n");
+            return Ok(());
+        }
+        Err(e) => {
+            return Err(format!(
+                "failed to read backup at {}: {}",
+                path.display(),
+                e
+            ))
+        }
+    };
     let original: std::collections::HashMap<String, WindowsInterfaceDns> =
         serde_json::from_str(&json).map_err(|e| format!("invalid backup file: {}", e))?;
 
@@ -1191,8 +1229,20 @@ fn uninstall_macos() -> Result<(), String> {
     use std::collections::HashMap;
 
     let path = backup_path();
-    let json = std::fs::read_to_string(&path)
-        .map_err(|e| format!("no backup found at {}: {}", path.display(), e))?;
+    let json = match std::fs::read_to_string(&path) {
+        Ok(j) => j,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("  No system DNS backup found — system DNS was not managed by numa.\n");
+            return Ok(());
+        }
+        Err(e) => {
+            return Err(format!(
+                "failed to read backup at {}: {}",
+                path.display(),
+                e
+            ))
+        }
+    };
 
     let original: HashMap<String, Vec<String>> =
         serde_json::from_str(&json).map_err(|e| format!("invalid backup file: {}", e))?;
@@ -1244,16 +1294,27 @@ const PLIST_DEST: &str = "/Library/LaunchDaemons/com.numa.dns.plist";
 #[cfg(target_os = "linux")]
 const SYSTEMD_UNIT: &str = "/etc/systemd/system/numa.service";
 
+const SKIP_DNS_NOTICE: &str =
+    "  --no-system-dns: system DNS unchanged. Point clients at 127.0.0.1 yourself.";
+
 /// Install Numa as a system service that starts on boot and auto-restarts.
-pub fn install_service() -> Result<(), String> {
+///
+/// `skip_system_dns = true` registers the service but leaves the host's DNS
+/// configuration untouched (no backup written, no `127.0.0.1` redirect). The
+/// operator is responsible for routing traffic to numa themselves — front-end
+/// proxy, browser DoH, etc.
+pub fn install_service(skip_system_dns: bool) -> Result<(), String> {
     #[cfg(target_os = "macos")]
-    let result = install_service_macos();
+    let result = install_service_macos(skip_system_dns);
     #[cfg(target_os = "linux")]
-    let result = install_service_linux();
+    let result = install_service_linux(skip_system_dns);
     #[cfg(windows)]
-    let result = install_windows();
+    let result = install_windows(skip_system_dns);
     #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
-    let result = Err::<(), String>("service installation not supported on this OS".to_string());
+    let result = {
+        let _ = skip_system_dns;
+        Err::<(), String>("service installation not supported on this OS".to_string())
+    };
 
     if result.is_ok() {
         if let Err(e) = trust_ca() {
@@ -1266,27 +1327,29 @@ pub fn install_service() -> Result<(), String> {
 
 /// Start the service. If already installed, just starts it via the platform
 /// service manager. If not installed, falls through to a full install.
-pub fn start_service() -> Result<(), String> {
+pub fn start_service(skip_system_dns: bool) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        install_service()
+        install_service(skip_system_dns)
     }
     #[cfg(target_os = "linux")]
     {
-        install_service()
+        install_service(skip_system_dns)
     }
     #[cfg(windows)]
     {
         if is_service_registered() {
+            let _ = skip_system_dns;
             start_service_scm()?;
             eprintln!("  Service started.\n");
             Ok(())
         } else {
-            install_service()
+            install_service(skip_system_dns)
         }
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
     {
+        let _ = skip_system_dns;
         Err("service start not supported on this OS".to_string())
     }
 }
@@ -1430,7 +1493,7 @@ fn replace_exe_path(service: &str) -> Result<String, String> {
 }
 
 #[cfg(target_os = "macos")]
-fn install_service_macos() -> Result<(), String> {
+fn install_service_macos(skip_system_dns: bool) -> Result<(), String> {
     // Create log directory
     std::fs::create_dir_all("/usr/local/var/log")
         .map_err(|e| format!("failed to create log dir: {}", e))?;
@@ -1478,7 +1541,9 @@ fn install_service_macos() -> Result<(), String> {
         );
     }
 
-    if let Err(e) = install_macos() {
+    if skip_system_dns {
+        eprintln!("{}", SKIP_DNS_NOTICE);
+    } else if let Err(e) = install_macos() {
         eprintln!("  warning: failed to configure system DNS: {}", e);
     }
 
@@ -1739,7 +1804,7 @@ fn install_service_binary_linux() -> Result<std::path::PathBuf, String> {
 }
 
 #[cfg(target_os = "linux")]
-fn install_service_linux() -> Result<(), String> {
+fn install_service_linux(skip_system_dns: bool) -> Result<(), String> {
     let exe = install_service_binary_linux()?;
     let unit = include_str!("../numa.service").replace("{{exe_path}}", &exe.to_string_lossy());
     std::fs::write(SYSTEMD_UNIT, unit)
@@ -1749,7 +1814,9 @@ fn install_service_linux() -> Result<(), String> {
     run_systemctl(&["enable", "numa"])?;
 
     // Configure system DNS before starting numa so resolved releases port 53 first
-    if let Err(e) = install_linux() {
+    if skip_system_dns {
+        eprintln!("{}", SKIP_DNS_NOTICE);
+    } else if let Err(e) = install_linux() {
         eprintln!("  warning: failed to configure system DNS: {}", e);
     }
 

--- a/tests/docker/install-no-system-dns.sh
+++ b/tests/docker/install-no-system-dns.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+#
+# Cross-distro verification of `numa install --no-system-dns`.
+#
+# Asserts on each distro: install registers + activates the systemd unit
+# but leaves /etc/resolv.conf and /etc/systemd/resolved.conf.d/numa.conf
+# untouched, and uninstall handles the missing backup file as a no-op
+# (returns 0, does not error with "no backup found").
+#
+# Each distro runs in its own privileged systemd-as-PID-1 container,
+# builds numa from /src, then runs the scenario. First run is slow per
+# distro (~3-6 min for image pull + apt/dnf/pacman + cold cargo build);
+# subsequent runs reuse cached cargo + target volumes (~30s per distro).
+#
+# Requirements: docker
+# Usage:        ./tests/docker/install-no-system-dns.sh
+#               DISTROS=ubuntu:24.04 ./tests/docker/install-no-system-dns.sh   # subset
+
+set -u
+set -o pipefail
+
+GREEN="\033[32m"; RED="\033[31m"; DIM="\033[90m"; RESET="\033[0m"
+
+# archlinux:latest is x86_64-only and fails to build under Rosetta/qemu
+# emulation on Apple Silicon (pacman 7 sandbox + emulation interaction).
+# Opt in explicitly when running on amd64 hosts: DISTROS="... archlinux:latest"
+DISTROS_DEFAULT=(
+    "ubuntu:24.04"
+    "debian:bookworm"
+    "fedora:latest"
+)
+read -ra DISTROS <<<"${DISTROS:-${DISTROS_DEFAULT[*]}}"
+
+# ============================================================
+# Mode B: running inside a distro container
+# ============================================================
+if [ "${NUMA_INSIDE:-}" = "1" ]; then
+    set +e
+    NUMA=/work/target/release/numa
+    FAIL=0
+
+    pass() { printf "  ${GREEN}PASS${RESET}: %s\n" "$*"; }
+    fail() { printf "  ${RED}FAIL${RESET}: %s\n" "$*"; FAIL=1; }
+
+    wait_active() {
+        local n=0
+        while [ $n -lt 20 ]; do
+            systemctl is-active --quiet numa && return 0
+            sleep 0.5
+            n=$((n + 1))
+        done
+        return 1
+    }
+
+    # Capture pre-install state of system DNS knobs we expect to leave alone.
+    snapshot_before() {
+        cp -a /etc/resolv.conf /tmp/resolv.before 2>/dev/null || touch /tmp/resolv.before
+        ls -la /etc/systemd/resolved.conf.d/ 2>/dev/null > /tmp/resolved-d.before || true
+    }
+
+    assert_resolv_unchanged() {
+        if diff -q /tmp/resolv.before /etc/resolv.conf >/dev/null 2>&1; then
+            pass "/etc/resolv.conf unchanged"
+        else
+            fail "/etc/resolv.conf was modified"
+            diff /tmp/resolv.before /etc/resolv.conf | head -10 || true
+        fi
+    }
+
+    assert_no_resolved_dropin() {
+        if [ ! -f /etc/systemd/resolved.conf.d/numa.conf ]; then
+            pass "no /etc/systemd/resolved.conf.d/numa.conf written"
+        else
+            fail "drop-in /etc/systemd/resolved.conf.d/numa.conf exists"
+        fi
+    }
+
+    assert_unit_registered() {
+        if [ -f /etc/systemd/system/numa.service ]; then
+            pass "/etc/systemd/system/numa.service installed"
+        else
+            fail "unit file missing"
+        fi
+    }
+
+    printf "\n=== Scenario: install --no-system-dns leaves system DNS alone ===\n"
+    snapshot_before
+    "$NUMA" install --no-system-dns >/tmp/install.log 2>&1
+    rc=$?
+    if [ $rc -ne 0 ]; then
+        fail "install --no-system-dns exited $rc"
+        tail -20 /tmp/install.log
+    else
+        pass "install --no-system-dns exited 0"
+    fi
+    wait_active && pass "service is active" || fail "service did not become active"
+    assert_unit_registered
+    assert_resolv_unchanged
+    assert_no_resolved_dropin
+    if grep -q "no-system-dns" /tmp/install.log; then
+        pass "install output mentions --no-system-dns notice"
+    else
+        fail "install output missing --no-system-dns notice"
+    fi
+
+    printf "\n=== Scenario: uninstall is a no-op when no backup exists ===\n"
+    "$NUMA" uninstall >/tmp/uninstall.log 2>&1
+    rc=$?
+    if [ $rc -eq 0 ]; then
+        pass "uninstall exited 0 (graceful no-op)"
+    else
+        fail "uninstall exited $rc (regression)"
+        tail -10 /tmp/uninstall.log
+    fi
+    if systemctl is-active --quiet numa; then
+        fail "service still active after uninstall"
+    else
+        pass "service stopped"
+    fi
+
+    if [ "$FAIL" -eq 0 ]; then
+        printf "\n${GREEN}── all checks passed ──${RESET}\n"
+        exit 0
+    else
+        printf "\n${RED}── checks failed ──${RESET}\n"
+        exit 1
+    fi
+fi
+
+# ============================================================
+# Mode A: host-side bootstrap, one container per distro
+# ============================================================
+set -e
+cd "$(dirname "$0")/../.."
+SRC=$PWD
+
+# Build the per-distro systemd image. Tag is `numa-no-system-dns-<distro>:local`.
+# Sets the global IMAGE_TAG so callers can read it without re-deriving.
+build_image() {
+    local distro="$1"
+    IMAGE_TAG="numa-no-system-dns-${distro//[:.\/]/-}:local"
+
+    local dockerfile
+    case "$distro" in
+        ubuntu:*|debian:*)
+            dockerfile=$(cat <<DOCKERFILE
+FROM $distro
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq && apt-get install -y -qq \
+      systemd systemd-sysv ca-certificates curl build-essential \
+      pkg-config libssl-dev cmake make perl iproute2 \
+    && rm -rf /var/lib/apt/lists/* \
+    && for u in dev-hugepages.mount sys-fs-fuse-connections.mount \
+                systemd-logind.service getty.target console-getty.service; do \
+         systemctl mask \$u; \
+       done
+STOPSIGNAL SIGRTMIN+3
+CMD ["/lib/systemd/systemd"]
+DOCKERFILE
+)
+            ;;
+        archlinux:*)
+            # pacman 7+ sandboxes syscalls; disable for cross-arch emulation.
+            dockerfile=$(cat <<DOCKERFILE
+FROM $distro
+RUN sed -i 's/^#DisableSandboxSyscalls/DisableSandboxSyscalls/' /etc/pacman.conf \
+    && pacman -Sy --noconfirm --needed \
+         systemd ca-certificates curl base-devel \
+         pkgconf openssl cmake make perl iproute2 \
+    && for u in dev-hugepages.mount sys-fs-fuse-connections.mount \
+                systemd-logind.service getty.target console-getty.service; do \
+         systemctl mask \$u; \
+       done
+STOPSIGNAL SIGRTMIN+3
+CMD ["/usr/lib/systemd/systemd"]
+DOCKERFILE
+)
+            ;;
+        fedora:*)
+            dockerfile=$(cat <<DOCKERFILE
+FROM $distro
+RUN dnf install -q -y \
+      systemd ca-certificates curl gcc gcc-c++ \
+      pkgconfig openssl-devel cmake make perl-core iproute \
+    && dnf clean all \
+    && for u in dev-hugepages.mount sys-fs-fuse-connections.mount \
+                systemd-logind.service getty.target console-getty.service; do \
+         systemctl mask \$u; \
+       done
+STOPSIGNAL SIGRTMIN+3
+CMD ["/usr/lib/systemd/systemd"]
+DOCKERFILE
+)
+            ;;
+        *)
+            echo "unsupported distro: $distro" >&2
+            return 1
+            ;;
+    esac
+    docker build "${@:2}" -t "$IMAGE_TAG" -f - . <<<"$dockerfile" 2>&1 | tail -5
+    docker image inspect "$IMAGE_TAG" >/dev/null 2>&1
+}
+
+run_distro() {
+    local distro="$1"
+    local container="numa-no-system-dns-${distro//[:.\/]/-}-$$"
+    local cargo_vol="numa-no-system-dns-cargo-${distro//[:.\/]/-}"
+    local work_vol="numa-no-system-dns-work-${distro//[:.\/]/-}"
+    local rc
+
+    # archlinux only publishes x86_64 — force amd64 for both build and run.
+    # Other distros use the host's native arch (arm64 on Apple Silicon),
+    # which avoids slow QEMU emulation for the cargo build.
+    local platform=()
+    case "$distro" in
+        archlinux:*) platform=(--platform linux/amd64) ;;
+    esac
+
+    printf "\n${DIM}── %s: building image ──${RESET}\n" "$distro"
+    if ! build_image "$distro" "${platform[@]+"${platform[@]}"}"; then
+        echo "image build failed for $distro" >&2
+        return 1
+    fi
+
+    docker rm -f "$container" >/dev/null 2>&1 || true
+    printf "${DIM}── %s: starting systemd container (%s) ──${RESET}\n" "$distro" "$IMAGE_TAG"
+    docker run -d --name "$container" \
+        "${platform[@]+"${platform[@]}"}" \
+        --privileged --cgroupns=host \
+        --tmpfs /run --tmpfs /run/lock --tmpfs /tmp:exec \
+        -v "$SRC:/src:ro" \
+        -v "$cargo_vol:/root/.cargo" \
+        -v "$work_vol:/work" \
+        "$IMAGE_TAG" >/dev/null
+
+    # Wait for systemd to be up
+    for _ in $(seq 1 30); do
+        state=$(docker exec "$container" systemctl is-system-running 2>&1 || true)
+        case "$state" in running|degraded) break ;; esac
+        sleep 0.5
+    done
+
+    printf "${DIM}── %s: copying source + cargo build --release (cached) ──${RESET}\n" "$distro"
+    docker exec "$container" bash -c '
+set -e
+mkdir -p /work
+tar -C /src --exclude=./target --exclude=./.git --exclude=./.claude -cf - . | tar -C /work -xf -
+if ! command -v cargo &>/dev/null; then
+    curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --quiet
+fi
+. "$HOME/.cargo/env"
+cd /work
+cargo build --release --locked 2>&1 | tail -3
+'
+
+    printf "${DIM}── %s: running scenario ──${RESET}\n" "$distro"
+    docker exec -e NUMA_INSIDE=1 "$container" bash /src/tests/docker/install-no-system-dns.sh
+    rc=$?
+
+    docker rm -f "$container" >/dev/null 2>&1 || true
+    return $rc
+}
+
+declare -a PASSED=()
+declare -a FAILED=()
+set +e
+for distro in "${DISTROS[@]}"; do
+    printf "\n${GREEN}══════ %s ══════${RESET}\n" "$distro"
+    if run_distro "$distro"; then
+        PASSED+=("$distro")
+    else
+        FAILED+=("$distro")
+    fi
+done
+
+printf "\n══════ summary ══════\n"
+for d in "${PASSED[@]+"${PASSED[@]}"}"; do printf "  ${GREEN}✓${RESET} %s\n" "$d"; done
+for d in "${FAILED[@]+"${FAILED[@]}"}"; do printf "  ${RED}✗${RESET} %s\n" "$d"; done
+[ ${#FAILED[@]} -eq 0 ]


### PR DESCRIPTION
## Summary

- Adds `numa install --no-system-dns` (and `numa service start --no-system-dns`) to register the system service without touching the host's DNS configuration. No backup written, no redirect to 127.0.0.1.
- Closes the deferred follow-up #5 from PR #183. Honors HighPolygon's explicit ask in #182: their setup uses Tailscale + Radmin VPN adapters whose MagicDNS / VPN-internal name resolution breaks when numa rewrites adapter DNS to 127.0.0.1.
- Operator routes traffic to numa themselves (front-end proxy, browser DoH, etc.) — out of scope for this PR.
- Uninstall on Windows + macOS now treats a missing backup as "system DNS was not numa-managed; nothing to restore" — a no-op log line instead of the previous hard error. Linux already did this; brings macOS/Windows to parity.

## Per-platform behavior

| Platform | With `--no-system-dns` |
|---|---|
| Windows | skip backup write + `redirect_dns_with_interfaces`; `disable_dnscache` still runs (port 53 still claimed). |
| macOS   | skip `install_macos` (the `networksetup -setdnsservers` loop). |
| Linux   | skip `install_linux` (resolv.conf rewrite or systemd-resolved drop-in). |

## Validation

`tests/docker/install-no-system-dns.sh` — privileged systemd-as-PID-1 container per distro, builds numa, asserts install registers the service but leaves `/etc/resolv.conf` and `/etc/systemd/resolved.conf.d/numa.conf` untouched, and uninstall is a graceful no-op when no backup exists.

| Platform          | Method                       | Install path | New no-backup uninstall path |
|-------------------|------------------------------|--------------|------------------------------|
| `ubuntu:24.04`    | docker harness, 8/8 checks   | ✓            | ✓                            |
| `debian:bookworm` | docker harness, 8/8 checks   | ✓            | ✓                            |
| `fedora:latest`   | docker harness, 8/8 checks   | ✓            | ✓                            |
| `archlinux:latest`| skipped (env)¹               | —            | —                            |
| Windows 11        | manual on @HighPolygon's box² | ✓            | ✓                            |
| macOS             | manual round-trip on dev box | ✓            | ✓                            |

¹ pacman 7 sandbox interaction breaks under Rosetta/qemu on Apple Silicon. Same `install_service_linux` code path as the others; opt-in via `DISTROS=...archlinux:latest` on amd64 hosts.

² Mixed-adapter setup (Wi-Fi + Ethernet + Tailscale + manual Quad9 NIC). Full transcript in PR comments. Also incidentally confirmed PR #183's family-split fix — both v4 entries restored on each adapter.

## Out of scope

- Documentation for *how* operators should route traffic to numa when this flag is set — that's situational (Tailscale, dnscrypt-proxy front-end, browser DoH, kube CoreDNS forwarder, etc.) and belongs in a guide, not the README.
- The other two #183 deferred items (#3 partial-restore rollback, #4 GUID-stable adapter matching).

## Test plan

- [x] `make all` clean (lint + 398 unit tests + 1 cargo integration test)
- [x] `numa help` lists the new flag under both `install` and `service start`
- [x] /simplify pass (3 reviewers): redundant `wrote_fresh_backup` dropped, repeated literals lifted to `NO_SYSTEM_DNS_FLAG` + `SKIP_DNS_NOTICE` consts, `write_windows_backup` helper extracted to flatten nesting
- [x] Linux docker harness: ubuntu/debian/fedora all 8/8 (install + uninstall scenarios)
- [x] Manual Windows: end-to-end on HighPolygon's real machine — 4-step round-trip green, all branches exercised including the new no-backup uninstall
- [x] Manual macOS: end-to-end round-trip on dev box (1.1.1.1/8.8.8.8 Wi-Fi backup) — all 4 steps green; new no-backup branch printed `No system DNS backup found — system DNS was not managed by numa.` and exited 0; daily-driver state restored after the test