### PR TITLE
fix(macos): service status uses system-domain target

### DIFF
--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -1288,7 +1288,7 @@ fn uninstall_macos() -> Result<(), String> {
 // --- Service management ---
 
 #[cfg(target_os = "macos")]
-const PLIST_LABEL: &str = "com.numa.dns";
+const PLIST_SYSTEM_TARGET: &str = "system/com.numa.dns";
 #[cfg(target_os = "macos")]
 const PLIST_DEST: &str = "/Library/LaunchDaemons/com.numa.dns.plist";
 #[cfg(target_os = "linux")]
@@ -1426,7 +1426,7 @@ pub fn restart_service() -> Result<(), String> {
     {
         let exe_path = exe_path.to_string_lossy();
         let output = std::process::Command::new("launchctl")
-            .args(["list", PLIST_LABEL])
+            .args(["print", PLIST_SYSTEM_TARGET])
             .output();
         match output {
             Ok(o) if o.status.success() => {
@@ -1590,8 +1590,10 @@ fn uninstall_service_macos() -> Result<(), String> {
 
 #[cfg(target_os = "macos")]
 fn service_status_macos() -> Result<(), String> {
+    // `list <label>` only searches the caller's bootstrap domain (gui/<uid>);
+    // our daemon is bootstrapped into `system`, so target it explicitly.
     let output = std::process::Command::new("launchctl")
-        .args(["list", PLIST_LABEL])
+        .args(["print", PLIST_SYSTEM_TARGET])
         .output()
         .map_err(|e| format!("failed to run launchctl: {}", e))?;
 


### PR DESCRIPTION
## Summary

- `numa service install` reports success and `dig @127.0.0.1` works, but `numa service status` falsely reports "Numa service is not installed" — confusing for anyone diagnosing whether install actually took.
- Root cause: install bootstraps the daemon into the `system` domain (PR #42), but `service_status_macos` and the restart-path readiness probe still call `launchctl list <label>`, which only searches the caller's bootstrap domain (= `gui/<uid>` for a normal user shell) and cannot see system-domain daemons.
- Fix: switch both call sites to `launchctl print system/com.numa.dns`. Targets the system domain explicitly, works without sudo for read-only inspection, and the output is more useful (path, state, pid, env) than the legacy `list` format.

## Test plan

- [x] `make all` (lint + 398 tests) green
- [x] Manual: with daemon installed, `numa service status` (no sudo) now reports "Numa service is loaded" and prints daemon record
- [x] Manual: `sudo numa uninstall` followed by `numa service status` correctly reports "Numa service is not installed"
- [x] Reviewer: confirm restart path still works (`sudo numa service restart` after `cargo build`)