### PR TITLE
fix(cache): restore question + rd/ra on cache-hit responses (#188)

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -365,6 +365,9 @@ async fn resolve_remote(
         }
         let mut resp = cached;
         resp.header.id = query.header.id;
+        resp.header.recursion_desired = query.header.recursion_desired;
+        resp.header.recursion_available = true;
+        resp.questions = query.questions.clone();
         if cached_dnssec == DnssecStatus::Secure {
             resp.header.authed_data = true;
         }
@@ -1667,5 +1670,35 @@ mod tests {
             DnsRecord::A { addr, .. } => assert_eq!(*addr, Ipv4Addr::new(10, 0, 0, 7)),
             other => panic!("expected A record, got {:?}", other),
         }
+    }
+
+    /// #188: cache entries synthesized internally (e.g. NS delegation snapshots)
+    /// have no question section and no rd/ra flags. The cache-hit serve path
+    /// must restore these from the client query before returning to the wire.
+    #[tokio::test]
+    async fn cache_hit_restores_question_and_rd_ra_from_client_query() {
+        let mut malformed = DnsPacket::new();
+        malformed.header.response = true;
+        malformed.header.rescode = ResultCode::NOERROR;
+        malformed.answers.push(DnsRecord::NS {
+            domain: "ikea.com".into(),
+            host: "udns1.cscdns.net".into(),
+            ttl: 86400,
+        });
+
+        let ctx = Arc::new(crate::testutil::test_ctx().await);
+        ctx.cache
+            .write()
+            .unwrap()
+            .insert("ikea.com", QueryType::NS, &malformed);
+
+        let (resp, path) = resolve_in_test(&ctx, "ikea.com", QueryType::NS).await;
+
+        assert_eq!(path, QueryPath::Cached);
+        assert_eq!(resp.questions.len(), 1);
+        assert_eq!(resp.questions[0].name, "ikea.com");
+        assert_eq!(resp.questions[0].qtype, QueryType::NS);
+        assert!(resp.header.recursion_desired);
+        assert!(resp.header.recursion_available);
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #188 (the malformed-NS half): clients querying a delegated zone via Numa's recursive mode (e.g. `dig ikea.com NS @numa`) saw a response with `QUERY: 0` and no `rd`/`ra` flags.
- Root cause: `cache_ns_delegation` (`src/recursive.rs:570`) inserts a synthesized packet — no questions, no rd/ra — to store delegation NS records keyed by zone. The cache-hit branch in `resolve_remote` only patched the ID before returning, so the synthetic shape leaked to the wire.
- Fix: in the cache-hit branch, also restore `recursion_desired` / `recursion_available` / `questions` from the client query, mirroring `resolve_recursive`'s existing post-processing for fresh recursive responses.


## Test plan

- [x] New regression test `cache_hit_restores_question_and_rd_ra_from_client_query` drives a synthetic malformed NS entry through the full `resolve_query` pipeline (via `resolve_in_test`), asserts `path == Cached`, and verifies the served packet has the question echoed and rd/ra set
- [x] Confirmed test fails on the unpatched code, passes on the fix
- [x] `make all` green (399 tests)
- [x] Manual: `dig ikea.com NS @<numa>` after a `dig www.ikea.com @<numa>` should now return a well-formed response (QUERY: 1, flags include `qr rd ra`)