### PR TITLE
fix(proxy-tld): NXDOMAIN for unknown names; native v6 for v6-only peers

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -296,7 +296,10 @@ fn resolve_local(
     None
 }
 
-/// Resolve .numa: remote clients get LAN IP (can't reach 127.0.0.1), local get loopback.
+/// Resolve `.numa` queries:
+///   - locally-registered service → loopback (local client) or LAN IP (remote)
+///   - LAN peer learned via discovery → that peer's actual IP (v4 or v6 native)
+///   - unknown name → NXDOMAIN (never silently sinkhole to loopback)
 fn resolve_proxy_tld(
     query: &DnsPacket,
     src_addr: SocketAddr,
@@ -306,33 +309,58 @@ fn resolve_proxy_tld(
 ) -> (DnsPacket, QueryPath, DnssecStatus) {
     let service_name = qname.strip_suffix(&ctx.proxy_tld_suffix).unwrap_or(qname);
     let is_remote = !src_addr.ip().is_loopback();
-    let resolve_ip = {
-        let local = ctx.services.lock().unwrap();
-        if local.lookup(service_name).is_some() {
-            if is_remote {
-                *ctx.lan_ip.lock().unwrap()
-            } else {
-                std::net::Ipv4Addr::LOCALHOST
-            }
+
+    // Locally-registered service → loopback (local) or our LAN IP (remote).
+    if ctx.services.lock().unwrap().lookup(service_name).is_some() {
+        let v4 = if is_remote {
+            *ctx.lan_ip.lock().unwrap()
         } else {
-            let mut peers = ctx.lan_peers.lock().unwrap();
-            peers
-                .lookup(service_name)
-                .and_then(|(ip, _)| match ip {
-                    std::net::IpAddr::V4(v4) => Some(v4),
-                    _ => None,
-                })
-                .unwrap_or(std::net::Ipv4Addr::LOCALHOST)
+            std::net::Ipv4Addr::LOCALHOST
+        };
+        let v6 = if v4 == std::net::Ipv4Addr::LOCALHOST {
+            std::net::Ipv6Addr::LOCALHOST
+        } else {
+            v4.to_ipv6_mapped()
+        };
+        let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
+        resp.answers
+            .push(sinkhole_record(qname, qtype, v4, v6, 300));
+        return (resp, QueryPath::Local, DnssecStatus::Indeterminate);
+    }
+
+    // LAN peer learned via discovery → return its actual address natively.
+    if let Some((ip, _)) = ctx.lan_peers.lock().unwrap().lookup(service_name) {
+        let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
+        match (qtype, ip) {
+            (QueryType::AAAA, std::net::IpAddr::V6(v6)) => {
+                resp.answers.push(DnsRecord::AAAA {
+                    domain: qname.to_string(),
+                    addr: v6,
+                    ttl: 300,
+                });
+            }
+            (QueryType::AAAA, std::net::IpAddr::V4(v4)) => {
+                resp.answers.push(DnsRecord::AAAA {
+                    domain: qname.to_string(),
+                    addr: v4.to_ipv6_mapped(),
+                    ttl: 300,
+                });
+            }
+            (_, std::net::IpAddr::V4(v4)) => {
+                resp.answers.push(DnsRecord::A {
+                    domain: qname.to_string(),
+                    addr: v4,
+                    ttl: 300,
+                });
+            }
+            // A/other-qtype query on a v6-only peer → NODATA (NOERROR, empty).
+            (_, std::net::IpAddr::V6(_)) => {}
         }
-    };
-    let v6 = if resolve_ip == std::net::Ipv4Addr::LOCALHOST {
-        std::net::Ipv6Addr::LOCALHOST
-    } else {
-        resolve_ip.to_ipv6_mapped()
-    };
-    let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
-    resp.answers
-        .push(sinkhole_record(qname, qtype, resolve_ip, v6, 300));
+        return (resp, QueryPath::Local, DnssecStatus::Indeterminate);
+    }
+
+    // Unknown name in the proxy TLD → NXDOMAIN.
+    let resp = DnsPacket::response_from(query, ResultCode::NXDOMAIN);
     (resp, QueryPath::Local, DnssecStatus::Indeterminate)
 }
 
@@ -778,7 +806,7 @@ fn special_use_response(query: &DnsPacket, qname: &str, qtype: QueryType) -> Dns
 mod tests {
     use super::*;
     use std::collections::HashMap;
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
     use std::sync::{Arc, Mutex};
     use tokio::sync::broadcast;
 
@@ -1304,6 +1332,80 @@ mod tests {
             DnsRecord::A { addr, .. } => assert_eq!(*addr, Ipv4Addr::LOCALHOST),
             other => panic!("expected A record, got {:?}", other),
         }
+    }
+
+    /// Unknown name in the proxy TLD must NXDOMAIN, not silently return
+    /// loopback. Returning loopback for unknown `.numa` names is a footgun:
+    /// typo'd hostnames and stale references end up routing to the resolver
+    /// host instead of failing fast.
+    #[tokio::test]
+    async fn pipeline_tld_proxy_unknown_returns_nxdomain() {
+        let ctx = Arc::new(crate::testutil::test_ctx().await);
+
+        let (resp_a, path_a) = resolve_in_test(&ctx, "no-such-service.numa", QueryType::A).await;
+        assert_eq!(path_a, QueryPath::Local);
+        assert_eq!(resp_a.header.rescode, ResultCode::NXDOMAIN);
+        assert!(resp_a.answers.is_empty());
+
+        let (resp_aaaa, path_aaaa) =
+            resolve_in_test(&ctx, "no-such-service.numa", QueryType::AAAA).await;
+        assert_eq!(path_aaaa, QueryPath::Local);
+        assert_eq!(resp_aaaa.header.rescode, ResultCode::NXDOMAIN);
+        assert!(resp_aaaa.answers.is_empty());
+    }
+
+    /// LAN peer with an IPv4 address: A → native v4, AAAA → v4-mapped v6.
+    #[tokio::test]
+    async fn pipeline_tld_proxy_v4_peer_returns_native_a_and_mapped_aaaa() {
+        let ctx = crate::testutil::test_ctx().await;
+        ctx.lan_peers
+            .lock()
+            .unwrap()
+            .update("10.0.0.5".parse().unwrap(), &[("kiosk".into(), 8080)]);
+        let ctx = Arc::new(ctx);
+
+        let (resp_a, _) = resolve_in_test(&ctx, "kiosk.numa", QueryType::A).await;
+        assert_eq!(resp_a.header.rescode, ResultCode::NOERROR);
+        match &resp_a.answers[0] {
+            DnsRecord::A { addr, .. } => assert_eq!(*addr, Ipv4Addr::new(10, 0, 0, 5)),
+            other => panic!("expected A record, got {:?}", other),
+        }
+
+        let (resp_aaaa, _) = resolve_in_test(&ctx, "kiosk.numa", QueryType::AAAA).await;
+        assert_eq!(resp_aaaa.header.rescode, ResultCode::NOERROR);
+        match &resp_aaaa.answers[0] {
+            DnsRecord::AAAA { addr, .. } => {
+                assert_eq!(*addr, Ipv4Addr::new(10, 0, 0, 5).to_ipv6_mapped())
+            }
+            other => panic!("expected AAAA record, got {:?}", other),
+        }
+    }
+
+    /// LAN peer with only an IPv6 address: AAAA → native v6, A → NODATA
+    /// (NOERROR with empty answer section, *not* loopback).
+    #[tokio::test]
+    async fn pipeline_tld_proxy_v6_only_peer_native_aaaa_nodata_a() {
+        let v6: Ipv6Addr = "2001:db8::42".parse().unwrap();
+        let ctx = crate::testutil::test_ctx().await;
+        ctx.lan_peers
+            .lock()
+            .unwrap()
+            .update(v6.into(), &[("ipv6host".into(), 22)]);
+        let ctx = Arc::new(ctx);
+
+        let (resp_aaaa, _) = resolve_in_test(&ctx, "ipv6host.numa", QueryType::AAAA).await;
+        assert_eq!(resp_aaaa.header.rescode, ResultCode::NOERROR);
+        match &resp_aaaa.answers[0] {
+            DnsRecord::AAAA { addr, .. } => assert_eq!(*addr, v6),
+            other => panic!("expected AAAA record, got {:?}", other),
+        }
+
+        let (resp_a, _) = resolve_in_test(&ctx, "ipv6host.numa", QueryType::A).await;
+        assert_eq!(resp_a.header.rescode, ResultCode::NOERROR);
+        assert!(
+            resp_a.answers.is_empty(),
+            "v6-only peer + A query must be NODATA, not loopback"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- `resolve_proxy_tld` silently sinkholed any unknown `.numa` name to `127.0.0.1` / `::1`. Typos, stale references, and queries like `pi0.local.numa` (libc appending the `search numa` line) all resolved to the resolver host instead of failing fast. Now returns **NXDOMAIN**.
- IPv6-only LAN peers were unreachable via the proxy TLD: the peer-lookup arm dropped `IpAddr::V6` and fell through to the loopback default. Now: v6 peers return native AAAA; A queries on v6-only peers answer NODATA (NOERROR + empty) per RFC 2308.
- v4 peers continue to return native A; AAAA on a v4 peer returns the v4-mapped form. The local-service path (loopback vs LAN IP based on `is_remote`) is unchanged.

## Test plan

- [x] `cargo test --lib` — 409 unit tests pass (including 3 new ones below)
- [x] `cargo fmt --check`, `cargo check`, `cargo audit` via `make all` — all green
- [x] New tests in `src/ctx.rs`:
  - `pipeline_tld_proxy_unknown_returns_nxdomain` — codifies the bug (NXDOMAIN, not loopback) for both A and AAAA
  - `pipeline_tld_proxy_v4_peer_returns_native_a_and_mapped_aaaa`
  - `pipeline_tld_proxy_v6_only_peer_native_aaaa_nodata_a`
- [x] Live repro on Pi running 0.15.1: `getent ahosts garbage.numa` → returned `127.0.0.1` / `::1` before; will NXDOMAIN after rebuild.
- [x] Existing `pipeline_tld_proxy_resolves_service` still passes (no regression on the local-service path).