### PR TITLE
fix(macos): write /etc/resolver/numa for VPN-resilient .numa resolution

### DIFF
--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -1215,6 +1215,11 @@ fn install_macos() -> Result<(), String> {
             .status();
     }
 
+    // Anchor `.numa` resolution to numa via /etc/resolver — survives
+    // VPN/MagicDNS clients (Tailscale, WireGuard) that install themselves
+    // as the unscoped resolver and would otherwise NXDOMAIN our TLD.
+    write_resolver_dropin();
+
     eprintln!();
     if !has_useful_existing {
         eprintln!("  Original DNS saved to {}", backup_path().display());
@@ -1224,9 +1229,59 @@ fn install_macos() -> Result<(), String> {
     Ok(())
 }
 
+/// `/etc/resolver/<tld>` tells macOS: for queries under `.<tld>`, ALWAYS
+/// use this nameserver, regardless of the global resolver chain. Without
+/// it, a VPN that registers itself as the unscoped resolver intercepts
+/// `.numa` lookups and returns NXDOMAIN.
+#[cfg(target_os = "macos")]
+fn write_resolver_dropin() {
+    let path = std::path::Path::new(MACOS_RESOLVER_DROPIN);
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!("  warning: failed to create {}: {}", parent.display(), e);
+            return;
+        }
+    }
+    if let Err(e) = std::fs::write(path, "nameserver 127.0.0.1\n") {
+        eprintln!("  warning: failed to write {}: {}", path.display(), e);
+        return;
+    }
+    // Force mDNSResponder to re-read /etc/resolver/* immediately. Without
+    // a flush, the new file is picked up only after FSEvents propagation
+    // (seconds) or until the negative cache for `.numa` lookups expires.
+    let _ = std::process::Command::new("killall")
+        .args(["-HUP", "mDNSResponder"])
+        .status();
+    eprintln!("  Anchored .numa resolution at {}", path.display());
+}
+
+#[cfg(target_os = "macos")]
+fn remove_resolver_dropin() {
+    let path = std::path::Path::new(MACOS_RESOLVER_DROPIN);
+    match std::fs::remove_file(path) {
+        Ok(_) => {
+            let _ = std::process::Command::new("killall")
+                .args(["-HUP", "mDNSResponder"])
+                .status();
+            eprintln!("  Removed {}", path.display());
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => eprintln!("  warning: failed to remove {}: {}", path.display(), e),
+    }
+}
+
+#[cfg(target_os = "macos")]
+const MACOS_RESOLVER_DROPIN: &str = "/etc/resolver/numa";
+
 #[cfg(target_os = "macos")]
 fn uninstall_macos() -> Result<(), String> {
     use std::collections::HashMap;
+
+    // /etc/resolver/numa is written by every regular install (and not by
+    // --no-system-dns), so always attempt removal regardless of whether a
+    // backup exists. remove_resolver_dropin is a no-op when the file is
+    // already gone.
+    remove_resolver_dropin();
 
     let path = backup_path();
     let json = match std::fs::read_to_string(&path) {


### PR DESCRIPTION
## Summary

- macOS install now writes `/etc/resolver/numa` (`nameserver 127.0.0.1`) and HUPs mDNSResponder, anchoring `.numa` TLD resolution to the local numa instance regardless of what owns the global resolver chain.
- macOS uninstall removes the dropin alongside the existing networksetup restore — including the no-backup branch from #184.
- Closes a real-world breakage: when Tailscale's MagicDNS (or any VPN's NetworkExtension) installs itself as the unscoped resolver #1, it intercepts `.numa` lookups, returns NXDOMAIN, and macOS caches the negative. The numa CA, proxy, and local zone all work — but `curl https://numa.numa` and Chrome both fail through the system resolver while `dig @127.0.0.1` succeeds.

## Why search domains alone weren't enough

The existing `networksetup -setsearchdomains ... numa` call only handles unqualified-name suffixing (`numa` → `numa.numa`). It does not influence which resolver an FQDN lookup is routed to. Per-interface DNS settings (also via `networksetup`) lose to a NetworkExtension-managed unscoped resolver. `/etc/resolver/<tld>` sits above both — it's the documented macOS escape hatch for TLD-scoped routing, and what acrylic-dns / dnsmasq / similar tools use.

## Validation

Manual round-trip on the dev box (Tailscale as resolver #1, numa as resolver #2):

| Step | Result |
|---|---|
| Pre-fix: `dig @127.0.0.1 numa.numa` | ✓ 127.0.0.1 (numa knows) |
| Pre-fix: `curl https://numa.numa` | ✗ Could not resolve host (Tailscale intercepts, NXDOMAIN) |
| Post-fix install: dropin written, mDNSResponder HUPed | ✓ output mentions "Anchored .numa resolution at /etc/resolver/numa" |
| Post-fix: `dscacheutil -q host -a name numa.numa` | ✓ 127.0.0.1 |
| Post-fix: `curl https://numa.numa` | ✓ |

## Out of scope

- Linux equivalent. Linux's TLD-routing options are systemd-resolved drop-ins (per-domain routing) or split-DNS via dnsmasq — different mechanisms, separate change. The same Tailscale-overrides-numa failure mode exists in principle on Linux but hasn't been reported.
- Configurable TLD. The dropin path is hardcoded to `numa` matching the existing hardcoded `setsearchdomains ... numa` call. If/when `proxy.tld` becomes truly user-configurable end-to-end, both should derive from the same source.
- Custom-`/etc/resolver/numa`-already-present detection. We unconditionally overwrite. The content is a single fixed line; any pre-existing file we'd care about preserving is unlikely.

## Test plan

- [x] `make all` clean (lint + 398 unit tests + 1 cargo integration test)
- [x] Manual dev-box round-trip: pre-fix `curl https://numa.numa` failed via system resolver despite numa serving it correctly; post-fix it works
- [ ] Manual: clean macOS box without Tailscale — confirm new install path is no-op-when-not-needed (should be — file is written but harmless, mDNSResponder picks up the same answer it'd otherwise reach via the resolver chain)
- [x] Manual: uninstall + reinstall round-trip — confirm dropin is removed cleanly and re-written