### PR TITLE
fix(windows): recover to DHCP when uninstall can't restore

### DIFF
--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -731,10 +731,7 @@ fn run_loopback_recovery() {
     for action in plan_loopback_recovery(&live) {
         match action.apply() {
             Ok(msg) => eprintln!("  recovery: {}", msg),
-            Err(e) => eprintln!(
-                "  warning: recovery failed for \"{}\": {}",
-                action.name, e
-            ),
+            Err(e) => eprintln!("  warning: recovery failed for \"{}\": {}", action.name, e),
         }
     }
 }
@@ -749,8 +746,7 @@ fn plan_loopback_recovery(
     let synth: std::collections::HashMap<String, WindowsInterfaceDns> = live
         .iter()
         .filter(|(_, iface)| {
-            !iface.servers.is_empty()
-                && iface.servers.iter().all(|s| is_loopback_or_stub(s))
+            !iface.servers.is_empty() && iface.servers.iter().all(|s| is_loopback_or_stub(s))
         })
         .map(|(name, iface)| {
             (

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -717,6 +717,70 @@ fn plan_windows_restore(
     (plans, missing)
 }
 
+/// Run the loopback-DHCP recovery sweep with a freshly-queried live snapshot.
+/// Used by uninstall to ensure no adapter is left stranded at 127.0.0.1 after
+/// the targeted restore can't run or partially fails. Non-fatal: warnings only.
+#[cfg(windows)]
+fn run_loopback_recovery() {
+    let live = match get_windows_interfaces() {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("  warning: could not query adapters for recovery sweep: {}", e);
+            return;
+        }
+    };
+    for action in plan_loopback_recovery(&live) {
+        match action.apply() {
+            Ok(msg) => eprintln!("  recovery: {}", msg),
+            Err(e) => eprintln!(
+                "  warning: recovery failed for \"{}\": {}",
+                action.name, e
+            ),
+        }
+    }
+}
+
+/// Safety net: build "set DHCP" plans for any live adapter currently pointed at
+/// loopback/stub DNS only. Used when a normal restore can't run (no backup) or
+/// failed (netsh error, adapter renamed). Without this, uninstall would leave
+/// the user stranded at 127.0.0.1 with numa already gone — broken internet.
+#[cfg(any(windows, test))]
+fn plan_loopback_recovery(
+    live: &std::collections::HashMap<String, WindowsInterfaceDns>,
+) -> Vec<RestorePlan> {
+    let mut plans = Vec::new();
+    let mut names: Vec<&String> = live.keys().collect();
+    names.sort();
+    for name in names {
+        let iface = &live[name];
+        if iface.servers.is_empty() {
+            continue; // already DHCP
+        }
+        if !iface.servers.iter().all(|s| is_loopback_or_stub(s)) {
+            continue; // has a real upstream — leave alone
+        }
+        let v6_in_use = iface
+            .servers
+            .iter()
+            .any(|s| s.parse::<std::net::Ipv6Addr>().is_ok());
+        plans.push(RestorePlan {
+            name: name.clone(),
+            if_index: iface.if_index,
+            family: AddressFamily::V4,
+            servers: vec![],
+        });
+        if v6_in_use {
+            plans.push(RestorePlan {
+                name: name.clone(),
+                if_index: iface.if_index,
+                family: AddressFamily::V6,
+                servers: vec![],
+            });
+        }
+    }
+    plans
+}
+
 /// Capture pre-numa DNS state for `uninstall` to restore. Returns `Ok(true)`
 /// when a fresh backup was written; `Ok(false)` when an existing useful
 /// backup was preserved (re-install on numa-managed state).
@@ -1140,9 +1204,11 @@ fn uninstall_windows() -> Result<(), String> {
     let json = match std::fs::read_to_string(&path) {
         Ok(j) => j,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // Install was --no-system-dns (or backup never written): there
-            // is nothing to restore. Still re-enable Dnscache so the host
-            // is back to a stock configuration.
+            // Install was --no-system-dns (or backup never written / deleted):
+            // no targeted restore is possible. But adapters may still point at
+            // 127.0.0.1 from a prior install — force them back to DHCP so the
+            // user isn't left without internet.
+            run_loopback_recovery();
             enable_dnscache();
             eprintln!("  No system DNS backup found — system DNS was not managed by numa.");
             eprintln!("  DNS Client re-enabled. Reboot to fully restore the DNS Client service.\n");
@@ -1174,6 +1240,14 @@ fn uninstall_windows() -> Result<(), String> {
                 apply_failed = true;
             }
         }
+    }
+
+    // Safety net for the failure cases: if the targeted restore left any
+    // adapter still pointed at loopback (netsh failure, or live adapter not
+    // present in the backup), force those to DHCP so internet isn't broken.
+    // Re-query live state so we don't fight the apply loop above.
+    if apply_failed || !skipped.is_empty() {
+        run_loopback_recovery();
     }
 
     // Keep the backup if anything went wrong — adapter offline (re-runnable
@@ -2604,6 +2678,76 @@ mod tests {
                 ],
                 vec![],
             ),
+        );
+    }
+
+    #[test]
+    fn loopback_recovery_emits_dhcp_for_loopback_only_adapters() {
+        let mut live = std::collections::HashMap::new();
+        live.insert("Wi-Fi".into(), iface(12, &["127.0.0.1"]));
+
+        assert_eq!(
+            plan_loopback_recovery(&live),
+            vec![plan("Wi-Fi", 12, AddressFamily::V4, &[])],
+        );
+    }
+
+    #[test]
+    fn loopback_recovery_skips_adapters_with_real_upstream() {
+        let mut live = std::collections::HashMap::new();
+        live.insert("Wi-Fi".into(), iface(12, &["127.0.0.1", "8.8.8.8"]));
+
+        assert_eq!(plan_loopback_recovery(&live), vec![]);
+    }
+
+    #[test]
+    fn loopback_recovery_skips_already_dhcp_adapters() {
+        let mut live = std::collections::HashMap::new();
+        live.insert("Wi-Fi".into(), iface(12, &[]));
+
+        assert_eq!(plan_loopback_recovery(&live), vec![]);
+    }
+
+    #[test]
+    fn loopback_recovery_emits_v6_when_v6_loopback_present() {
+        let mut live = std::collections::HashMap::new();
+        live.insert("Wi-Fi".into(), iface(12, &["127.0.0.1", "::1"]));
+
+        assert_eq!(
+            plan_loopback_recovery(&live),
+            vec![
+                plan("Wi-Fi", 12, AddressFamily::V4, &[]),
+                plan("Wi-Fi", 12, AddressFamily::V6, &[]),
+            ],
+        );
+    }
+
+    #[test]
+    fn loopback_recovery_skips_v6_when_only_v4_loopback() {
+        let mut live = std::collections::HashMap::new();
+        live.insert("Wi-Fi".into(), iface(12, &["127.0.0.1"]));
+
+        // No v6 plan — v6 stack on the adapter may be disabled, and
+        // `netsh interface ipv6 set ... dhcp` would error in that case.
+        assert_eq!(
+            plan_loopback_recovery(&live),
+            vec![plan("Wi-Fi", 12, AddressFamily::V4, &[])],
+        );
+    }
+
+    #[test]
+    fn loopback_recovery_handles_multiple_adapters_sorted() {
+        let mut live = std::collections::HashMap::new();
+        live.insert("Wi-Fi".into(), iface(12, &["127.0.0.1"]));
+        live.insert("Ethernet".into(), iface(8, &["127.0.0.1"]));
+        live.insert("Tailscale".into(), iface(20, &["100.100.100.100"]));
+
+        assert_eq!(
+            plan_loopback_recovery(&live),
+            vec![
+                plan("Ethernet", 8, AddressFamily::V4, &[]),
+                plan("Wi-Fi", 12, AddressFamily::V4, &[]),
+            ],
         );
     }
 

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -717,15 +717,14 @@ fn plan_windows_restore(
     (plans, missing)
 }
 
