### PR TITLE
fix(cli): share default config path with the service (#202)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,11 +144,10 @@ fn config_dir_unix() -> std::path::PathBuf {
     daemon_data_dir()
 }
 
-/// Default config path the CLI reads/writes for toggles like `numa lan on`
-/// and the daemon loads when no path is passed. On Windows this matches the
-/// path SCM uses, so toggling from any directory updates the file the
-/// service actually reads (issue #202). On Unix it stays CWD-relative —
-/// systemd/launchd run the daemon with a known WorkingDirectory.
+/// Default config path for CLI toggles (`numa lan on`, etc.) and the
+/// Windows service entry. On Windows this matches the SCM's data dir
+/// so toggles update the file the service reads (issue #202). Unix
+/// callers still use the CWD-relative literal `"numa.toml"`.
 pub fn cli_config_path() -> String {
     #[cfg(windows)]
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,22 @@ fn config_dir_unix() -> std::path::PathBuf {
     daemon_data_dir()
 }
 
+/// Default config path the CLI reads/writes for toggles like `numa lan on`
+/// and the daemon loads when no path is passed. On Windows this matches the
+/// path SCM uses, so toggling from any directory updates the file the
+/// service actually reads (issue #202). On Unix it stays CWD-relative —
+/// systemd/launchd run the daemon with a known WorkingDirectory.
+pub fn cli_config_path() -> String {
+    #[cfg(windows)]
+    {
+        data_dir().join("numa.toml").to_string_lossy().into_owned()
+    }
+    #[cfg(not(windows))]
+    {
+        "numa.toml".to_string()
+    }
+}
+
 /// Default system-wide data directory for TLS certs. Overridable via
 /// `[server] data_dir = "..."` in numa.toml — this function only provides
 /// the fallback when the config doesn't set it.

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ fn main() -> numa::Result<()> {
             let sub = std::env::args().nth(2).unwrap_or_default();
             let config_path = std::env::args()
                 .nth(3)
-                .unwrap_or_else(|| "numa.toml".to_string());
+                .unwrap_or_else(numa::cli_config_path);
             let enabled = match sub.as_str() {
                 "on" => true,
                 "off" => false,
@@ -134,9 +134,9 @@ fn main() -> numa::Result<()> {
             eprintln!("  service stop    Uninstall the system service");
             eprintln!("  service restart Restart the service with updated binary");
             eprintln!("  service status  Check if the service is running");
-            trace_usage("  lan on|off      Enable/disable LAN service discovery (mDNS)");
-            trace_usage("  block on|off    Enable/disable ad-blocking");
-            trace_usage("  dnssec on|off   Enable/disable DNSSEC validation");
+            eprintln!("  lan on|off      Enable/disable LAN service discovery (mDNS)");
+            eprintln!("  block on|off    Enable/disable ad-blocking");
+            eprintln!("  dnssec on|off   Enable/disable DNSSEC validation");
             eprintln!("  relay [PORT] [BIND]");
             eprintln!("                  Run as an ODoH relay (RFC 9230, default 127.0.0.1:8443)");
             eprintln!("  setup-phone     Generate a QR code to install Numa DoT on a phone");
@@ -186,8 +186,13 @@ fn set_config_bool(
     let contents = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            if let Some(parent) = std::path::Path::new(path).parent() {
+                if !parent.as_os_str().is_empty() {
+                    std::fs::create_dir_all(parent)?;
+                }
+            }
             std::fs::write(path, format!("[{}]\n{} = {}\n", section, key, value))?;
-            print_toggle_status(feature_name, value);
+            print_toggle_status(feature_name, value, path);
             return Ok(());
         }
         Err(e) => return Err(e.into()),
@@ -195,7 +200,7 @@ fn set_config_bool(
 
     let result = update_config_content(&contents, section, key, value);
     std::fs::write(path, result)?;
-    print_toggle_status(feature_name, value);
+    print_toggle_status(feature_name, value, path);
     Ok(())
 }
 
@@ -242,20 +247,20 @@ fn update_config_content(contents: &str, section: &str, key: &str, value: bool) 
     result
 }
 
-fn print_toggle_status(feature: &str, enabled: bool) {
+fn print_toggle_status(feature: &str, enabled: bool, path: &str) {
     let label = if enabled { "enabled" } else { "disabled" };
     let color = if enabled { "32" } else { "33" };
     eprintln!(
         "\x1b[1;38;2;192;98;58mNuma\x1b[0m — {} \x1b[{}m{}\x1b[0m",
         feature, color, label
     );
+    let display = std::fs::canonicalize(path)
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| path.to_string());
+    eprintln!("  Wrote {}", display);
     if enabled {
         eprintln!("  Restart Numa for changes to take effect");
     }
-}
-
-fn trace_usage(msg: &str) {
-    eprintln!("{}", msg);
 }
 
 #[cfg(test)]
@@ -264,8 +269,9 @@ mod tests {
 
     #[test]
     fn test_update_config_content() {
-        let input = "[dnssec]\nstrict = true\n\n[lan]\nenabled = false\n\n[blocking]\nrefresh_hours = 24\n";
-        
+        let input =
+            "[dnssec]\nstrict = true\n\n[lan]\nenabled = false\n\n[blocking]\nrefresh_hours = 24\n";
+
         let output = update_config_content(input, "lan", "enabled", true);
         assert!(output.contains("[lan]\nenabled = true"));
         assert!(output.contains("[dnssec]"));
@@ -280,10 +286,12 @@ mod tests {
     }
 
     #[test]
-    fn test_update_config_out_of_order() {
-        let input = "[lan]\nfoo = 1\n\n[blocking]\nenabled = false\n\n[lan]\nenabled = false\n";
+    fn test_update_config_inserts_into_existing_later_section() {
+        // [blocking] appears before [lan]; [lan] exists but lacks `enabled`.
+        // The new key should land inside [lan], not at EOF or inside [blocking].
+        let input = "[blocking]\nenabled = false\n\n[lan]\nfoo = 1\n";
         let output = update_config_content(input, "lan", "enabled", true);
-        assert!(output.contains("[lan]\nenabled = true"));
+        assert!(output.contains("[lan]\nenabled = true\nfoo = 1"));
         assert!(output.contains("[blocking]\nenabled = false"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,10 +186,11 @@ fn set_config_bool(
     let contents = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            if let Some(parent) = std::path::Path::new(path).parent() {
-                if !parent.as_os_str().is_empty() {
-                    std::fs::create_dir_all(parent)?;
-                }
+            if let Some(parent) = std::path::Path::new(path)
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+            {
+                std::fs::create_dir_all(parent)?;
             }
             std::fs::write(path, format!("[{}]\n{} = {}\n", section, key, value))?;
             print_toggle_status(feature_name, value, path);
@@ -254,10 +255,7 @@ fn print_toggle_status(feature: &str, enabled: bool, path: &str) {
         "\x1b[1;38;2;192;98;58mNuma\x1b[0m — {} \x1b[{}m{}\x1b[0m",
         feature, color, label
     );
-    let display = std::fs::canonicalize(path)
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|_| path.to_string());
-    eprintln!("  Wrote {}", display);
+    eprintln!("  Wrote {}", path);
     if enabled {
         eprintln!("  Restart Numa for changes to take effect");
     }
@@ -287,8 +285,7 @@ mod tests {
 
     #[test]
     fn test_update_config_inserts_into_existing_later_section() {
-        // [blocking] appears before [lan]; [lan] exists but lacks `enabled`.
-        // The new key should land inside [lan], not at EOF or inside [blocking].
+        // New key must land inside [lan], not at EOF or inside [blocking].
         let input = "[blocking]\nenabled = false\n\n[lan]\nfoo = 1\n";
         let output = update_config_content(input, "lan", "enabled", true);
         assert!(output.contains("[lan]\nenabled = true\nfoo = 1"));

--- a/src/windows_service.rs
+++ b/src/windows_service.rs
@@ -61,7 +61,7 @@ fn run_service() -> windows_service::Result<()> {
     // dedicated thread runs the runtime so this function can return cleanly
     // once the SCM tells us to stop — we can't block the dispatcher thread
     // forever without preventing graceful shutdown.
-    let config_path = service_config_path();
+    let config_path = crate::cli_config_path();
     let (server_done_tx, server_done_rx) = mpsc::channel::<()>();
 
     let server_thread = std::thread::spawn(move || {
@@ -117,14 +117,4 @@ fn run_service() -> windows_service::Result<()> {
 /// will hang here waiting for an SCM that isn't talking to them.
 pub fn run_as_service() -> windows_service::Result<()> {
     service_dispatcher::start(SERVICE_NAME, ffi_service_main)
-}
-
-/// Path to the config file used when running under SCM. SCM launches the
-/// service with SYSTEM's working directory (usually `C:\Windows\System32`),
-/// so a relative `numa.toml` lookup won't find anything meaningful.
-fn service_config_path() -> String {
-    crate::data_dir()
-        .join("numa.toml")
-        .to_string_lossy()
-        .into_owned()
 }


### PR DESCRIPTION
On Windows, `numa lan|block|dnssec on` silently wrote to a CWD-relative `numa.toml` while the SCM service kept reading `%PROGRAMDATA%\numa\numa.toml` — the toggle reported success but the service never saw the change. Repro in #202.

This PR routes the CLI default through a new `cli_config_path()` in `lib.rs` that returns the same path the service reads on Windows (`%PROGRAMDATA%\numa\numa.toml`) and the existing CWD-relative `numa.toml` on Unix. `windows_service.rs` drops its local `service_config_path()` helper and uses the shared function, so the two paths can no longer drift.

Also picks up two review items from #187 that landed in main with the merge:

- drop the `trace_usage(...)` shim — plain `eprintln!` reads the same
- rewrite `test_update_config_out_of_order` — the previous input had two `[lan]` sections (invalid TOML). The replacement uses `[blocking]` before `[lan]` with the key missing, exercising the real "insert-into-existing-later-section" path.

Small UX add: print the absolute path that was just written (`Wrote C:\ProgramData\numa\numa.toml`), and `create_dir_all` the parent so a brand-new install can write the file on first toggle.

Closes #202.