### PR TITLE
fix(ctx): consolidate response shaping — clear aa, preserve EDE (#192, #193)

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -182,6 +182,7 @@ pub async fn resolve_query(
         debug!("response too large, setting TC bit for {}", qname);
         let mut tc_response = DnsPacket::response_from(&query, response.header.rescode);
         tc_response.header.truncated_message = true;
+        shape_response_for_client(&mut tc_response, &query, ctx.filter_aaaa);
         resp_buffer = BytePacketBuffer::new();
         tc_response.write(&mut resp_buffer)?;
     }
@@ -568,7 +569,17 @@ fn strip_svcb_ipv6_hints(pkt: &mut DnsPacket) {
 /// Final pass before serialization. Clears `aa` (#192), mirrors client's
 /// OPT-or-absence preserving upstream options like EDE (#193, RFC 4035
 /// §3.2.1), strips DNSSEC + SVCB-ipv6hint for non-DO clients.
-fn shape_response_for_client(response: &mut DnsPacket, query: &DnsPacket, filter_aaaa: bool) {
+///
+/// Must be called on every response built for a client: happy path
+/// (resolve_query), TC-bit rebuild, and SERVFAIL/FORMERR in tcp/doh.
+/// The pre-parse FORMERR in tcp/doh is the one exception — the query
+/// never parsed, so OPT mirroring is impossible. AD bit is owned by
+/// the validator (ctx.rs:142) and intentionally not touched here.
+pub(crate) fn shape_response_for_client(
+    response: &mut DnsPacket,
+    query: &DnsPacket,
+    filter_aaaa: bool,
+) {
     let client_do = query.edns.as_ref().is_some_and(|e| e.do_bit);
 
     response.header.authoritative_answer = false;
@@ -1946,6 +1957,34 @@ mod tests {
         assert_eq!(
             edns.options, ede,
             "EDE option bytes must survive serialize -> reparse"
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_truncated_response_mirrors_client_opt() {
+        // RFC 6891 §6.1.1: the OPT-mirror invariant must hold even on the
+        // TC-bit rebuild path, which throws the original (shaped) response
+        // away and synthesizes a fresh one when serialization overflows.
+        let mut ctx = crate::testutil::test_ctx().await;
+        let big_record = DnsRecord::UNKNOWN {
+            domain: "huge.test".into(),
+            qtype: 99,
+            data: vec![0u8; 5000], // exceeds the 4096-byte serialization buffer
+            ttl: 60,
+        };
+        let mut inner = HashMap::new();
+        inner.insert(QueryType::UNKNOWN(99), vec![big_record]);
+        ctx.zone_map.insert("huge.test".to_string(), inner);
+        let ctx = Arc::new(ctx);
+
+        let mut query = DnsPacket::query(0xBEEF, "huge.test", QueryType::UNKNOWN(99));
+        query.edns = Some(crate::packet::EdnsOpt::default());
+        let (resp, _) = resolve_in_test_with_query(&ctx, query).await;
+
+        assert!(resp.header.truncated_message, "TC bit must be set");
+        assert!(
+            resp.edns.is_some(),
+            "TC response must mirror client's OPT"
         );
     }
 }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1913,4 +1913,116 @@ mod tests {
         assert_eq!(response.answers.len(), 1);
         assert!(matches!(response.answers[0], DnsRecord::A { .. }));
     }
+
+    // ---- Full-pipeline wiring tests for shape_response_for_client ----
+    // The unit tests above verify the helper's invariants in isolation; these
+    // verify the helper is actually wired into resolve_query and that the
+    // invariants survive serialize -> reparse on the wire.
+
+    #[tokio::test]
+    async fn pipeline_clears_aa_bit_from_forwarded_response() {
+        // #192: even when upstream sets aa=1, the client must see aa=0.
+        let mut upstream_resp = DnsPacket::new();
+        upstream_resp.header.response = true;
+        upstream_resp.header.rescode = ResultCode::NOERROR;
+        upstream_resp.header.authoritative_answer = true;
+        upstream_resp.answers.push(DnsRecord::A {
+            domain: "aa.test".into(),
+            addr: Ipv4Addr::new(1, 2, 3, 4),
+            ttl: 60,
+        });
+        let upstream_addr = crate::testutil::mock_upstream(upstream_resp).await;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.forwarding_rules = vec![ForwardingRule::new(
+            "aa.test".to_string(),
+            UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]),
+        )];
+        let ctx = Arc::new(ctx);
+
+        let (resp, path) = resolve_in_test(&ctx, "aa.test", QueryType::A).await;
+        assert_eq!(path, QueryPath::Forwarded);
+        assert!(
+            !resp.header.authoritative_answer,
+            "aa bit must be cleared even when upstream set it"
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_drops_opt_when_client_sent_none() {
+        // #193 / RFC 6891 §6.1.1: client sent no OPT -> response must have none,
+        // even if upstream included one.
+        let mut upstream_resp = DnsPacket::new();
+        upstream_resp.header.response = true;
+        upstream_resp.header.rescode = ResultCode::NOERROR;
+        upstream_resp.edns = Some(crate::packet::EdnsOpt {
+            udp_payload_size: 4096,
+            options: ede_opt_bytes(22),
+            ..Default::default()
+        });
+        upstream_resp.answers.push(DnsRecord::A {
+            domain: "noedns.test".into(),
+            addr: Ipv4Addr::new(1, 2, 3, 4),
+            ttl: 60,
+        });
+        let upstream_addr = crate::testutil::mock_upstream(upstream_resp).await;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.forwarding_rules = vec![ForwardingRule::new(
+            "noedns.test".to_string(),
+            UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]),
+        )];
+        let ctx = Arc::new(ctx);
+
+        // resolve_in_test builds a query without EDNS.
+        let (resp, _) = resolve_in_test(&ctx, "noedns.test", QueryType::A).await;
+        assert!(
+            resp.edns.is_none(),
+            "client sent no OPT, response must omit OPT"
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_preserves_upstream_ede_for_edns_client() {
+        // #136 angle: when the client opts into EDNS, upstream's EDE option
+        // must survive the full pipeline (serialize -> reparse) so debuggers
+        // and validators see *why* a response is empty.
+        let ede = ede_opt_bytes(22); // 22 = "No Reachable Authority"
+        let mut upstream_resp = DnsPacket::new();
+        upstream_resp.header.response = true;
+        upstream_resp.header.rescode = ResultCode::NOERROR;
+        upstream_resp.edns = Some(crate::packet::EdnsOpt {
+            udp_payload_size: 1232,
+            options: ede.clone(),
+            ..Default::default()
+        });
+        let upstream_addr = crate::testutil::mock_upstream(upstream_resp).await;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.forwarding_rules = vec![ForwardingRule::new(
+            "ede.test".to_string(),
+            UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]),
+        )];
+        let ctx = Arc::new(ctx);
+
+        // Build a query *with* EDNS so the response mirror keeps the OPT.
+        let mut query = DnsPacket::query(0xBEEF, "ede.test", QueryType::A);
+        query.edns = Some(crate::packet::EdnsOpt::default());
+        let mut buf = BytePacketBuffer::new();
+        query.write(&mut buf).unwrap();
+        let raw = &buf.buf[..buf.pos];
+        let src: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let (resp_buf, _) = resolve_query(query, raw, src, &ctx, Transport::Udp)
+            .await
+            .unwrap();
+        let mut parse = BytePacketBuffer::from_bytes(resp_buf.filled());
+        let resp = DnsPacket::from_buffer(&mut parse).unwrap();
+
+        let edns = resp.edns.expect("OPT must reach the client");
+        assert_eq!(
+            edns.options, ede,
+            "EDE option bytes must survive serialize -> reparse"
+        );
+    }
 }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1193,8 +1193,6 @@ mod tests {
         resolve_in_test_with_query(ctx, DnsPacket::query(0xBEEF, domain, qtype)).await
     }
 
-    /// Variant of `resolve_in_test` that takes a pre-built query, for tests
-    /// that need to set EDNS or other non-default header bits on the request.
     async fn resolve_in_test_with_query(
         ctx: &Arc<ServerCtx>,
         query: DnsPacket,
@@ -1922,10 +1920,7 @@ mod tests {
         assert!(matches!(response.answers[0], DnsRecord::A { .. }));
     }
 
-    // ---- Full-pipeline wiring tests for shape_response_for_client ----
-    // The unit tests above verify the helper's invariants in isolation; these
-    // verify the helper is actually wired into resolve_query and that the
-    // invariants survive serialize -> reparse on the wire.
+    // ---- Wiring tests: shape_response_for_client must be called by resolve_query ----
 
     #[tokio::test]
     async fn pipeline_clears_aa_bit_from_forwarded_response() {
@@ -1956,11 +1951,7 @@ mod tests {
         // even if upstream included one.
         let mut upstream_resp =
             crate::testutil::a_record_response("noedns.test", Ipv4Addr::new(1, 2, 3, 4), 60);
-        upstream_resp.edns = Some(crate::packet::EdnsOpt {
-            udp_payload_size: 4096,
-            options: ede_opt_bytes(22),
-            ..Default::default()
-        });
+        upstream_resp.edns = Some(crate::packet::EdnsOpt::default());
         let upstream_addr = crate::testutil::mock_upstream(upstream_resp).await;
 
         let mut ctx = crate::testutil::test_ctx().await;
@@ -1987,7 +1978,6 @@ mod tests {
         upstream_resp.header.response = true;
         upstream_resp.header.rescode = ResultCode::NOERROR;
         upstream_resp.edns = Some(crate::packet::EdnsOpt {
-            udp_payload_size: 1232,
             options: ede.clone(),
             ..Default::default()
         });

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1982,9 +1982,6 @@ mod tests {
         let (resp, _) = resolve_in_test_with_query(&ctx, query).await;
 
         assert!(resp.header.truncated_message, "TC bit must be set");
-        assert!(
-            resp.edns.is_some(),
-            "TC response must mirror client's OPT"
-        );
+        assert!(resp.edns.is_some(), "TC response must mirror client's OPT");
     }
 }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -116,7 +116,6 @@ pub async fn resolve_query(
         }
     };
 
-    let client_do = query.edns.as_ref().is_some_and(|e| e.do_bit);
     let mut response = response;
 
     // DNSSEC validation (recursive/forwarded responses only)
@@ -153,27 +152,7 @@ pub async fn resolve_query(
             .insert_with_status(&qname, qtype, &response, status);
     }
 
-    // Strip DNSSEC records if client didn't set DO bit
-    if !client_do {
-        strip_dnssec_records(&mut response);
-    }
-
-    // filter_aaaa: also strip ipv6hint from HTTPS/SVCB answers so modern
-    // browsers (Chrome ≥103 etc.) don't receive v6 address hints via the
-    // HTTPS record path that bypasses AAAA entirely. Gated on !client_do
-    // because modifying rdata invalidates any accompanying RRSIG — a DO-bit
-    // validator downstream would reject the response as Bogus.
-    if ctx.filter_aaaa && !client_do {
-        strip_svcb_ipv6_hints(&mut response);
-    }
-
-    // Echo EDNS back if client sent it
-    if query.edns.is_some() {
-        response.edns = Some(crate::packet::EdnsOpt {
-            do_bit: client_do,
-            ..Default::default()
-        });
-    }
+    shape_response_for_client(&mut response, &query, ctx.filter_aaaa);
 
     let elapsed = start.elapsed();
 
@@ -584,6 +563,41 @@ fn strip_svcb_ipv6_hints(pkt: &mut DnsPacket) {
             }
         }
     });
+}
+
+/// Final pass before serialization: shape `response` to match what the client
+/// actually asked for, regardless of which upstream path produced it.
+/// Consolidates the per-client invariants that used to live inline in
+/// `resolve_query`:
+///
+/// - **#192**: clear `aa` (Numa is a recursor/forwarder, not authoritative).
+/// - **#193**: emit OPT iff the client did; when preserving, keep upstream's
+///   EDNS options (notably RFC 8914 EDE) and override only the DO bit per
+///   RFC 4035 §3.2.1.
+/// - DNSSEC and SVCB-ipv6hint stripping for non-DO clients.
+fn shape_response_for_client(response: &mut DnsPacket, query: &DnsPacket, filter_aaaa: bool) {
+    let client_do = query.edns.as_ref().is_some_and(|e| e.do_bit);
+
+    response.header.authoritative_answer = false;
+
+    if !client_do {
+        strip_dnssec_records(response);
+        if filter_aaaa {
+            strip_svcb_ipv6_hints(response);
+        }
+    }
+
+    response.edns = match (&query.edns, response.edns.take()) {
+        (None, _) => None,
+        (Some(_), Some(mut upstream)) => {
+            upstream.do_bit = client_do;
+            Some(upstream)
+        }
+        (Some(_), None) => Some(crate::packet::EdnsOpt {
+            do_bit: client_do,
+            ..Default::default()
+        }),
+    };
 }
 
 fn is_special_use_domain(qname: &str) -> bool {
@@ -1787,5 +1801,129 @@ mod tests {
         assert_eq!(resp.questions[0].qtype, QueryType::NS);
         assert!(resp.header.recursion_desired);
         assert!(resp.header.recursion_available);
+    }
+
+    // ---- shape_response_for_client unit tests (#192, #193) ----
+
+    fn ede_opt_bytes(code: u16) -> Vec<u8> {
+        // RFC 8914 OPT body: option-code=15 (EDE), option-length=2, INFO-CODE.
+        let mut v = vec![0, 15, 0, 2];
+        v.extend_from_slice(&code.to_be_bytes());
+        v
+    }
+
+    #[test]
+    fn shape_clears_aa_bit_from_upstream() {
+        // #192: cached/forwarded responses inherit upstream's aa=1; clear it.
+        let query = DnsPacket::query(0x1, "example.com", QueryType::A);
+        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        response.header.authoritative_answer = true;
+
+        shape_response_for_client(&mut response, &query, false);
+
+        assert!(!response.header.authoritative_answer);
+    }
+
+    #[test]
+    fn shape_drops_edns_when_client_did_not_send() {
+        // #193: RFC 6891 §6.1.1 — emit OPT only when requestor included one.
+        let query = DnsPacket::query(0x1, "example.com", QueryType::A);
+        assert!(query.edns.is_none());
+        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        response.edns = Some(crate::packet::EdnsOpt {
+            udp_payload_size: 4096,
+            options: ede_opt_bytes(22),
+            ..Default::default()
+        });
+
+        shape_response_for_client(&mut response, &query, false);
+
+        assert!(response.edns.is_none(), "upstream OPT must be dropped");
+    }
+
+    #[test]
+    fn shape_preserves_upstream_edns_options_when_client_sent_edns() {
+        // The EDE-preservation half of #193: when both sides talk EDNS,
+        // keep upstream's EDE/Padding/etc. instead of replacing with a bare
+        // default. EDE in particular tells clients *why* a response is empty.
+        let mut query = DnsPacket::query(0x1, "example.com", QueryType::A);
+        query.edns = Some(crate::packet::EdnsOpt::default());
+        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        let ede = ede_opt_bytes(22); // 22 = "No Reachable Authority"
+        response.edns = Some(crate::packet::EdnsOpt {
+            udp_payload_size: 1232,
+            options: ede.clone(),
+            do_bit: true,
+            ..Default::default()
+        });
+
+        shape_response_for_client(&mut response, &query, false);
+
+        let edns = response.edns.expect("OPT must be preserved");
+        assert_eq!(edns.options, ede, "EDE option must survive shaping");
+        assert_eq!(edns.udp_payload_size, 1232);
+    }
+
+    #[test]
+    fn shape_overrides_do_bit_to_match_client() {
+        // RFC 4035 §3.2.1: response DO bit reflects the requestor's DO bit.
+        let mut query = DnsPacket::query(0x1, "example.com", QueryType::A);
+        query.edns = Some(crate::packet::EdnsOpt {
+            do_bit: false,
+            ..Default::default()
+        });
+        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        response.edns = Some(crate::packet::EdnsOpt {
+            do_bit: true,
+            ..Default::default()
+        });
+
+        shape_response_for_client(&mut response, &query, false);
+
+        assert!(!response.edns.unwrap().do_bit);
+    }
+
+    #[test]
+    fn shape_synthesizes_minimal_opt_when_upstream_has_none() {
+        // Client opted into EDNS but upstream omitted OPT (local zones,
+        // synthesized responses) — emit a minimal OPT so the client sees
+        // EDNS in the exchange.
+        let mut query = DnsPacket::query(0x1, "example.com", QueryType::A);
+        query.edns = Some(crate::packet::EdnsOpt::default());
+        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        assert!(response.edns.is_none());
+
+        shape_response_for_client(&mut response, &query, false);
+
+        assert!(response.edns.is_some());
+    }
+
+    #[test]
+    fn shape_strips_dnssec_records_for_non_do_client() {
+        let query = DnsPacket::query(0x1, "example.com", QueryType::A);
+        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        response.answers.push(DnsRecord::A {
+            domain: "example.com".into(),
+            addr: Ipv4Addr::new(192, 0, 2, 1),
+            ttl: 300,
+        });
+        response.answers.push(DnsRecord::RRSIG {
+            domain: "example.com".into(),
+            type_covered: QueryType::A.to_num(),
+            algorithm: 13,
+            labels: 2,
+            original_ttl: 300,
+            expiration: 0,
+            inception: 0,
+            key_tag: 0,
+            signer_name: "example.com".into(),
+            signature: vec![],
+            ttl: 300,
+        });
+
+        shape_response_for_client(&mut response, &query, false);
+
+        assert_eq!(response.answers.len(), 1);
+        assert!(matches!(response.answers[0], DnsRecord::A { .. }));
     }
 }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -566,15 +566,14 @@ fn strip_svcb_ipv6_hints(pkt: &mut DnsPacket) {
     });
 }
 