-/// Run the loopback-DHCP recovery sweep with a freshly-queried live snapshot.
-/// Used by uninstall to ensure no adapter is left stranded at 127.0.0.1 after
-/// the targeted restore can't run or partially fails. Non-fatal: warnings only.
+/// Force any live adapter stranded at loopback/stub DNS back to DHCP. Safety
+/// net for uninstall paths that can't run a targeted restore.
 #[cfg(windows)]
 fn run_loopback_recovery() {
     let live = match get_windows_interfaces() {
         Ok(l) => l,
         Err(e) => {
-            eprintln!("  warning: could not query adapters for recovery sweep: {}", e);
+            eprintln!("  warning: could not query adapters for recovery: {}", e);
             return;
         }
     };
@@ -740,45 +739,30 @@ fn run_loopback_recovery() {
     }
 }
 
-/// Safety net: build "set DHCP" plans for any live adapter currently pointed at
-/// loopback/stub DNS only. Used when a normal restore can't run (no backup) or
-/// failed (netsh error, adapter renamed). Without this, uninstall would leave
-/// the user stranded at 127.0.0.1 with numa already gone — broken internet.
+/// Build DHCP plans for live adapters whose DNS is loopback/stub only.
+/// Synthesises a "backup" of loopback servers so `plan_windows_restore`'s
+/// loopback filter strips everything → empty-servers plans → DHCP via apply().
 #[cfg(any(windows, test))]
 fn plan_loopback_recovery(
     live: &std::collections::HashMap<String, WindowsInterfaceDns>,
 ) -> Vec<RestorePlan> {
-    let mut plans = Vec::new();
-    let mut names: Vec<&String> = live.keys().collect();
-    names.sort();
-    for name in names {
-        let iface = &live[name];
-        if iface.servers.is_empty() {
-            continue; // already DHCP
-        }
-        if !iface.servers.iter().all(|s| is_loopback_or_stub(s)) {
-            continue; // has a real upstream — leave alone
-        }
-        let v6_in_use = iface
-            .servers
-            .iter()
-            .any(|s| s.parse::<std::net::Ipv6Addr>().is_ok());
-        plans.push(RestorePlan {
-            name: name.clone(),
-            if_index: iface.if_index,
-            family: AddressFamily::V4,
-            servers: vec![],
-        });
-        if v6_in_use {
-            plans.push(RestorePlan {
-                name: name.clone(),
-                if_index: iface.if_index,
-                family: AddressFamily::V6,
-                servers: vec![],
-            });
-        }
-    }
-    plans
+    let synth: std::collections::HashMap<String, WindowsInterfaceDns> = live
+        .iter()
+        .filter(|(_, iface)| {
+            !iface.servers.is_empty()
+                && iface.servers.iter().all(|s| is_loopback_or_stub(s))
+        })
+        .map(|(name, iface)| {
+            (
+                name.clone(),
+                WindowsInterfaceDns {
+                    if_index: 0,
+                    servers: iface.servers.clone(),
+                },
+            )
+        })
+        .collect();
+    plan_windows_restore(&synth, live).0
 }
 
 /// Capture pre-numa DNS state for `uninstall` to restore. Returns `Ok(true)`
