### PR TITLE
fix(packet): reject reserved label-length bits (#142)

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -5,6 +5,7 @@ const BUF_SIZE: usize = 4096;
 pub struct BytePacketBuffer {
     pub buf: [u8; BUF_SIZE],
     pub pos: usize,
+    overflow: bool,
 }
 
 impl Default for BytePacketBuffer {
@@ -18,6 +19,7 @@ impl BytePacketBuffer {
         BytePacketBuffer {
             buf: [0; BUF_SIZE],
             pos: 0,
+            overflow: false,
         }
     }
 
@@ -34,6 +36,12 @@ impl BytePacketBuffer {
 
     pub fn filled(&self) -> &[u8] {
         &self.buf[..self.pos]
+    }
+
+    /// True iff a `write*` errored because the buffer was full (vs. input
+    /// rejection by write_qname). Only the former is a legit TC fallback (#142).
+    pub fn overflowed(&self) -> bool {
+        self.overflow
     }
 
     pub fn step(&mut self, steps: usize) -> Result<()> {
@@ -115,6 +123,11 @@ impl BytePacketBuffer {
                 jumped = true;
                 jumps_performed += 1;
                 continue;
+            } else if (len & 0xC0) != 0 {
+                // RFC 1035 §4.1.4: 01/10 are reserved. Refuse rather than
+                // consume up to 191 bytes of garbage (e.g. a pointer landing
+                // mid-label, as observed against Tailscale MagicDNS, #142).
+                return Err(format!("Reserved label length bits: 0x{:02x}", len).into());
             } else {
                 pos += 1;
 
@@ -154,6 +167,7 @@ impl BytePacketBuffer {
 
     pub fn write(&mut self, val: u8) -> Result<()> {
         if self.pos >= BUF_SIZE {
+            self.overflow = true;
             return Err("End of buffer".into());
         }
         self.buf[self.pos] = val;
@@ -251,6 +265,7 @@ impl BytePacketBuffer {
     pub fn write_bytes(&mut self, data: &[u8]) -> Result<()> {
         let end = self.pos + data.len();
         if end > BUF_SIZE {
+            self.overflow = true;
             return Err("End of buffer".into());
         }
         self.buf[self.pos..end].copy_from_slice(data);
@@ -427,5 +442,30 @@ mod tests {
         b.write_qname(".").unwrap();
         assert_eq!(&a.buf[..a.pos], b"\x00");
         assert_eq!(&b.buf[..b.pos], b"\x00");
+    }
+
+    fn assert_read_qname_err(wire: &[u8], start: usize) {
+        let mut buf = BytePacketBuffer::from_bytes(wire);
+        buf.seek(start).unwrap();
+        let mut out = String::new();
+        assert!(buf.read_qname(&mut out).is_err(), "got Ok({:?})", out);
+    }
+
+    #[test]
+    fn read_qname_rejects_reserved_label_high_bits() {
+        // RFC 1035 §4.1.4: 01/10 are reserved (only 00 = label, 11 = pointer).
+        let mut wire = vec![0x80];
+        wire.extend(std::iter::repeat_n(b'a', 128));
+        wire.push(0);
+        assert_read_qname_err(&wire, 0);
+    }
+
+    #[test]
+    fn read_qname_rejects_pointer_landing_mid_label() {
+        // [3]foo[0]<c0 02> — pointer jumps to offset 2 ('o' = 0x6f), whose
+        // reserved bits trip the guard. Mid-label landings on bytes < 0x40
+        // still slip through — best-effort, not full structural validation.
+        // Observed against Tailscale MagicDNS (#142).
+        assert_read_qname_err(b"\x03foo\x00\xc0\x02", 5);
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -38,8 +38,7 @@ impl BytePacketBuffer {
         &self.buf[..self.pos]
     }
 
-    /// True iff a `write*` errored because the buffer was full (vs. input
-    /// rejection by write_qname). Only the former is a legit TC fallback (#142).
+    /// True iff a `write*` errored because the buffer was full (#142).
     pub fn overflowed(&self) -> bool {
         self.overflow
     }
@@ -444,28 +443,22 @@ mod tests {
         assert_eq!(&b.buf[..b.pos], b"\x00");
     }
 
-    fn assert_read_qname_err(wire: &[u8], start: usize) {
-        let mut buf = BytePacketBuffer::from_bytes(wire);
-        buf.seek(start).unwrap();
-        let mut out = String::new();
-        assert!(buf.read_qname(&mut out).is_err(), "got Ok({:?})", out);
-    }
-
     #[test]
     fn read_qname_rejects_reserved_label_high_bits() {
         // RFC 1035 §4.1.4: 01/10 are reserved (only 00 = label, 11 = pointer).
         let mut wire = vec![0x80];
         wire.extend(std::iter::repeat_n(b'a', 128));
         wire.push(0);
-        assert_read_qname_err(&wire, 0);
+        let mut buf = BytePacketBuffer::from_bytes(&wire);
+        assert!(buf.read_qname(&mut String::new()).is_err());
     }
 
     #[test]
     fn read_qname_rejects_pointer_landing_mid_label() {
         // [3]foo[0]<c0 02> — pointer jumps to offset 2 ('o' = 0x6f), whose
-        // reserved bits trip the guard. Mid-label landings on bytes < 0x40
-        // still slip through — best-effort, not full structural validation.
-        // Observed against Tailscale MagicDNS (#142).
-        assert_read_qname_err(b"\x03foo\x00\xc0\x02", 5);
+        // reserved bits trip the guard. Observed against Tailscale MagicDNS (#142).
+        let mut buf = BytePacketBuffer::from_bytes(b"\x03foo\x00\xc0\x02");
+        buf.seek(5).unwrap();
+        assert!(buf.read_qname(&mut String::new()).is_err());
     }
 }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -194,18 +194,9 @@ pub async fn resolve_query(
         response.resources.len(),
     );
 
-    // Serialize response
     // TODO: TC bit is UDP-specific; DoT connections could carry up to 65535 bytes.
     // Once BytePacketBuffer supports larger buffers, skip truncation for TCP/TLS.
-    let mut resp_buffer = BytePacketBuffer::new();
-    if response.write(&mut resp_buffer).is_err() {
-        // Response too large — set TC bit and send header + question only
-        debug!("response too large, setting TC bit for {}", qname);
-        let mut tc_response = DnsPacket::response_from(&query, response.header.rescode);
-        tc_response.header.truncated_message = true;
-        resp_buffer = BytePacketBuffer::new();
-        tc_response.write(&mut resp_buffer)?;
-    }
+    let resp_buffer = serialize_with_fallback(&mut response, &query, &qname)?;
 
     // Record stats and query log
     {
@@ -229,6 +220,36 @@ pub async fn resolve_query(
     });
 
     Ok((resp_buffer, path))
+}
+
+/// Wire-encode `response`: buffer-full → TC bit, serializer-rejected → SERVFAIL.
+/// Mutates `response.header.rescode` on SERVFAIL so the caller's query log
+/// reflects the truth (see #142).
+fn serialize_with_fallback(
+    response: &mut DnsPacket,
+    query: &DnsPacket,
+    qname: &str,
+) -> crate::Result<BytePacketBuffer> {
+    let mut buf = BytePacketBuffer::new();
+    match response.write(&mut buf) {
+        Ok(()) => Ok(buf),
+        Err(_) if buf.overflowed() => {
+            debug!("response too large, setting TC bit for {}", qname);
+            let mut tc = DnsPacket::response_from(query, response.header.rescode);
+            tc.header.truncated_message = true;
+            let mut out = BytePacketBuffer::new();
+            tc.write(&mut out)?;
+            Ok(out)
+        }
+        Err(e) => {
+            warn!("response serialize error for {}: {}", qname, e);
+            response.header.rescode = ResultCode::SERVFAIL;
+            let servfail = DnsPacket::response_from(query, ResultCode::SERVFAIL);
+            let mut out = BytePacketBuffer::new();
+            servfail.write(&mut out)?;
+            Ok(out)
+        }
+    }
 }
 
 /// Local resolution pipeline: overrides, .localhost, zones, special-use, .numa
@@ -1757,6 +1778,69 @@ mod tests {
             DnsRecord::A { addr, .. } => assert_eq!(*addr, Ipv4Addr::new(10, 0, 0, 7)),
             other => panic!("expected A record, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn serialize_with_fallback_passes_through_valid_response() {
+        let query = DnsPacket::query(0x1234, "example.com", QueryType::A);
+        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        response.answers.push(DnsRecord::A {
+            domain: "example.com".into(),
+            addr: Ipv4Addr::new(192, 0, 2, 1),
+            ttl: 300,
+        });
+        let buf = serialize_with_fallback(&mut response, &query, "example.com").unwrap();
+        let parsed =
+            DnsPacket::from_buffer(&mut BytePacketBuffer::from_bytes(buf.filled())).unwrap();
+        assert_eq!(parsed.header.rescode, ResultCode::NOERROR);
+        assert!(!parsed.header.truncated_message);
+        assert_eq!(parsed.answers.len(), 1);
+    }
+
+    #[test]
+    fn serialize_with_fallback_sets_tc_on_buffer_overflow() {
+        // 4096-byte buffer / ~24 bytes per TXT-as-UNKNOWN record → ~170+ fills it.
+        let query = DnsPacket::query(0x1234, "example.com", QueryType::TXT);
+        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        for _ in 0..256 {
+            response.answers.push(DnsRecord::UNKNOWN {
+                domain: "example.com".into(),
+                qtype: QueryType::TXT.to_num(),
+                data: vec![0u8; 32],
+                ttl: 300,
+            });
+        }
+        let buf = serialize_with_fallback(&mut response, &query, "example.com").unwrap();
+        let parsed =
+            DnsPacket::from_buffer(&mut BytePacketBuffer::from_bytes(buf.filled())).unwrap();
+        assert!(parsed.header.truncated_message, "TC bit must be set");
+        assert_eq!(parsed.header.rescode, ResultCode::NOERROR);
+    }
+
+    #[test]
+    fn serialize_with_fallback_returns_servfail_for_malformed_label() {
+        // A >63-byte raw label reaches write_qname → reject as SERVFAIL,
+        // not TC (TC would send the client to TCP for the same failure). #142.
+        let query = DnsPacket::query(0x1234, "example.com", QueryType::A);
+        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        response.answers.push(DnsRecord::A {
+            domain: format!("{}.example.com", "a".repeat(64)),
+            addr: Ipv4Addr::new(192, 0, 2, 1),
+            ttl: 300,
+        });
+        let buf = serialize_with_fallback(&mut response, &query, "example.com").unwrap();
+        let parsed =
+            DnsPacket::from_buffer(&mut BytePacketBuffer::from_bytes(buf.filled())).unwrap();
+        assert_eq!(parsed.header.rescode, ResultCode::SERVFAIL);
+        assert!(
+            !parsed.header.truncated_message,
+            "must not set TC for parse errors"
+        );
+        assert_eq!(
+            response.header.rescode,
+            ResultCode::SERVFAIL,
+            "caller-visible rescode must reflect SERVFAIL for query logging"
+        );
     }
 
     /// #188: cache entries synthesized internally (e.g. NS delegation snapshots)

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -201,9 +201,7 @@ pub async fn resolve_query(
     Ok((resp_buffer, path))
 }
 
-/// Wire-encode `response`: buffer-full → TC bit, serializer-rejected → SERVFAIL.
-/// Mutates `response.header.rescode` on SERVFAIL so the caller's query log
-/// reflects the truth (see #142).
+/// Buffer-full → TC bit, serializer-rejected → SERVFAIL (#142).
 fn serialize_with_fallback(
     response: &mut DnsPacket,
     query: &DnsPacket,
@@ -224,6 +222,7 @@ fn serialize_with_fallback(
         }
         Err(e) => {
             warn!("response serialize error for {}: {}", qname, e);
+            // mirror to caller's rescode so the query log reflects SERVFAIL
             response.header.rescode = ResultCode::SERVFAIL;
             let mut servfail = DnsPacket::response_from(query, ResultCode::SERVFAIL);
             shape_response_for_client(&mut servfail, query, filter_aaaa);

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -173,8 +173,6 @@ pub async fn resolve_query(
         response.resources.len(),
     );
 
-    // TODO: TC bit is UDP-specific; DoT connections could carry up to 65535 bytes.
-    // Once BytePacketBuffer supports larger buffers, skip truncation for TCP/TLS.
     let resp_buffer = serialize_with_fallback(&mut response, &query, &qname, ctx.filter_aaaa)?;
 
     // Record stats and query log
@@ -202,6 +200,8 @@ pub async fn resolve_query(
 }
 
 /// Buffer-full → TC bit, serializer-rejected → SERVFAIL (#142).
+/// TODO: TC is UDP-specific; once BytePacketBuffer supports >4096 bytes,
+/// skip truncation for TCP/TLS (which can carry up to 65535).
 fn serialize_with_fallback(
     response: &mut DnsPacket,
     query: &DnsPacket,

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1760,6 +1760,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pipeline_forwarding_malformed_upstream_yields_servfail() {
+        // #142: pre-fix, a label byte with reserved high bits 01 was treated
+        // as a length and silently consumed up to 191 bytes of garbage. This
+        // packet's authority NS record starts with 0x40 (64 + reserved bits) —
+        // pre-fix parsed cleanly and returned a bogus NS to the client.
+        // Post-fix the parser rejects, surfacing as SERVFAIL.
+        let mut wire = vec![
+            0x01, 0x00, 0x81, 0x80, // id (patched), flags
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, // QD=1 NS=1
+            0x01, b'x', 0x04, b't', b'e', b's', b't', 0x00, // qname x.test
+            0x00, 0x01, 0x00, 0x01, // A IN
+            0x40, // authority name length: 64 with reserved bits 01
+        ];
+        wire.extend(std::iter::repeat_n(b'a', 64)); // 64 bytes of filler label
+        wire.extend_from_slice(&[
+            0x00, // name terminator
+            0x00, 0x02, 0x00, 0x01, // NS IN
+            0x00, 0x00, 0x0e, 0x10, // TTL 3600
+            0x00, 0x02, 0xc0, 0x0c, // RDLEN=2, rdata = pointer to qname
+        ]);
+
+        let upstream_addr = crate::testutil::mock_upstream_raw(wire).await;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.forwarding_rules = vec![ForwardingRule::new(
+            "test".to_string(),
+            UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]),
+        )];
+        let ctx = Arc::new(ctx);
+
+        let (resp, path) = resolve_in_test(&ctx, "x.test", QueryType::A).await;
+        assert_eq!(path, QueryPath::UpstreamError);
+        assert_eq!(resp.header.rescode, ResultCode::SERVFAIL);
+        assert!(resp.answers.is_empty());
+    }
+
+    #[tokio::test]
     async fn pipeline_default_pool_reports_upstream_path() {
         let upstream_resp =
             crate::testutil::a_record_response("example.com", Ipv4Addr::new(93, 184, 216, 34), 300);

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -101,6 +101,22 @@ pub async fn mock_upstream(response: DnsPacket) -> SocketAddr {
     addr
 }
 
+/// Like `mock_upstream` but sends raw wire bytes (patches the first 2 bytes
+/// with the query ID). Use when the response is intentionally malformed and
+/// can't survive our own serializer.
+pub async fn mock_upstream_raw(mut bytes: Vec<u8>) -> SocketAddr {
+    let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = sock.local_addr().unwrap();
+    tokio::spawn(async move {
+        let mut buf = [0u8; 512];
+        let (_, src) = sock.recv_from(&mut buf).await.unwrap();
+        bytes[0] = buf[0];
+        bytes[1] = buf[1];
+        sock.send_to(&bytes, src).await.unwrap();
+    });
+    addr
+}
+
 /// UDP socket that accepts connections but never replies.
 /// Useful as an upstream that triggers timeouts.
 pub fn blackhole_upstream() -> SocketAddr {

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -86,24 +86,13 @@ pub fn a_record_response(domain: &str, addr: Ipv4Addr, ttl: u32) -> DnsPacket {
 /// Spawn a UDP socket that replies to the first DNS query with the given
 /// response packet (patching the query ID to match). Returns the socket address.
 pub async fn mock_upstream(response: DnsPacket) -> SocketAddr {
-    let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-    let addr = sock.local_addr().unwrap();
-    tokio::spawn(async move {
-        let mut buf = [0u8; 512];
-        let (_, src) = sock.recv_from(&mut buf).await.unwrap();
-        let query_id = u16::from_be_bytes([buf[0], buf[1]]);
-        let mut resp = response;
-        resp.header.id = query_id;
-        let mut out = BytePacketBuffer::new();
-        resp.write(&mut out).unwrap();
-        sock.send_to(out.filled(), src).await.unwrap();
-    });
-    addr
+    let mut out = BytePacketBuffer::new();
+    response.write(&mut out).unwrap();
+    mock_upstream_raw(out.filled().to_vec()).await
 }
 
-/// Like `mock_upstream` but sends raw wire bytes (patches the first 2 bytes
-/// with the query ID). Use when the response is intentionally malformed and
-/// can't survive our own serializer.
+/// Like `mock_upstream` but sends raw wire bytes — for intentionally
+/// malformed responses that can't survive our own serializer.
 pub async fn mock_upstream_raw(mut bytes: Vec<u8>) -> SocketAddr {
     let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let addr = sock.local_addr().unwrap();


### PR DESCRIPTION
## Summary

- `read_qname` now rejects bytes with reserved high bits (RFC 1035 §4.1.4 `01`/`10` patterns), instead of consuming up to 191 bytes of garbage when a compression pointer lands mid-label
- `BytePacketBuffer` tracks an `overflow` flag so callers can distinguish "wire too large" from "serializer rejected input"
- `ctx::serialize_with_fallback` splits the two: buffer-full → TC bit, serialize-error → SERVFAIL (and mutates `response.header.rescode` so the query log reflects the truth)

Fixes #142. Observed against Tailscale MagicDNS, which emits a 219-byte packet whose SOA mname pointer `c0 5a` lands inside the `adobeaemcloud` label body.

## Test plan

- [x] `cargo test buffer::tests::read_qname` — three new tests for reserved-bits and mid-label pointer rejection
- [x] `cargo test serialize_with_fallback` — pass-through, TC-on-overflow, SERVFAIL-on-malformed-label
- [x] `make all` — full lint + 409 lib tests + integration tests green
- [x] Field-check against Tailscale MagicDNS (`100.100.100.100:53`) with `kdig @127.0.0.1 odin.adobe.com HTTPS` — should return SERVFAIL or fail over, not empty TC