-/// Final pass before serialization. Clears `aa` (#192), mirrors client's
-/// OPT-or-absence preserving upstream options like EDE (#193, RFC 4035
-/// §3.2.1), strips DNSSEC + SVCB-ipv6hint for non-DO clients.
+/// Final pass before serialization. Clears `aa`, mirrors the client's
+/// OPT-or-absence (RFC 6891 §6.1.1) preserving upstream options such as
+/// EDE, and strips DNSSEC + SVCB-ipv6hint for non-DO clients (RFC 4035
+/// §3.2.1).
 ///
-/// Must be called on every response built for a client: happy path
-/// (resolve_query), TC-bit rebuild, and SERVFAIL/FORMERR in tcp/doh.
-/// The pre-parse FORMERR in tcp/doh is the one exception — the query
-/// never parsed, so OPT mirroring is impossible. AD bit is owned by
-/// the validator (ctx.rs:142) and intentionally not touched here.
+/// Call on every response built for a client: happy path, TC rebuild,
+/// SERVFAIL/FORMERR. The pre-parse FORMERR is the exception — no parsed
+/// query, no OPT to mirror.
 pub(crate) fn shape_response_for_client(
     response: &mut DnsPacket,
     query: &DnsPacket,

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -565,16 +565,9 @@ fn strip_svcb_ipv6_hints(pkt: &mut DnsPacket) {
     });
 }
 
