### PR TITLE
feat(forward): TCP fallback for UDP-hostile networks

### DIFF
--- a/scripts/bench-vs-unbound.sh
+++ b/scripts/bench-vs-unbound.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Spin up Numa-bench (5454) + Unbound (5456), run the
+# `recursive_compare --vs-unbound[-cold]` Criterion bench, tear down.
+#
+# Usage:
+#   scripts/bench-vs-unbound.sh           # warm cache, forwarding mode
+#   scripts/bench-vs-unbound.sh --cold    # unique subdomains, recursive mode
+set -euo pipefail
+
+MODE="warm"
+if [[ "${1:-}" == "--cold" ]]; then
+  MODE="cold"
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d -t numa-bench-vs-unbound.XXXXXX)"
+NUMA_PID=""
+UNBOUND_PID=""
+
+cleanup() {
+  [[ -n "$NUMA_PID" ]] && kill "$NUMA_PID" 2>/dev/null || true
+  [[ -n "$UNBOUND_PID" ]] && kill "$UNBOUND_PID" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+if [[ "$MODE" == "cold" ]]; then
+  # Both servers recurse from roots — apples-to-apples cold path.
+  NUMA_TOML="benches/numa-bench-recursive.toml"
+  BENCH_FLAG="--vs-unbound-cold"
+  cat >"$WORK/unbound.conf" <<EOF
+server:
+    verbosity: 0
+    interface: 127.0.0.1@5456
+    do-ip6: no
+    do-tcp: yes
+    access-control: 127.0.0.0/8 allow
+    username: ""
+    chroot: ""
+    pidfile: "$WORK/unbound.pid"
+    use-syslog: no
+    logfile: "$WORK/unbound.log"
+    cache-min-ttl: 60
+    cache-max-ttl: 3600
+    prefetch: yes
+EOF
+else
+  # Both servers forward to Quad9 over plain UDP — canonical cached comparison.
+  NUMA_TOML="benches/numa-bench.toml"
+  BENCH_FLAG="--vs-unbound"
+  cat >"$WORK/unbound.conf" <<EOF
+server:
+    verbosity: 0
+    interface: 127.0.0.1@5456
+    do-ip6: no
+    do-tcp: yes
+    access-control: 127.0.0.0/8 allow
+    username: ""
+    chroot: ""
+    pidfile: "$WORK/unbound.pid"
+    use-syslog: no
+    logfile: "$WORK/unbound.log"
+    cache-min-ttl: 60
+    cache-max-ttl: 3600
+    prefetch: yes
+forward-zone:
+    name: "."
+    forward-addr: 9.9.9.9
+EOF
+fi
+
+echo "==> mode: $MODE (numa: $NUMA_TOML)"
+
+echo "==> building numa (release)"
+cargo build --release --bin numa 2>&1 | tail -3
+
+echo "==> starting unbound on 127.0.0.1:5456"
+/opt/homebrew/sbin/unbound -c "$WORK/unbound.conf" -d >"$WORK/unbound.stderr" 2>&1 &
+UNBOUND_PID=$!
+
+echo "==> starting numa-bench on 127.0.0.1:5454"
+"$ROOT/target/release/numa" "$ROOT/$NUMA_TOML" >"$WORK/numa.log" 2>&1 &
+NUMA_PID=$!
+
+echo "==> waiting for both servers"
+for i in $(seq 1 30); do
+  ok_u=0; ok_n=0
+  dig @127.0.0.1 -p 5456 example.com +short +time=1 +tries=1 >/dev/null 2>&1 && ok_u=1
+  dig @127.0.0.1 -p 5454 example.com +short +time=1 +tries=1 >/dev/null 2>&1 && ok_n=1
+  if [[ $ok_u -eq 1 && $ok_n -eq 1 ]]; then
+    echo "    ready (after ${i}s)"
+    break
+  fi
+  sleep 1
+  if [[ $i -eq 30 ]]; then
+    echo "ERROR: servers did not become ready"
+    echo "--- unbound stderr ---"; tail -20 "$WORK/unbound.stderr" || true
+    echo "--- numa log ---"; tail -20 "$WORK/numa.log" || true
+    exit 1
+  fi
+done
+
+echo "==> running cargo bench --bench recursive_compare -- $BENCH_FLAG"
+cd "$ROOT"
+cargo bench --bench recursive_compare -- "$BENCH_FLAG"

--- a/scripts/bench-vs-unbound.sh
+++ b/scripts/bench-vs-unbound.sh
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
-# Spin up Numa-bench (5454) + Unbound (5456), run the
-# `recursive_compare --vs-unbound[-cold]` Criterion bench, tear down.
+# Spin up Numa-bench + Unbound, run the `recursive_compare --vs-unbound[-cold]`
+# Criterion bench, tear down.
 #
 # Usage:
 #   scripts/bench-vs-unbound.sh           # warm cache, forwarding mode
 #   scripts/bench-vs-unbound.sh --cold    # unique subdomains, recursive mode
 set -euo pipefail
 
-MODE="warm"
+NUMA_PORT="${NUMA_PORT:-5454}"
+UNBOUND_PORT="${UNBOUND_PORT:-5456}"
+UPSTREAM="${UPSTREAM:-9.9.9.9}"
+UNBOUND_BIN="${UNBOUND_BIN:-/opt/homebrew/sbin/unbound}"
+
 if [[ "${1:-}" == "--cold" ]]; then
   MODE="cold"
+  NUMA_TOML="benches/numa-bench-recursive.toml"
+  BENCH_FLAG="--vs-unbound-cold"
+else
+  MODE="warm"
+  NUMA_TOML="benches/numa-bench.toml"
+  BENCH_FLAG="--vs-unbound"
 fi
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -24,14 +34,10 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-if [[ "$MODE" == "cold" ]]; then
-  # Both servers recurse from roots — apples-to-apples cold path.
-  NUMA_TOML="benches/numa-bench-recursive.toml"
-  BENCH_FLAG="--vs-unbound-cold"
-  cat >"$WORK/unbound.conf" <<EOF
+cat >"$WORK/unbound.conf" <<EOF
 server:
     verbosity: 0
-    interface: 127.0.0.1@5456
+    interface: 127.0.0.1@$UNBOUND_PORT
     do-ip6: no
     do-tcp: yes
     access-control: 127.0.0.0/8 allow
@@ -44,28 +50,14 @@ server:
     cache-max-ttl: 3600
     prefetch: yes
 EOF
-else
-  # Both servers forward to Quad9 over plain UDP — canonical cached comparison.
-  NUMA_TOML="benches/numa-bench.toml"
-  BENCH_FLAG="--vs-unbound"
-  cat >"$WORK/unbound.conf" <<EOF
-server:
-    verbosity: 0
-    interface: 127.0.0.1@5456
-    do-ip6: no
-    do-tcp: yes
-    access-control: 127.0.0.0/8 allow
-    username: ""
-    chroot: ""
-    pidfile: "$WORK/unbound.pid"
-    use-syslog: no
-    logfile: "$WORK/unbound.log"
-    cache-min-ttl: 60
-    cache-max-ttl: 3600
-    prefetch: yes
+
+# Warm mode forwards to a public resolver (apples-to-apples with numa-bench
+# which also forwards). Cold mode recurses from roots on both sides.
+if [[ "$MODE" == "warm" ]]; then
+  cat >>"$WORK/unbound.conf" <<EOF
 forward-zone:
     name: "."
-    forward-addr: 9.9.9.9
+    forward-addr: $UPSTREAM
 EOF
 fi
 
@@ -74,19 +66,19 @@ echo "==> mode: $MODE (numa: $NUMA_TOML)"
 echo "==> building numa (release)"
 cargo build --release --bin numa 2>&1 | tail -3
 
-echo "==> starting unbound on 127.0.0.1:5456"
-/opt/homebrew/sbin/unbound -c "$WORK/unbound.conf" -d >"$WORK/unbound.stderr" 2>&1 &
+echo "==> starting unbound on 127.0.0.1:$UNBOUND_PORT"
+"$UNBOUND_BIN" -c "$WORK/unbound.conf" -d >"$WORK/unbound.stderr" 2>&1 &
 UNBOUND_PID=$!
 
-echo "==> starting numa-bench on 127.0.0.1:5454"
+echo "==> starting numa-bench on 127.0.0.1:$NUMA_PORT"
 "$ROOT/target/release/numa" "$ROOT/$NUMA_TOML" >"$WORK/numa.log" 2>&1 &
 NUMA_PID=$!
 
 echo "==> waiting for both servers"
 for i in $(seq 1 30); do
   ok_u=0; ok_n=0
-  dig @127.0.0.1 -p 5456 example.com +short +time=1 +tries=1 >/dev/null 2>&1 && ok_u=1
-  dig @127.0.0.1 -p 5454 example.com +short +time=1 +tries=1 >/dev/null 2>&1 && ok_n=1
+  dig @127.0.0.1 -p "$UNBOUND_PORT" example.com +short +time=1 +tries=1 >/dev/null 2>&1 && ok_u=1
+  dig @127.0.0.1 -p "$NUMA_PORT" example.com +short +time=1 +tries=1 >/dev/null 2>&1 && ok_n=1
   if [[ $ok_u -eq 1 && $ok_n -eq 1 ]]; then
     echo "    ready (after ${i}s)"
     break

--- a/src/api.rs
+++ b/src/api.rs
@@ -205,6 +205,7 @@ struct TransportStats {
 #[derive(Serialize)]
 struct UpstreamTransportStats {
     udp: u64,
+    tcp: u64,
     doh: u64,
     dot: u64,
     odoh: u64,
@@ -592,6 +593,7 @@ async fn stats(State(ctx): State<Arc<ServerCtx>>) -> Json<StatsResponse> {
         },
         upstream_transport: UpstreamTransportStats {
             udp: snap.upstream_transport_udp,
+            tcp: snap.upstream_transport_tcp,
             doh: snap.upstream_transport_doh,
             dot: snap.upstream_transport_dot,
             odoh: snap.upstream_transport_odoh,

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -16,6 +16,10 @@ use crate::Result;
 #[derive(Clone)]
 pub enum Upstream {
     Udp(SocketAddr),
+    /// Plain DNS over TCP (RFC 1035 §4.2.2). Used as a UDP-fallback transport
+    /// on networks that block outbound UDP:53 to non-self resolvers — common
+    /// at carriers running BCP 38-style amplification mitigation.
+    Tcp(SocketAddr),
     Doh {
         url: String,
         client: reqwest::Client,
@@ -42,7 +46,9 @@ impl Upstream {
     /// single IP to track; SRTT is skipped for them.
     pub fn tracked_ip(&self) -> Option<IpAddr> {
         match self {
-            Upstream::Udp(addr) | Upstream::Dot { addr, .. } => Some(addr.ip()),
+            Upstream::Udp(addr) | Upstream::Tcp(addr) | Upstream::Dot { addr, .. } => {
+                Some(addr.ip())
+            }
             Upstream::Doh { .. } | Upstream::Odoh { .. } => None,
         }
     }
@@ -50,6 +56,7 @@ impl Upstream {
     pub fn transport(&self) -> UpstreamTransport {
         match self {
             Upstream::Udp(_) => UpstreamTransport::Udp,
+            Upstream::Tcp(_) => UpstreamTransport::Tcp,
             Upstream::Doh { .. } => UpstreamTransport::Doh,
             Upstream::Dot { .. } => UpstreamTransport::Dot,
             Upstream::Odoh { .. } => UpstreamTransport::Odoh,
@@ -61,6 +68,7 @@ impl PartialEq for Upstream {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Udp(a), Self::Udp(b)) => a == b,
+            (Self::Tcp(a), Self::Tcp(b)) => a == b,
             (Self::Doh { url: a, .. }, Self::Doh { url: b, .. }) => a == b,
             (Self::Dot { addr: a, .. }, Self::Dot { addr: b, .. }) => a == b,
             (
@@ -92,6 +100,7 @@ impl fmt::Display for Upstream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Upstream::Udp(addr) => write!(f, "{}", addr),
+            Upstream::Tcp(addr) => write!(f, "tcp://{}", addr),
             Upstream::Doh { url, .. } => f.write_str(url),
             Upstream::Dot { addr, tls_name, .. } => match tls_name {
                 Some(name) => write!(f, "tls://{}#{}", addr, name),
@@ -163,6 +172,11 @@ pub fn parse_upstream(
             tls_name,
             connector,
         });
+    }
+    // tcp://IP:PORT  or  tcp://IP  (default port = `default_port`, typically 53)
+    if let Some(rest) = s.strip_prefix("tcp://") {
+        let addr = parse_upstream_addr(rest, default_port)?;
+        return Ok(Upstream::Tcp(addr));
     }
     let addr = parse_upstream_addr(s, default_port)?;
     Ok(Upstream::Udp(addr))
@@ -303,19 +317,27 @@ pub(crate) async fn forward_tcp(
     upstream: SocketAddr,
     timeout_duration: Duration,
 ) -> Result<DnsPacket> {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::TcpStream;
-
     let mut send_buffer = BytePacketBuffer::new();
     query.write(&mut send_buffer)?;
-    let msg = send_buffer.filled();
+    let data = forward_tcp_raw(send_buffer.filled(), upstream, timeout_duration).await?;
+    let mut recv_buffer = BytePacketBuffer::from_bytes(&data);
+    DnsPacket::from_buffer(&mut recv_buffer)
+}
+
+async fn forward_tcp_raw(
+    wire: &[u8],
+    upstream: SocketAddr,
+    timeout_duration: Duration,
+) -> Result<Vec<u8>> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
 
     let mut stream = timeout(timeout_duration, TcpStream::connect(upstream)).await??;
 
     // Single write: Microsoft/Azure DNS servers close TCP connections on split segments
-    let mut outbuf = Vec::with_capacity(2 + msg.len());
-    outbuf.extend_from_slice(&(msg.len() as u16).to_be_bytes());
-    outbuf.extend_from_slice(msg);
+    let mut outbuf = Vec::with_capacity(2 + wire.len());
+    outbuf.extend_from_slice(&(wire.len() as u16).to_be_bytes());
+    outbuf.extend_from_slice(wire);
     stream.write_all(&outbuf).await?;
 
     // Read length-prefixed response
@@ -326,8 +348,7 @@ pub(crate) async fn forward_tcp(
     let mut data = vec![0u8; resp_len];
     timeout(timeout_duration, stream.read_exact(&mut data)).await??;
 
-    let mut recv_buffer = BytePacketBuffer::from_bytes(&data);
-    DnsPacket::from_buffer(&mut recv_buffer)
+    Ok(data)
 }
 
 async fn forward_dot_raw(
@@ -371,6 +392,7 @@ pub async fn forward_query_raw(
 ) -> Result<Vec<u8>> {
     match upstream {
         Upstream::Udp(addr) => forward_udp_raw(wire, *addr, timeout_duration).await,
+        Upstream::Tcp(addr) => forward_tcp_raw(wire, *addr, timeout_duration).await,
         Upstream::Doh { url, client } => forward_doh_raw(wire, url, client, timeout_duration).await,
         Upstream::Dot {
             addr,
@@ -461,6 +483,13 @@ pub async fn forward_with_hedging_raw(
     }
 }
 
+/// Primaries with SRTT at or above this are skipped when a fallback is
+/// available — saves the per-query timeout cost on networks where UDP:53 is
+/// known broken (RDS-style amplification mitigation, BCP 38). Decay
+/// (`srtt::DECAY_AFTER_SECS`) eventually drops the SRTT back below the
+/// threshold so the primary is re-probed if the network changes.
+const PRIMARY_SKIP_SRTT_MS: u64 = 4000;
+
 pub async fn forward_with_failover_raw(
     wire: &[u8],
     pool: &UpstreamPool,
@@ -481,8 +510,10 @@ pub async fn forward_with_failover_raw(
     };
     candidates.sort_by_key(|&(_, rtt)| rtt);
 
+    let has_fallback = !pool.fallback.is_empty();
     let all_upstreams: Vec<&Upstream> = candidates
         .iter()
+        .filter(|&&(_, rtt)| !has_fallback || rtt < PRIMARY_SKIP_SRTT_MS)
         .map(|&(i, _)| &pool.primary[i])
         .chain(pool.fallback.iter())
         .collect();
@@ -603,6 +634,12 @@ mod tests {
             client: reqwest::Client::new(),
         };
         assert_eq!(u.to_string(), "https://dns.quad9.net/dns-query");
+    }
+
+    #[test]
+    fn upstream_display_tcp() {
+        let u = Upstream::Tcp("9.9.9.9:53".parse().unwrap());
+        assert_eq!(u.to_string(), "tcp://9.9.9.9:53");
     }
 
     fn make_query() -> DnsPacket {
@@ -743,6 +780,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_tcp_scheme_default_port() {
+        let u = parse_upstream("tcp://1.2.3.4", 53, None).unwrap();
+        assert_eq!(u, Upstream::Tcp("1.2.3.4:53".parse().unwrap()));
+    }
+
+    #[test]
+    fn parse_tcp_scheme_explicit_port() {
+        let u = parse_upstream("tcp://1.2.3.4:5353", 53, None).unwrap();
+        assert_eq!(u, Upstream::Tcp("1.2.3.4:5353".parse().unwrap()));
+    }
+
+    #[test]
     fn pool_label_single() {
         let pool = UpstreamPool::new(vec![Upstream::Udp("1.2.3.4:53".parse().unwrap())], vec![]);
         assert_eq!(pool.label(), "1.2.3.4:53");
@@ -755,6 +804,87 @@ mod tests {
             vec![Upstream::Udp("8.8.8.8:53".parse().unwrap())],
         );
         assert_eq!(pool.label(), "1.2.3.4:53 (+1 more)");
+    }
+
+    #[tokio::test]
+    async fn failover_skips_bad_srtt_primary_when_fallback_exists() {
+        // UDP primary's SRTT is pre-pinned at FAILURE_PENALTY. With a
+        // fallback present, the failover loop should skip the primary
+        // entirely (no UDP timeout cost) and go straight to fallback.
+        let query = make_query();
+        let response_bytes = to_wire(&make_response(&query));
+
+        let app = axum::Router::new().route(
+            "/dns-query",
+            axum::routing::post(move || {
+                let body = response_bytes.clone();
+                async move {
+                    (
+                        [(axum::http::header::CONTENT_TYPE, "application/dns-message")],
+                        body,
+                    )
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let doh_addr = listener.local_addr().unwrap();
+        tokio::spawn(axum::serve(listener, app).into_future());
+
+        let bad_udp_addr: SocketAddr = "192.0.2.99:53".parse().unwrap();
+        let pool = UpstreamPool::new(
+            vec![Upstream::Udp(bad_udp_addr)],
+            vec![Upstream::Doh {
+                url: format!("http://{}/dns-query", doh_addr),
+                client: reqwest::Client::new(),
+            }],
+        );
+
+        let srtt = RwLock::new(SrttCache::new(true));
+        srtt.write().unwrap().record_failure(bad_udp_addr.ip());
+
+        let wire = to_wire(&query);
+        let start = Instant::now();
+        let resp_wire = forward_with_failover_raw(
+            &wire,
+            &pool,
+            &srtt,
+            // High primary timeout — if the circuit-breaker fails to skip,
+            // the test would block ~500ms on the unreachable UDP primary.
+            Duration::from_millis(500),
+            Duration::ZERO,
+        )
+        .await
+        .expect("should fall through to DoH fallback");
+        assert!(
+            start.elapsed() < Duration::from_millis(200),
+            "primary was attempted, elapsed={:?}",
+            start.elapsed()
+        );
+
+        let mut buf = BytePacketBuffer::from_bytes(&resp_wire);
+        let result = DnsPacket::from_buffer(&mut buf).unwrap();
+        assert_eq!(result.header.id, 0xABCD);
+    }
+
+    #[tokio::test]
+    async fn failover_tries_bad_srtt_primary_when_no_fallback() {
+        // No fallback means the circuit-breaker must NOT skip the only
+        // upstream — better to try and fail with a timeout than to error
+        // out without sending a single query.
+        let bad_udp_addr: SocketAddr = "192.0.2.99:53".parse().unwrap();
+        let pool = UpstreamPool::new(vec![Upstream::Udp(bad_udp_addr)], vec![]);
+        let srtt = RwLock::new(SrttCache::new(true));
+        srtt.write().unwrap().record_failure(bad_udp_addr.ip());
+
+        let result = forward_with_failover_raw(
+            &[0u8; 12],
+            &pool,
+            &srtt,
+            Duration::from_millis(50),
+            Duration::ZERO,
+        )
+        .await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -41,18 +41,14 @@ pub enum Upstream {
 }
 
 impl Upstream {
-    /// SRTT key for this upstream: `(IpAddr, UpstreamTransport)`. UDP, TCP,
-    /// and DoT to the same IP get independent EWMAs so transport-specific
-    /// failure (BCP 38 dropping UDP, TLS handshake stalls) does not poison
-    /// the others. `Doh`/`Odoh` route through a URL + connection pool, so
-    /// there is no single IP to track and SRTT is skipped for them.
+    /// SRTT key, when the upstream has a stable IP. `Doh`/`Odoh` route
+    /// through a URL + connection pool, so they never key here.
     pub fn tracked_key(&self) -> Option<(IpAddr, UpstreamTransport)> {
-        match self {
-            Upstream::Udp(addr) => Some((addr.ip(), UpstreamTransport::Udp)),
-            Upstream::Tcp(addr) => Some((addr.ip(), UpstreamTransport::Tcp)),
-            Upstream::Dot { addr, .. } => Some((addr.ip(), UpstreamTransport::Dot)),
-            Upstream::Doh { .. } | Upstream::Odoh { .. } => None,
-        }
+        let ip = match self {
+            Upstream::Udp(a) | Upstream::Tcp(a) | Upstream::Dot { addr: a, .. } => a.ip(),
+            Upstream::Doh { .. } | Upstream::Odoh { .. } => return None,
+        };
+        Some((ip, self.transport()))
     }
 
     pub fn transport(&self) -> UpstreamTransport {

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -41,14 +41,16 @@ pub enum Upstream {
 }
 
 impl Upstream {
-    /// IP address to key SRTT tracking on, if the upstream has a stable one.
-    /// `Doh` and `Odoh` route through a URL + connection pool, so there's no
-    /// single IP to track; SRTT is skipped for them.
-    pub fn tracked_ip(&self) -> Option<IpAddr> {
+    /// SRTT key for this upstream: `(IpAddr, UpstreamTransport)`. UDP, TCP,
+    /// and DoT to the same IP get independent EWMAs so transport-specific
+    /// failure (BCP 38 dropping UDP, TLS handshake stalls) does not poison
+    /// the others. `Doh`/`Odoh` route through a URL + connection pool, so
+    /// there is no single IP to track and SRTT is skipped for them.
+    pub fn tracked_key(&self) -> Option<(IpAddr, UpstreamTransport)> {
         match self {
-            Upstream::Udp(addr) | Upstream::Tcp(addr) | Upstream::Dot { addr, .. } => {
-                Some(addr.ip())
-            }
+            Upstream::Udp(addr) => Some((addr.ip(), UpstreamTransport::Udp)),
+            Upstream::Tcp(addr) => Some((addr.ip(), UpstreamTransport::Tcp)),
+            Upstream::Dot { addr, .. } => Some((addr.ip(), UpstreamTransport::Dot)),
             Upstream::Doh { .. } | Upstream::Odoh { .. } => None,
         }
     }
@@ -496,7 +498,10 @@ pub async fn forward_with_failover_raw(
             .iter()
             .enumerate()
             .map(|(i, u)| {
-                let rtt = u.tracked_ip().map(|ip| srtt_read.get(ip)).unwrap_or(0);
+                let rtt = u
+                    .tracked_key()
+                    .map(|(ip, t)| srtt_read.get(ip, t))
+                    .unwrap_or(0);
                 (i, rtt)
             })
             .collect()
@@ -526,15 +531,15 @@ pub async fn forward_with_failover_raw(
         };
         match result {
             Ok(resp) => {
-                if let Some(ip) = upstream.tracked_ip() {
+                if let Some((ip, t)) = upstream.tracked_key() {
                     let rtt_ms = start.elapsed().as_millis() as u64;
-                    srtt.write().unwrap().record_rtt(ip, rtt_ms, false);
+                    srtt.write().unwrap().record_rtt(ip, t, rtt_ms);
                 }
                 return Ok(resp);
             }
             Err(e) => {
-                if let Some(ip) = upstream.tracked_ip() {
-                    srtt.write().unwrap().record_failure(ip);
+                if let Some((ip, t)) = upstream.tracked_key() {
+                    srtt.write().unwrap().record_failure(ip, t);
                 }
                 log::debug!("upstream {} failed: {}", upstream, e);
                 last_err = Some(e);
@@ -833,7 +838,9 @@ mod tests {
         );
 
         let srtt = RwLock::new(SrttCache::new(true));
-        srtt.write().unwrap().record_failure(bad_udp_addr.ip());
+        srtt.write()
+            .unwrap()
+            .record_failure(bad_udp_addr.ip(), UpstreamTransport::Udp);
 
         let wire = to_wire(&query);
         let start = Instant::now();
@@ -867,7 +874,9 @@ mod tests {
         let bad_udp_addr: SocketAddr = "192.0.2.99:53".parse().unwrap();
         let pool = UpstreamPool::new(vec![Upstream::Udp(bad_udp_addr)], vec![]);
         let srtt = RwLock::new(SrttCache::new(true));
-        srtt.write().unwrap().record_failure(bad_udp_addr.ip());
+        srtt.write()
+            .unwrap()
+            .record_failure(bad_udp_addr.ip(), UpstreamTransport::Udp);
 
         let result = forward_with_failover_raw(
             &[0u8; 12],
@@ -979,7 +988,10 @@ mod tests {
             Duration::ZERO,
         )
         .await;
-        assert!(srtt.read().unwrap().is_known(blackhole.ip()));
+        assert!(srtt
+            .read()
+            .unwrap()
+            .is_known(blackhole.ip(), UpstreamTransport::Udp));
     }
 
     #[tokio::test]
@@ -1012,7 +1024,7 @@ mod tests {
         )
         .await;
         let cache = srtt.read().unwrap();
-        assert!(cache.is_known(dead1.ip()));
-        assert!(cache.is_known(dead2.ip()));
+        assert!(cache.is_known(dead1.ip(), UpstreamTransport::Dot));
+        assert!(cache.is_known(dead2.ip(), UpstreamTransport::Dot));
     }
 }

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -483,13 +483,6 @@ pub async fn forward_with_hedging_raw(
     }
 }
 
-/// Primaries with SRTT at or above this are skipped when a fallback is
-/// available — saves the per-query timeout cost on networks where UDP:53 is
-/// known broken (RDS-style amplification mitigation, BCP 38). Decay
-/// (`srtt::DECAY_AFTER_SECS`) eventually drops the SRTT back below the
-/// threshold so the primary is re-probed if the network changes.
-const PRIMARY_SKIP_SRTT_MS: u64 = 4000;
-
 pub async fn forward_with_failover_raw(
     wire: &[u8],
     pool: &UpstreamPool,
@@ -513,7 +506,7 @@ pub async fn forward_with_failover_raw(
     let has_fallback = !pool.fallback.is_empty();
     let all_upstreams: Vec<&Upstream> = candidates
         .iter()
-        .filter(|&&(_, rtt)| !has_fallback || rtt < PRIMARY_SKIP_SRTT_MS)
+        .filter(|&&(_, rtt)| !has_fallback || rtt < crate::srtt::PRIMARY_SKIP_SRTT_MS)
         .map(|&(i, _)| &pool.primary[i])
         .chain(pool.fallback.iter())
         .collect();

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -12,6 +12,7 @@ use crate::packet::DnsPacket;
 use crate::question::QueryType;
 use crate::record::DnsRecord;
 use crate::srtt::SrttCache;
+use crate::stats::UpstreamTransport;
 
 const MAX_REFERRAL_DEPTH: u8 = 10;
 const MAX_CNAME_DEPTH: u8 = 8;
@@ -198,7 +199,7 @@ pub(crate) fn resolve_iterative<'a>(
         }
 
         let (mut current_zone, mut ns_addrs) = find_closest_ns(qname, cache, root_hints);
-        srtt.read().unwrap().sort_by_rtt(&mut ns_addrs);
+        srtt.read().unwrap().sort_by_udp_rtt(&mut ns_addrs);
         let mut ns_idx = 0;
 
         for _ in 0..MAX_REFERRAL_DEPTH {
@@ -239,7 +240,7 @@ pub(crate) fn resolve_iterative<'a>(
                 }
                 let mut new_addrs = resolve_ns_addrs_from_glue(&response, &all_ns, cache);
                 if !new_addrs.is_empty() {
-                    srtt.read().unwrap().sort_by_rtt(&mut new_addrs);
+                    srtt.read().unwrap().sort_by_udp_rtt(&mut new_addrs);
                     ns_addrs = new_addrs;
                     ns_idx = 0;
                     continue;
@@ -340,7 +341,7 @@ pub(crate) fn resolve_iterative<'a>(
                 return Err(format!("could not resolve any NS for {}", qname).into());
             }
 
-            srtt.read().unwrap().sort_by_rtt(&mut new_ns_addrs);
+            srtt.read().unwrap().sort_by_udp_rtt(&mut new_ns_addrs);
             ns_addrs = new_ns_addrs;
             ns_idx = 0;
         }
@@ -597,13 +598,17 @@ async fn tcp_with_srtt(
 ) -> crate::Result<DnsPacket> {
     match crate::forward::forward_tcp(query, server, TCP_TIMEOUT).await {
         Ok(resp) => {
-            srtt.write()
-                .unwrap()
-                .record_rtt(server.ip(), start.elapsed().as_millis() as u64, true);
+            srtt.write().unwrap().record_rtt(
+                server.ip(),
+                UpstreamTransport::Tcp,
+                start.elapsed().as_millis() as u64,
+            );
             Ok(resp)
         }
         Err(e) => {
-            srtt.write().unwrap().record_failure(server.ip());
+            srtt.write()
+                .unwrap()
+                .record_failure(server.ip(), UpstreamTransport::Tcp);
             Err(e)
         }
     }
@@ -626,7 +631,10 @@ async fn send_query_hedged(
 
     let primary = servers[0];
     let secondary = servers[1];
-    let primary_known = srtt.read().unwrap().is_known(primary.ip());
+    let primary_known = srtt
+        .read()
+        .unwrap()
+        .is_known(primary.ip(), UpstreamTransport::Udp);
 
     if !primary_known {
         // Cold: fire both simultaneously, first response wins
@@ -670,7 +678,11 @@ async fn send_query_hedged(
         }
     } else {
         // Warm: send to best, hedge after SRTT × 3 if slow
-        let hedge_ms = srtt.read().unwrap().get(primary.ip()) * 3;
+        let hedge_ms = srtt
+            .read()
+            .unwrap()
+            .get(primary.ip(), UpstreamTransport::Udp)
+            * 3;
         let hedge_delay = Duration::from_millis(hedge_ms.max(50));
 
         let fut_a = send_query(qname, qtype, primary, srtt);
@@ -752,8 +764,8 @@ async fn send_query(
             UDP_FAILURES.store(0, Ordering::Release);
             srtt.write().unwrap().record_rtt(
                 server.ip(),
+                UpstreamTransport::Udp,
                 start.elapsed().as_millis() as u64,
-                false,
             );
             Ok(resp)
         }
@@ -770,7 +782,9 @@ async fn send_query(
             }
             // UDP works in general (priming succeeded) but this server timed out.
             // Don't waste another 400ms on TCP — the server is unreachable.
-            srtt.write().unwrap().record_failure(server.ip());
+            srtt.write()
+                .unwrap()
+                .record_failure(server.ip(), UpstreamTransport::Udp);
             Err(e)
         }
     }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -590,11 +590,26 @@ async fn resolve_upstream_pool(
                 config.upstream.port,
                 Some(bootstrap_resolver.clone()),
             )?;
-            let fallback = parse_upstream_list(
+            let mut fallback = parse_upstream_list(
                 &config.upstream.fallback,
                 config.upstream.port,
                 Some(bootstrap_resolver.clone()),
             )?;
+
+            // Pair every UDP primary with a TCP sibling in fallback, so a
+            // UDP-hostile network (carriers running BCP 38-style amplification
+            // mitigation drop outbound UDP:53 to non-self resolvers) doesn't
+            // break Forward mode. SRTT circuit-breaker in the failover loop
+            // skips the UDP primary once it's known broken — TCP fallback
+            // runs directly without paying the UDP timeout per query.
+            for u in &primary {
+                if let crate::forward::Upstream::Udp(addr) = u {
+                    let tcp = crate::forward::Upstream::Tcp(*addr);
+                    if !fallback.contains(&tcp) {
+                        fallback.push(tcp);
+                    }
+                }
+            }
 
             let pool = UpstreamPool::new(primary, fallback);
             let label = pool.label();

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -596,12 +596,9 @@ async fn resolve_upstream_pool(
                 Some(bootstrap_resolver.clone()),
             )?;
 
-            // Pair every UDP primary with a TCP sibling in fallback, so a
-            // UDP-hostile network (carriers running BCP 38-style amplification
-            // mitigation drop outbound UDP:53 to non-self resolvers) doesn't
-            // break Forward mode. SRTT circuit-breaker in the failover loop
-            // skips the UDP primary once it's known broken — TCP fallback
-            // runs directly without paying the UDP timeout per query.
+            // Pair every UDP primary with a TCP sibling in fallback so
+            // Forward mode survives carriers that drop outbound UDP:53
+            // for amplification mitigation (BCP 38).
             for u in &primary {
                 if let crate::forward::Upstream::Udp(addr) = u {
                     let tcp = crate::forward::Upstream::Tcp(*addr);

--- a/src/srtt.rs
+++ b/src/srtt.rs
@@ -9,6 +9,12 @@ const DECAY_AFTER_SECS: u64 = 300;
 const MAX_ENTRIES: usize = 4096;
 const EVICT_BATCH: usize = 64;
 
+/// Failover circuit-breaker threshold: a primary upstream at or above this
+/// SRTT is skipped when a fallback is available. Calibrated between
+/// `INITIAL_SRTT_MS` and `FAILURE_PENALTY_MS` so a single failure trips it
+/// and decay un-trips it within ~5 minutes.
+pub const PRIMARY_SKIP_SRTT_MS: u64 = 4000;
+
 struct SrttEntry {
     srtt_ms: u64,
     updated_at: Instant,

--- a/src/srtt.rs
+++ b/src/srtt.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::time::Instant;
 
+use crate::stats::UpstreamTransport;
+
 const INITIAL_SRTT_MS: u64 = 200;
 const FAILURE_PENALTY_MS: u64 = 5000;
-const TCP_PENALTY_MS: u64 = 100;
 const DECAY_AFTER_SECS: u64 = 300;
 const MAX_ENTRIES: usize = 4096;
 const EVICT_BATCH: usize = 64;
@@ -12,8 +13,18 @@ const EVICT_BATCH: usize = 64;
 /// Failover circuit-breaker threshold: a primary upstream at or above this
 /// SRTT is skipped when a fallback is available. Calibrated between
 /// `INITIAL_SRTT_MS` and `FAILURE_PENALTY_MS` so a single failure trips it
-/// and decay un-trips it within ~5 minutes.
+/// and decay un-trips it within ~5 minutes. With per-`(ip, transport)`
+/// keying, success on a sibling transport (e.g. TCP fallback for the same
+/// IP) does NOT re-arm probing of the broken transport — so on UDP-hostile
+/// networks the UDP timeout is taken at most once per decay window.
 pub const PRIMARY_SKIP_SRTT_MS: u64 = 4000;
+
+/// SRTT key: an IP plus the wire transport. Plain UDP and plain TCP to the
+/// same resolver get independent EWMAs so a UDP-hostile path (BCP 38) does
+/// not poison TCP's score and vice versa. DoT keys separately so TLS
+/// failures stay isolated from plain TCP. DoH/ODoH never key here — they
+/// route through a URL+pool, not a single IP.
+type SrttKey = (IpAddr, UpstreamTransport);
 
 struct SrttEntry {
     srtt_ms: u64,
@@ -21,7 +32,7 @@ struct SrttEntry {
 }
 
 pub struct SrttCache {
-    entries: HashMap<IpAddr, SrttEntry>,
+    entries: HashMap<SrttKey, SrttEntry>,
     enabled: bool,
 }
 
@@ -43,17 +54,18 @@ impl SrttCache {
         self.enabled
     }
 
-    /// Get current SRTT for an IP, applying decay if stale. Returns INITIAL for unknown.
-    pub fn get(&self, ip: IpAddr) -> u64 {
-        match self.entries.get(&ip) {
+    /// Get current SRTT for an (IP, transport), applying decay if stale.
+    /// Returns INITIAL for unknown.
+    pub fn get(&self, ip: IpAddr, transport: UpstreamTransport) -> u64 {
+        match self.entries.get(&(ip, transport)) {
             Some(entry) => Self::decayed_srtt(entry),
             None => INITIAL_SRTT_MS,
         }
     }
 
-    /// Whether we have observed RTT data for this IP.
-    pub fn is_known(&self, ip: IpAddr) -> bool {
-        self.entries.contains_key(&ip)
+    /// Whether we have observed RTT data for this (IP, transport).
+    pub fn is_known(&self, ip: IpAddr, transport: UpstreamTransport) -> bool {
+        self.entries.contains_key(&(ip, transport))
     }
 
     /// Apply time-based decay: each DECAY_AFTER_SECS period halves distance to INITIAL.
@@ -75,30 +87,29 @@ impl SrttCache {
     }
 
     /// Record a successful query RTT. No-op when disabled.
-    pub fn record_rtt(&mut self, ip: IpAddr, rtt_ms: u64, tcp: bool) {
+    pub fn record_rtt(&mut self, ip: IpAddr, transport: UpstreamTransport, rtt_ms: u64) {
         if !self.enabled {
             return;
         }
-        let effective = if tcp { rtt_ms + TCP_PENALTY_MS } else { rtt_ms };
         self.maybe_evict();
-        let entry = self.entries.entry(ip).or_insert(SrttEntry {
-            srtt_ms: effective,
+        let entry = self.entries.entry((ip, transport)).or_insert(SrttEntry {
+            srtt_ms: rtt_ms,
             updated_at: Instant::now(),
         });
         // Apply decay before EWMA so recovered servers aren't stuck at stale penalties
         let base = Self::decayed_srtt(entry);
         // BIND EWMA: new = (old * 7 + sample) / 8
-        entry.srtt_ms = (base * 7 + effective) / 8;
+        entry.srtt_ms = (base * 7 + rtt_ms) / 8;
         entry.updated_at = Instant::now();
     }
 
     /// Record a failure (timeout or error). No-op when disabled.
-    pub fn record_failure(&mut self, ip: IpAddr) {
+    pub fn record_failure(&mut self, ip: IpAddr, transport: UpstreamTransport) {
         if !self.enabled {
             return;
         }
         self.maybe_evict();
-        let entry = self.entries.entry(ip).or_insert(SrttEntry {
+        let entry = self.entries.entry((ip, transport)).or_insert(SrttEntry {
             srtt_ms: FAILURE_PENALTY_MS,
             updated_at: Instant::now(),
         });
@@ -106,17 +117,19 @@ impl SrttCache {
         entry.updated_at = Instant::now();
     }
 
-    /// Sort addresses by SRTT ascending (lowest/fastest first). No-op when disabled.
-    pub fn sort_by_rtt(&self, addrs: &mut [SocketAddr]) {
+    /// Sort UDP-context addresses by SRTT ascending (lowest/fastest first).
+    /// Recursive resolution always speaks UDP first to authoritatives, so a
+    /// dedicated UDP helper keeps the call sites free of transport literals.
+    pub fn sort_by_udp_rtt(&self, addrs: &mut [SocketAddr]) {
         if !self.enabled {
             return;
         }
-        addrs.sort_by_key(|a| self.get(a.ip()));
+        addrs.sort_by_key(|a| self.get(a.ip(), UpstreamTransport::Udp));
     }
 
     pub fn heap_bytes(&self) -> usize {
         let per_slot = std::mem::size_of::<u64>()
-            + std::mem::size_of::<IpAddr>()
+            + std::mem::size_of::<SrttKey>()
             + std::mem::size_of::<SrttEntry>()
             + 1;
         self.entries.capacity() * per_slot
@@ -135,10 +148,10 @@ impl SrttCache {
             return;
         }
         // Batch eviction: remove the oldest EVICT_BATCH entries at once
-        let mut by_age: Vec<IpAddr> = self.entries.keys().copied().collect();
-        by_age.sort_by_key(|ip| self.entries[ip].updated_at);
-        for ip in by_age.into_iter().take(EVICT_BATCH) {
-            self.entries.remove(&ip);
+        let mut by_age: Vec<SrttKey> = self.entries.keys().copied().collect();
+        by_age.sort_by_key(|k| self.entries[k].updated_at);
+        for k in by_age.into_iter().take(EVICT_BATCH) {
+            self.entries.remove(&k);
         }
     }
 }
@@ -147,6 +160,9 @@ impl SrttCache {
 mod tests {
     use super::*;
     use std::net::Ipv4Addr;
+
+    const UDP: UpstreamTransport = UpstreamTransport::Udp;
+    const TCP: UpstreamTransport = UpstreamTransport::Tcp;
 
     fn ip(last: u8) -> IpAddr {
         IpAddr::V4(Ipv4Addr::new(192, 0, 2, last))
@@ -159,48 +175,69 @@ mod tests {
     #[test]
     fn unknown_returns_initial() {
         let cache = SrttCache::new(true);
-        assert_eq!(cache.get(ip(1)), INITIAL_SRTT_MS);
+        assert_eq!(cache.get(ip(1), UDP), INITIAL_SRTT_MS);
     }
 
     #[test]
     fn ewma_converges() {
         let mut cache = SrttCache::new(true);
         for _ in 0..20 {
-            cache.record_rtt(ip(1), 100, false);
+            cache.record_rtt(ip(1), UDP, 100);
         }
-        let srtt = cache.get(ip(1));
+        let srtt = cache.get(ip(1), UDP);
         assert!(srtt >= 98 && srtt <= 102, "srtt={}", srtt);
     }
 
     #[test]
     fn failure_sets_penalty() {
         let mut cache = SrttCache::new(true);
-        cache.record_rtt(ip(1), 50, false);
-        cache.record_failure(ip(1));
-        assert_eq!(cache.get(ip(1)), FAILURE_PENALTY_MS);
+        cache.record_rtt(ip(1), UDP, 50);
+        cache.record_failure(ip(1), UDP);
+        assert_eq!(cache.get(ip(1), UDP), FAILURE_PENALTY_MS);
     }
 
     #[test]
-    fn tcp_penalty_added() {
+    fn udp_and_tcp_are_independent() {
+        // A flooded UDP path (5000ms penalty) must not drag down the TCP
+        // EWMA for the same IP. This is the bug the keying refactor fixes:
+        // on UDP-hostile networks (BCP 38), repeated UDP failures used to
+        // poison the shared SRTT entry, causing TCP fallback successes to
+        // re-arm UDP probing every ~3 queries.
         let mut cache = SrttCache::new(true);
+        cache.record_failure(ip(1), UDP);
         for _ in 0..20 {
-            cache.record_rtt(ip(1), 50, true);
+            cache.record_rtt(ip(1), TCP, 50);
         }
-        let srtt = cache.get(ip(1));
-        assert!(srtt >= 148 && srtt <= 152, "srtt={}", srtt);
+        assert_eq!(cache.get(ip(1), UDP), FAILURE_PENALTY_MS);
+        let tcp = cache.get(ip(1), TCP);
+        assert!(tcp >= 48 && tcp <= 52, "tcp srtt drifted: {}", tcp);
     }
 
     #[test]
-    fn sort_by_rtt_orders_correctly() {
+    fn sort_by_udp_rtt_orders_correctly() {
         let mut cache = SrttCache::new(true);
         for _ in 0..20 {
-            cache.record_rtt(ip(1), 500, false);
-            cache.record_rtt(ip(2), 100, false);
-            cache.record_rtt(ip(3), 10, false);
+            cache.record_rtt(ip(1), UDP, 500);
+            cache.record_rtt(ip(2), UDP, 100);
+            cache.record_rtt(ip(3), UDP, 10);
         }
         let mut addrs = vec![sock(1), sock(2), sock(3)];
-        cache.sort_by_rtt(&mut addrs);
+        cache.sort_by_udp_rtt(&mut addrs);
         assert_eq!(addrs, vec![sock(3), sock(2), sock(1)]);
+    }
+
+    #[test]
+    fn sort_by_udp_rtt_ignores_tcp_entries() {
+        // TCP scores must not influence UDP-context sorting.
+        let mut cache = SrttCache::new(true);
+        for _ in 0..20 {
+            cache.record_rtt(ip(1), TCP, 10); // would sort first if TCP leaked in
+            cache.record_rtt(ip(2), UDP, 100);
+        }
+        let mut addrs = vec![sock(1), sock(2)];
+        cache.sort_by_udp_rtt(&mut addrs);
+        // ip(1) has no UDP record → INITIAL (200) > ip(2) UDP (100)
+        assert_eq!(addrs, vec![sock(2), sock(1)]);
     }
 
     #[test]
@@ -208,20 +245,20 @@ mod tests {
         let cache = SrttCache::new(true);
         let mut addrs = vec![sock(1), sock(2), sock(3)];
         let original = addrs.clone();
-        cache.sort_by_rtt(&mut addrs);
+        cache.sort_by_udp_rtt(&mut addrs);
         assert_eq!(addrs, original);
     }
 
     #[test]
     fn disabled_is_noop() {
         let mut cache = SrttCache::new(false);
-        cache.record_rtt(ip(1), 50, false);
-        cache.record_failure(ip(2));
+        cache.record_rtt(ip(1), UDP, 50);
+        cache.record_failure(ip(2), UDP);
         assert_eq!(cache.len(), 0);
 
         let mut addrs = vec![sock(2), sock(1)];
         let original = addrs.clone();
-        cache.sort_by_rtt(&mut addrs);
+        cache.sort_by_udp_rtt(&mut addrs);
         assert_eq!(addrs, original);
     }
 
@@ -300,7 +337,7 @@ mod tests {
         let mut cache = SrttCache::new(true);
         let empty = cache.heap_bytes();
         for i in 1..=10u8 {
-            cache.record_rtt(ip(i), 100, false);
+            cache.record_rtt(ip(i), UDP, 100);
         }
         assert!(cache.heap_bytes() > empty);
     }
@@ -317,12 +354,12 @@ mod tests {
             ];
             cache.record_rtt(
                 IpAddr::V4(Ipv4Addr::new(octets[0], octets[1], octets[2], octets[3])),
+                UDP,
                 100,
-                false,
             );
         }
         assert_eq!(cache.len(), MAX_ENTRIES);
-        cache.record_rtt(ip(1), 100, false);
+        cache.record_rtt(ip(1), UDP, 100);
         // Batch eviction removes EVICT_BATCH entries
         assert!(cache.len() <= MAX_ENTRIES - EVICT_BATCH + 1);
     }

--- a/src/srtt.rs
+++ b/src/srtt.rs
@@ -19,20 +19,16 @@ const EVICT_BATCH: usize = 64;
 /// networks the UDP timeout is taken at most once per decay window.
 pub const PRIMARY_SKIP_SRTT_MS: u64 = 4000;
 
-/// SRTT key: an IP plus the wire transport. Plain UDP and plain TCP to the
-/// same resolver get independent EWMAs so a UDP-hostile path (BCP 38) does
-/// not poison TCP's score and vice versa. DoT keys separately so TLS
-/// failures stay isolated from plain TCP. DoH/ODoH never key here — they
-/// route through a URL+pool, not a single IP.
-type SrttKey = (IpAddr, UpstreamTransport);
-
 struct SrttEntry {
     srtt_ms: u64,
     updated_at: Instant,
 }
 
+/// Per-(ip, transport) EWMA so a UDP-hostile path (BCP 38) doesn't poison
+/// TCP's score on the same IP, and DoT TLS failures stay isolated from
+/// plain TCP. DoH/ODoH route through a URL+pool, never key here.
 pub struct SrttCache {
-    entries: HashMap<SrttKey, SrttEntry>,
+    entries: HashMap<(IpAddr, UpstreamTransport), SrttEntry>,
     enabled: bool,
 }
 
@@ -117,9 +113,7 @@ impl SrttCache {
         entry.updated_at = Instant::now();
     }
 
-    /// Sort UDP-context addresses by SRTT ascending (lowest/fastest first).
-    /// Recursive resolution always speaks UDP first to authoritatives, so a
-    /// dedicated UDP helper keeps the call sites free of transport literals.
+    /// Sort by UDP SRTT ascending (lowest/fastest first). No-op when disabled.
     pub fn sort_by_udp_rtt(&self, addrs: &mut [SocketAddr]) {
         if !self.enabled {
             return;
@@ -129,7 +123,7 @@ impl SrttCache {
 
     pub fn heap_bytes(&self) -> usize {
         let per_slot = std::mem::size_of::<u64>()
-            + std::mem::size_of::<SrttKey>()
+            + std::mem::size_of::<(IpAddr, UpstreamTransport)>()
             + std::mem::size_of::<SrttEntry>()
             + 1;
         self.entries.capacity() * per_slot
@@ -148,7 +142,7 @@ impl SrttCache {
             return;
         }
         // Batch eviction: remove the oldest EVICT_BATCH entries at once
-        let mut by_age: Vec<SrttKey> = self.entries.keys().copied().collect();
+        let mut by_age: Vec<_> = self.entries.keys().copied().collect();
         by_age.sort_by_key(|k| self.entries[k].updated_at);
         for k in by_age.into_iter().take(EVICT_BATCH) {
             self.entries.remove(&k);
@@ -198,11 +192,7 @@ mod tests {
 
     #[test]
     fn udp_and_tcp_are_independent() {
-        // A flooded UDP path (5000ms penalty) must not drag down the TCP
-        // EWMA for the same IP. This is the bug the keying refactor fixes:
-        // on UDP-hostile networks (BCP 38), repeated UDP failures used to
-        // poison the shared SRTT entry, causing TCP fallback successes to
-        // re-arm UDP probing every ~3 queries.
+        // UDP penalty must not bleed into the TCP EWMA on the same IP.
         let mut cache = SrttCache::new(true);
         cache.record_failure(ip(1), UDP);
         for _ in 0..20 {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -103,6 +103,7 @@ pub struct ServerStats {
     transport_dot: u64,
     transport_doh: u64,
     upstream_transport_udp: u64,
+    upstream_transport_tcp: u64,
     upstream_transport_doh: u64,
     upstream_transport_dot: u64,
     upstream_transport_odoh: u64,
@@ -142,6 +143,7 @@ impl Transport {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UpstreamTransport {
     Udp,
+    Tcp,
     Doh,
     Dot,
     Odoh,
@@ -151,6 +153,7 @@ impl UpstreamTransport {
     pub fn as_str(&self) -> &'static str {
         match self {
             UpstreamTransport::Udp => "UDP",
+            UpstreamTransport::Tcp => "TCP",
             UpstreamTransport::Doh => "DOH",
             UpstreamTransport::Dot => "DOT",
             UpstreamTransport::Odoh => "ODOH",
@@ -237,6 +240,7 @@ impl ServerStats {
             transport_dot: 0,
             transport_doh: 0,
             upstream_transport_udp: 0,
+            upstream_transport_tcp: 0,
             upstream_transport_doh: 0,
             upstream_transport_dot: 0,
             upstream_transport_odoh: 0,
@@ -276,6 +280,7 @@ impl ServerStats {
         if let Some(ut) = upstream_transport {
             match ut {
                 UpstreamTransport::Udp => self.upstream_transport_udp += 1,
+                UpstreamTransport::Tcp => self.upstream_transport_tcp += 1,
                 UpstreamTransport::Doh => self.upstream_transport_doh += 1,
                 UpstreamTransport::Dot => self.upstream_transport_dot += 1,
                 UpstreamTransport::Odoh => self.upstream_transport_odoh += 1,
@@ -310,6 +315,7 @@ impl ServerStats {
             transport_dot: self.transport_dot,
             transport_doh: self.transport_doh,
             upstream_transport_udp: self.upstream_transport_udp,
+            upstream_transport_tcp: self.upstream_transport_tcp,
             upstream_transport_doh: self.upstream_transport_doh,
             upstream_transport_dot: self.upstream_transport_dot,
             upstream_transport_odoh: self.upstream_transport_odoh,
@@ -328,7 +334,7 @@ impl ServerStats {
         let secs = uptime.as_secs() % 60;
 
         log::info!(
-            "STATS | uptime {}h{}m{}s | total {} | fwd {} | upstream {} | recursive {} | coalesced {} | cached {} | local {} | override {} | blocked {} | errors {} | up-udp {} | up-doh {} | up-dot {} | up-odoh {}",
+            "STATS | uptime {}h{}m{}s | total {} | fwd {} | upstream {} | recursive {} | coalesced {} | cached {} | local {} | override {} | blocked {} | errors {} | up-udp {} | up-tcp {} | up-doh {} | up-dot {} | up-odoh {}",
             hours, mins, secs,
             self.queries_total,
             self.queries_forwarded,
@@ -341,6 +347,7 @@ impl ServerStats {
             self.queries_blocked,
             self.upstream_errors,
             self.upstream_transport_udp,
+            self.upstream_transport_tcp,
             self.upstream_transport_doh,
             self.upstream_transport_dot,
             self.upstream_transport_odoh,
@@ -365,6 +372,7 @@ pub struct StatsSnapshot {
     pub transport_dot: u64,
     pub transport_doh: u64,
     pub upstream_transport_udp: u64,
+    pub upstream_transport_tcp: u64,
     pub upstream_transport_doh: u64,
     pub upstream_transport_dot: u64,
     pub upstream_transport_odoh: u64,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -140,7 +140,7 @@ impl Transport {
 /// `Option<UpstreamTransport>` — `None` for resolutions that never touched
 /// a forwarder (cache/local/blocked) or for recursive mode, which has its
 /// own counter via `QueryPath::Recursive`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum UpstreamTransport {
     Udp,
     Tcp,


### PR DESCRIPTION
## Summary

Carriers running BCP 38-style amplification mitigation drop outbound UDP:53 to non-self resolvers but accept TCP:53. Romanian RDS does this network-wide (verified — `dig +tcp @1.1.1.1 google.com` succeeds, `dig @1.1.1.1 google.com` times out); the same pattern is documented at large fractions of EU and US residential ISPs.

Today's behavior on these networks: numa's default Forward mode silently breaks. Auto-detected upstream is the ISP DNS, transport is UDP:53, every query times out at 5s with SERVFAIL. The user sees ODoH or `mode = "auto"` mentioned in docs and has to write a config file to recover.

This PR makes Forward mode self-heal — no config needed.

## Changes

- New `Upstream::Tcp(SocketAddr)` variant with RFC 1035 §4.2.2 wire-format dispatch (refactored `forward_tcp` to expose a `forward_tcp_raw` mirror of `forward_udp_raw`).
- `parse_upstream` recognizes `tcp://addr[:port]` for users who want to opt into TCP-only.
- Forward-mode upstream construction auto-pairs every UDP primary with a TCP sibling in the fallback list (`serve.rs`). No config required.
- **SRTT cache re-keyed by `(IpAddr, UpstreamTransport)`** so UDP, TCP, and DoT to the same IP get independent EWMAs. Transport-specific failure no longer poisons sibling transports.
- Failover-loop circuit-breaker (`PRIMARY_SKIP_SRTT_MS = 4000`): when a fallback exists, skip primaries whose SRTT is at or above the threshold. With per-transport keying, success on TCP fallback no longer re-arms UDP probing — the UDP timeout is taken at most once per ~5min decay window.
- `UpstreamTransport::Tcp` + `upstream_transport_tcp` counter wired through the snapshot, log line, and API serializer.

## Why this design (and what changed in review)

**First pass** kept SRTT keyed by IP and relied on the circuit-breaker alone. Review caught an oscillation bug: the auto-paired TCP sibling shares the IP, so every TCP success pulled the shared EWMA down via `(5000*7+50)/8 ≈ 4381 → 3840` and re-armed UDP probing roughly every third query — turning the "~one UDP timeout per 5min" claim into "~one timeout per 3 queries" under load.

**Solution architect agreed** the (IP, Transport) keying was the right fix: ~60-80 lines, contained to `srtt.rs` + ~3 caller sites in `forward.rs`/`recursive.rs`. Independent EWMAs make the circuit-breaker correct (skips only the broken transport), and the `TCP_PENALTY_MS` hack disappears (was compensating for the shared key).

DoT keys under its own `Dot` variant — TLS handshake failures stay isolated from plain TCP. DoH/ODoH still skip SRTT (URL + connection pool, no single IP).

## Behavior matrix

| Network | What happens |
|---|---|
| Healthy home/office | UDP wins SRTT race (low RTT), TCP fallback dormant. Same cost as today. |
| RDS-style (UDP:53 blocked, TCP:53 open) | First query: UDP fails → IP+UDP SRTT pinned at 5000. Subsequent queries skip UDP via circuit-breaker, run TCP fallback directly. UDP re-probed only after ~5min decay; TCP successes do **not** re-arm it. |
| Network change (hostile → healthy) | After ~5min decay, UDP SRTT drops below 4000, gets re-probed. If healthy, takes over again. |
| User chose `mode = "forward"` with explicit upstream | Same as above — TCP sibling appended automatically. |
| Forwarding rules (`[[forwarding]]`) | Not auto-paired; explicit `tcp://` available. |

## Bench

Re-ran `recursive_compare --vs-unbound-cold` (recursive mode, unique subdomains — exercises SRTT on every query). 505 samples per server, both running locally:

|  | Numa | Unbound | Δ |
|---|---|---|---|
| mean | 134.9 ms | 175.2 ms | **-23%** |
| median | 82.2 ms | 85.6 ms | -4% |
| p99 | 782.8 ms | 1135.9 ms | **-31%** |

No regression vs the recorded "-28% p99 cold" baseline; refactor preserves Numa's hedging advantage. Bench reproducer: `scripts/bench-vs-unbound.sh --cold`.

## Test plan

- [x] All existing tests pass; new tests added for `tcp://` parsing, `Upstream::Tcp` Display, transport-independent EWMAs (`udp_and_tcp_are_independent`), `sort_by_udp_rtt` ignoring TCP entries, and the failover circuit-breaker (with/without fallback).
- [x] `cargo fmt --check` clean; `cargo clippy --tests` shows no new warnings (5 pre-existing in srtt/recursive/config unrelated).
- [x] Cold recursive bench shows no regression (above).
- [ ] Manual: deploy to Windows host on RDS network, verify queries succeed without `numa.toml`.
- [ ] Integration test against dnsdist with UDP dropped — would close the loop on the hostile-network behavior. Separate follow-up so docker-test setup doesn't block the feature.

## Not in this PR

- RFC 7766 keep-alive pooling for TCP DNS — perf optimization, not correctness.
- TCP fallback for forwarding rules (`[[forwarding]]` blocks) — same auto-pairing logic could apply but scope-creep here.

Draft until reviewed; happy to ship after thumbs-up.