@@ -1204,10 +1188,7 @@ fn uninstall_windows() -> Result<(), String> {
     let json = match std::fs::read_to_string(&path) {
         Ok(j) => j,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // Install was --no-system-dns (or backup never written / deleted):
-            // no targeted restore is possible. But adapters may still point at
-            // 127.0.0.1 from a prior install — force them back to DHCP so the
-            // user isn't left without internet.
+            // No backup — sweep any adapters still on loopback back to DHCP.
             run_loopback_recovery();
             enable_dnscache();
             eprintln!("  No system DNS backup found — system DNS was not managed by numa.");
@@ -1242,10 +1223,7 @@ fn uninstall_windows() -> Result<(), String> {
         }
     }
 
-    // Safety net for the failure cases: if the targeted restore left any
-    // adapter still pointed at loopback (netsh failure, or live adapter not
-    // present in the backup), force those to DHCP so internet isn't broken.
-    // Re-query live state so we don't fight the apply loop above.
+    // Re-queries live state so we don't fight successful applies above.
     if apply_failed || !skipped.is_empty() {
         run_loopback_recovery();
     }


### PR DESCRIPTION
## Summary

`numa uninstall` on Windows could leave adapters pinned at `127.0.0.1` with numa already gone — bricking internet — in three cases:

1. **Backup file missing** at `C:\ProgramData\numa\original-dns.json` (install was `--no-system-dns`, file deleted, install crashed before writing it). The early-return path re-enabled Dnscache but never touched netsh, so the install-time `set dnsservers static 127.0.0.1` stayed in effect.
2. **`netsh` failure during the targeted restore loop.** The user saw a *"Partial restore"* warning but DNS was left at `127.0.0.1`.
3. **Adapter renamed between install and uninstall.** The backup's friendly-name key missed; the adapter went into `skipped`; the live adapter (still pointing at `127.0.0.1`) was never touched.

Adds a defensive recovery sweep that queries live adapters and forces any whose configured DNS is loopback/stub-only back to DHCP. Runs in the missing-backup branch and after the main apply loop on any failure or skip. Re-queries live state in the sweep so it doesn't fight successful restores from the apply loop.

## Design

- `plan_loopback_recovery(&live) -> Vec<RestorePlan>` — pure planner, `cfg(any(windows, test))`, unit-tested on macOS.
- `run_loopback_recovery()` — `cfg(windows)`, runs the planner against a fresh `get_windows_interfaces()` snapshot and applies the resulting plans.
- Wired into `uninstall_windows` at two points: the `NotFound` branch (before re-enabling Dnscache), and after the main apply loop when `apply_failed || !skipped.is_empty()`.

Empty `servers` on a `RestorePlan` already routes through `apply_dhcp` via the existing `RestorePlan::apply` (from #196), so no new netsh wrapper is needed.

## Test plan

- [x] `cargo check --all-targets` clean on macOS
- [x] 6 new `loopback_recovery_*` unit tests pass (loopback-only, real-upstream-present, already-DHCP, v6-paired, v4-only, multi-adapter sorted)
- [x] Full lib suite: **412 passed**
- [ ] Windows CI verifies the `cfg(windows)` paths compile
- [ ] Manual on Windows — three repros:
  - [ ] Install + delete `original-dns.json` + uninstall → adapter resets to DHCP
  - [ ] Install + rename adapter (or simulate netsh failure) + uninstall → recovery sweep restores DHCP
  - [ ] Install + uninstall (happy path) → no recovery sweep runs, no spurious DHCP messages

Pairs naturally with #196 (`RestorePlan::apply`) — the sweep reuses the empty-servers → DHCP path that #196 cleaned up.