-/// Final pass before serialization: shape `response` to match what the client
-/// actually asked for, regardless of which upstream path produced it.
-/// Consolidates the per-client invariants that used to live inline in
-/// `resolve_query`:
-///
-/// - **#192**: clear `aa` (Numa is a recursor/forwarder, not authoritative).
-/// - **#193**: emit OPT iff the client did; when preserving, keep upstream's
-///   EDNS options (notably RFC 8914 EDE) and override only the DO bit per
-///   RFC 4035 §3.2.1.
-/// - DNSSEC and SVCB-ipv6hint stripping for non-DO clients.
+/// Final pass before serialization. Clears `aa` (#192), mirrors client's
+/// OPT-or-absence preserving upstream options like EDE (#193, RFC 4035
+/// §3.2.1), strips DNSSEC + SVCB-ipv6hint for non-DO clients.
 fn shape_response_for_client(response: &mut DnsPacket, query: &DnsPacket, filter_aaaa: bool) {
     let client_do = query.edns.as_ref().is_some_and(|e| e.do_bit);
 
@@ -587,17 +580,11 @@ fn shape_response_for_client(response: &mut DnsPacket, query: &DnsPacket, filter
         }
     }
 
-    response.edns = match (&query.edns, response.edns.take()) {
-        (None, _) => None,
-        (Some(_), Some(mut upstream)) => {
-            upstream.do_bit = client_do;
-            Some(upstream)
-        }
-        (Some(_), None) => Some(crate::packet::EdnsOpt {
-            do_bit: client_do,
-            ..Default::default()
-        }),
-    };
+    response.edns = query.edns.as_ref().map(|_| {
+        let mut e = response.edns.take().unwrap_or_default();
+        e.do_bit = client_do;
+        e
+    });
 }
 
 fn is_special_use_domain(qname: &str) -> bool {

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1796,65 +1796,13 @@ mod tests {
         assert!(resp.header.recursion_available);
     }
 
-    // ---- shape_response_for_client unit tests (#192, #193) ----
+    // ---- shape_response_for_client unit tests ----
 
     fn ede_opt_bytes(code: u16) -> Vec<u8> {
         // RFC 8914 OPT body: option-code=15 (EDE), option-length=2, INFO-CODE.
         let mut v = vec![0, 15, 0, 2];
         v.extend_from_slice(&code.to_be_bytes());
         v
-    }
-
-    #[test]
-    fn shape_clears_aa_bit_from_upstream() {
-        // #192: cached/forwarded responses inherit upstream's aa=1; clear it.
-        let query = DnsPacket::query(0x1, "example.com", QueryType::A);
-        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
-        response.header.authoritative_answer = true;
-
-        shape_response_for_client(&mut response, &query, false);
-
-        assert!(!response.header.authoritative_answer);
-    }
-
-    #[test]
-    fn shape_drops_edns_when_client_did_not_send() {
-        // #193: RFC 6891 §6.1.1 — emit OPT only when requestor included one.
-        let query = DnsPacket::query(0x1, "example.com", QueryType::A);
-        assert!(query.edns.is_none());
-        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
-        response.edns = Some(crate::packet::EdnsOpt {
-            udp_payload_size: 4096,
-            options: ede_opt_bytes(22),
-            ..Default::default()
-        });
-
-        shape_response_for_client(&mut response, &query, false);
-
-        assert!(response.edns.is_none(), "upstream OPT must be dropped");
-    }
-
-    #[test]
-    fn shape_preserves_upstream_edns_options_when_client_sent_edns() {
-        // The EDE-preservation half of #193: when both sides talk EDNS,
-        // keep upstream's EDE/Padding/etc. instead of replacing with a bare
-        // default. EDE in particular tells clients *why* a response is empty.
-        let mut query = DnsPacket::query(0x1, "example.com", QueryType::A);
-        query.edns = Some(crate::packet::EdnsOpt::default());
-        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
-        let ede = ede_opt_bytes(22); // 22 = "No Reachable Authority"
-        response.edns = Some(crate::packet::EdnsOpt {
-            udp_payload_size: 1232,
-            options: ede.clone(),
-            do_bit: true,
-            ..Default::default()
-        });
-
-        shape_response_for_client(&mut response, &query, false);
-
-        let edns = response.edns.expect("OPT must be preserved");
-        assert_eq!(edns.options, ede, "EDE option must survive shaping");
-        assert_eq!(edns.udp_payload_size, 1232);
     }
 
     #[test]

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1190,7 +1190,15 @@ mod tests {
         domain: &str,
         qtype: QueryType,
     ) -> (DnsPacket, QueryPath) {
-        let query = DnsPacket::query(0xBEEF, domain, qtype);
+        resolve_in_test_with_query(ctx, DnsPacket::query(0xBEEF, domain, qtype)).await
+    }
+
+    /// Variant of `resolve_in_test` that takes a pre-built query, for tests
+    /// that need to set EDNS or other non-default header bits on the request.
+    async fn resolve_in_test_with_query(
+        ctx: &Arc<ServerCtx>,
+        query: DnsPacket,
+    ) -> (DnsPacket, QueryPath) {
         let mut buf = BytePacketBuffer::new();
         query.write(&mut buf).unwrap();
         let raw = &buf.buf[..buf.pos];
@@ -1922,15 +1930,9 @@ mod tests {
     #[tokio::test]
     async fn pipeline_clears_aa_bit_from_forwarded_response() {
         // #192: even when upstream sets aa=1, the client must see aa=0.
-        let mut upstream_resp = DnsPacket::new();
-        upstream_resp.header.response = true;
-        upstream_resp.header.rescode = ResultCode::NOERROR;
+        let mut upstream_resp =
+            crate::testutil::a_record_response("aa.test", Ipv4Addr::new(1, 2, 3, 4), 60);
         upstream_resp.header.authoritative_answer = true;
-        upstream_resp.answers.push(DnsRecord::A {
-            domain: "aa.test".into(),
-            addr: Ipv4Addr::new(1, 2, 3, 4),
-            ttl: 60,
-        });
         let upstream_addr = crate::testutil::mock_upstream(upstream_resp).await;
 
         let mut ctx = crate::testutil::test_ctx().await;
@@ -1952,18 +1954,12 @@ mod tests {
     async fn pipeline_drops_opt_when_client_sent_none() {
         // #193 / RFC 6891 §6.1.1: client sent no OPT -> response must have none,
         // even if upstream included one.
-        let mut upstream_resp = DnsPacket::new();
-        upstream_resp.header.response = true;
-        upstream_resp.header.rescode = ResultCode::NOERROR;
+        let mut upstream_resp =
+            crate::testutil::a_record_response("noedns.test", Ipv4Addr::new(1, 2, 3, 4), 60);
         upstream_resp.edns = Some(crate::packet::EdnsOpt {
             udp_payload_size: 4096,
             options: ede_opt_bytes(22),
             ..Default::default()
-        });
-        upstream_resp.answers.push(DnsRecord::A {
-            domain: "noedns.test".into(),
-            addr: Ipv4Addr::new(1, 2, 3, 4),
-            ttl: 60,
         });
         let upstream_addr = crate::testutil::mock_upstream(upstream_resp).await;
 
@@ -1974,7 +1970,6 @@ mod tests {
         )];
         let ctx = Arc::new(ctx);
 
-        // resolve_in_test builds a query without EDNS.
         let (resp, _) = resolve_in_test(&ctx, "noedns.test", QueryType::A).await;
         assert!(
             resp.edns.is_none(),
@@ -2005,19 +2000,9 @@ mod tests {
         )];
         let ctx = Arc::new(ctx);
 
-        // Build a query *with* EDNS so the response mirror keeps the OPT.
         let mut query = DnsPacket::query(0xBEEF, "ede.test", QueryType::A);
         query.edns = Some(crate::packet::EdnsOpt::default());
-        let mut buf = BytePacketBuffer::new();
-        query.write(&mut buf).unwrap();
-        let raw = &buf.buf[..buf.pos];
-        let src: SocketAddr = "127.0.0.1:1234".parse().unwrap();
-
-        let (resp_buf, _) = resolve_query(query, raw, src, &ctx, Transport::Udp)
-            .await
-            .unwrap();
-        let mut parse = BytePacketBuffer::from_bytes(resp_buf.filled());
-        let resp = DnsPacket::from_buffer(&mut parse).unwrap();
+        let (resp, _) = resolve_in_test_with_query(&ctx, query).await;
 
         let edns = resp.edns.expect("OPT must reach the client");
         assert_eq!(

--- a/src/doh.rs
+++ b/src/doh.rs
@@ -108,9 +108,7 @@ async fn resolve_doh(
         }
     };
 
-    let query_id = query.header.id;
-    let query_rd = query.header.recursion_desired;
-    let questions = query.questions.clone();
+    let query_for_error = query.clone();
 
     match resolve_query(query, dns_bytes, src, ctx, Transport::Doh).await {
         Ok((resp_buffer, _)) => {
@@ -119,13 +117,8 @@ async fn resolve_doh(
         }
         Err(e) => {
             warn!("DoH: resolve error for {}: {}", src, e);
-            let mut resp = DnsPacket::new();
-            resp.header.id = query_id;
-            resp.header.response = true;
-            resp.header.recursion_desired = query_rd;
-            resp.header.recursion_available = true;
-            resp.header.rescode = ResultCode::SERVFAIL;
-            resp.questions = questions;
+            let mut resp = DnsPacket::response_from(&query_for_error, ResultCode::SERVFAIL);
+            crate::ctx::shape_response_for_client(&mut resp, &query_for_error, ctx.filter_aaaa);
             serialize_response(&resp)
         }
     }
@@ -220,5 +213,33 @@ mod tests {
         pkt.header.rescode = ResultCode::FORMERR;
         let resp = serialize_response(&pkt);
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn doh_servfail_mirrors_client_opt() {
+        // RFC 6891 §6.1.1: SERVFAIL on the DoH error path must echo client OPT.
+        // resolve_query returns Err("empty question section") for queries with
+        // header.questions == 0, which is the cheapest way to drive the error
+        // branch from a unit test.
+        let mut query = DnsPacket::new();
+        query.header.id = 0x1234;
+        query.header.recursion_desired = true;
+        query.edns = Some(crate::packet::EdnsOpt::default());
+        let mut buf = BytePacketBuffer::new();
+        query.write(&mut buf).unwrap();
+
+        let ctx = std::sync::Arc::new(crate::testutil::test_ctx().await);
+        let src: std::net::SocketAddr = "127.0.0.1:1234".parse().unwrap();
+        let response = resolve_doh(buf.filled(), src, &ctx).await;
+
+        let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        let mut parse = BytePacketBuffer::from_bytes(&body);
+        let resp = DnsPacket::from_buffer(&mut parse).unwrap();
+
+        assert_eq!(resp.header.rescode, ResultCode::SERVFAIL);
+        assert!(
+            resp.edns.is_some(),
+            "DoH SERVFAIL must mirror client's OPT"
+        );
     }
 }

--- a/src/doh.rs
+++ b/src/doh.rs
@@ -217,10 +217,7 @@ mod tests {
 
     #[tokio::test]
     async fn doh_servfail_mirrors_client_opt() {
-        // RFC 6891 §6.1.1: SERVFAIL on the DoH error path must echo client OPT.
-        // resolve_query returns Err("empty question section") for queries with
-        // header.questions == 0, which is the cheapest way to drive the error
-        // branch from a unit test.
+        // RFC 6891 §6.1.1 on the Err-branch; empty-questions drives it.
         let mut query = DnsPacket::new();
         query.header.id = 0x1234;
         query.header.recursion_desired = true;

--- a/src/doh.rs
+++ b/src/doh.rs
@@ -232,14 +232,13 @@ mod tests {
         let src: std::net::SocketAddr = "127.0.0.1:1234".parse().unwrap();
         let response = resolve_doh(buf.filled(), src, &ctx).await;
 
-        let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
         let mut parse = BytePacketBuffer::from_bytes(&body);
         let resp = DnsPacket::from_buffer(&mut parse).unwrap();
 
         assert_eq!(resp.header.rescode, ResultCode::SERVFAIL);
-        assert!(
-            resp.edns.is_some(),
-            "DoH SERVFAIL must mirror client's OPT"
-        );
+        assert!(resp.edns.is_some(), "DoH SERVFAIL must mirror client's OPT");
     }
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -166,7 +166,8 @@ pub(crate) async fn handle_framed_dns_connection<S>(
             }
             Err(e) => {
                 warn!("{} | RESOLVE ERROR | {}", remote_addr, e);
-                let resp = DnsPacket::response_from(&query, ResultCode::SERVFAIL);
+                let mut resp = DnsPacket::response_from(&query, ResultCode::SERVFAIL);
+                crate::ctx::shape_response_for_client(&mut resp, &query, ctx.filter_aaaa);
                 if send_response(&mut stream, &resp, remote_addr, proto)
                     .await
                     .is_err()
@@ -335,6 +336,28 @@ mod tests {
         assert_eq!(resp.header.rescode, ResultCode::SERVFAIL);
         assert_eq!(resp.questions.len(), 1);
         assert_eq!(resp.questions[0].name, "nonexistent.test");
+    }
+
+    #[tokio::test]
+    async fn tcp_servfail_mirrors_client_opt() {
+        // RFC 6891 §6.1.1: the SERVFAIL on the Err-branch (resolve_query
+        // rejects a malformed query) must still mirror client OPT. The
+        // empty-questions case is the only Err resolve_query can return, so
+        // it's the only way to drive the suspect branch from a unit test.
+        let addr = spawn_tcp_server().await;
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+
+        let mut query = DnsPacket::new();
+        query.header.id = 0xBEEF;
+        query.header.recursion_desired = true;
+        query.edns = Some(crate::packet::EdnsOpt::default());
+        let resp = tcp_exchange(&mut stream, &query).await;
+
+        assert_eq!(resp.header.rescode, ResultCode::SERVFAIL);
+        assert!(
+            resp.edns.is_some(),
+            "SERVFAIL must mirror client's OPT"
+        );
     }
 
     #[tokio::test]

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -354,10 +354,7 @@ mod tests {
         let resp = tcp_exchange(&mut stream, &query).await;
 
         assert_eq!(resp.header.rescode, ResultCode::SERVFAIL);
-        assert!(
-            resp.edns.is_some(),
-            "SERVFAIL must mirror client's OPT"
-        );
+        assert!(resp.edns.is_some(), "SERVFAIL must mirror client's OPT");
     }
 
     #[tokio::test]

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -340,10 +340,7 @@ mod tests {
 
     #[tokio::test]
     async fn tcp_servfail_mirrors_client_opt() {
-        // RFC 6891 §6.1.1: the SERVFAIL on the Err-branch (resolve_query
-        // rejects a malformed query) must still mirror client OPT. The
-        // empty-questions case is the only Err resolve_query can return, so
-        // it's the only way to drive the suspect branch from a unit test.
+        // RFC 6891 §6.1.1 on the Err-branch; empty-questions drives it.
         let addr = spawn_tcp_server().await;
         let mut stream = TcpStream::connect(addr).await.unwrap();
 


### PR DESCRIPTION
## Summary

Replace the inline per-client invariants in `resolve_query` with a single `shape_response_for_client(response, query, filter_aaaa)` helper. Fixes two open response-shaping bugs in the same diff and closes the EDE-preservation gap surfaced while researching #136.

- **#192 — `aa` leak**: Numa is a recursor/forwarder, not authoritative. The bit was previously inherited from upstream wire (cache-hit / forward / odoh) and from auth-server replies (recursive). Now cleared unconditionally before serialization.
- **#193 — OPT leaked when client sent none**: RFC 6891 §6.1.1 — emit OPT only when the requestor included one. Now symmetric.
- **EDE preservation (#136 angle)**: when the client *did* send EDNS, the old code replaced upstream's OPT with `EdnsOpt::default()`, wiping RFC 8914 EDE codes, padding, server cookies, NSID. Now upstream's OPT is preserved; only the DO bit is overridden per RFC 4035 §3.2.1.

DNSSEC and SVCB-ipv6hint stripping move under the same helper for one-stop reading.

## Why one PR instead of three

Same ~15 lines in `ctx.rs:156-176`. Splitting into 3 PRs would mean three reviewers reconstructing the same set of invariants. A single helper makes the contract — "this is everything we do to a response before serializing it for a specific client" — readable in one place.

Out of scope (still separate tickets): #191 (cache not DO-aware), filter_aaaa NODATA missing SOA in authority.

## Test plan

- [x] Unit tests covering each invariant: aa-clear, OPT-drop-when-client-none, OPT-preserve-with-EDE-when-client-sent, DO-bit override, minimal OPT synthesis, DNSSEC strip
- [x] `make all` — lib tests + integration tests + clippy + fmt + audit green
- [ ] Field check against #136: build, deploy on user's Chromebook-enrollment chain, confirm whether EDE preservation changes enrollment outcome