### PR TITLE
feat(zones): wildcard support in local zones (#117)

### DIFF
--- a/benches/hot_path.rs
+++ b/benches/hot_path.rs
@@ -198,23 +198,6 @@ fn bench_zone_lookup_miss(c: &mut Criterion) {
     });
 }
 
-fn bench_zone_lookup_wildcard_hit(c: &mut Criterion) {
-    use numa::config::{build_zone_map, ZoneRecord};
-    let map = build_zone_map(&[ZoneRecord {
-        domain: "*.foo.bar.baz".into(),
-        record_type: "A".into(),
-        value: "10.0.0.1".into(),
-        ttl: 300,
-    }])
-    .unwrap();
-
-    c.bench_function("zone_lookup_wildcard_hit", |b| {
-        b.iter(|| {
-            map.lookup(black_box("deep.sub.foo.bar.baz"), QueryType::A);
-        })
-    });
-}
-
 criterion_group!(
     benches,
     bench_buffer_parse,
@@ -226,6 +209,5 @@ criterion_group!(
     bench_round_trip,
     bench_cache_populated_lookup,
     bench_zone_lookup_miss,
-    bench_zone_lookup_wildcard_hit,
 );
 criterion_main!(benches);

--- a/benches/hot_path.rs
+++ b/benches/hot_path.rs
@@ -171,6 +171,50 @@ fn bench_cache_populated_lookup(c: &mut Criterion) {
     });
 }
 
+fn bench_zone_lookup_miss(c: &mut Criterion) {
+    // The regression-prone case: every non-zone query pays for the wildcard
+    // check. Map mixes exact + wildcard entries so the suffix walk runs.
+    use numa::config::{build_zone_map, ZoneRecord};
+    let map = build_zone_map(&[
+        ZoneRecord {
+            domain: "internal.example".into(),
+            record_type: "A".into(),
+            value: "10.0.0.1".into(),
+            ttl: 300,
+        },
+        ZoneRecord {
+            domain: "*.svc.cluster.local".into(),
+            record_type: "A".into(),
+            value: "10.0.0.2".into(),
+            ttl: 300,
+        },
+    ])
+    .unwrap();
+
+    c.bench_function("zone_lookup_miss", |b| {
+        b.iter(|| {
+            map.lookup(black_box("www.example.com"), QueryType::A);
+        })
+    });
+}
+
+fn bench_zone_lookup_wildcard_hit(c: &mut Criterion) {
+    use numa::config::{build_zone_map, ZoneRecord};
+    let map = build_zone_map(&[ZoneRecord {
+        domain: "*.foo.bar.baz".into(),
+        record_type: "A".into(),
+        value: "10.0.0.1".into(),
+        ttl: 300,
+    }])
+    .unwrap();
+
+    c.bench_function("zone_lookup_wildcard_hit", |b| {
+        b.iter(|| {
+            map.lookup(black_box("deep.sub.foo.bar.baz"), QueryType::A);
+        })
+    });
+}
+
 criterion_group!(
     benches,
     bench_buffer_parse,
@@ -181,5 +225,7 @@ criterion_group!(
     bench_cache_insert,
     bench_round_trip,
     bench_cache_populated_lookup,
+    bench_zone_lookup_miss,
+    bench_zone_lookup_wildcard_hit,
 );
 criterion_main!(benches);

--- a/numa.toml
+++ b/numa.toml
@@ -165,6 +165,15 @@ tld = "numa"
 # value = "router.lan"
 # ttl = 300
 
+# Wildcard zones — one rule covers an entire subtree. Leftmost label only
+# (RFC 4592). Exact entries always win; the wildcard does NOT match its parent
+# (e.g. `*.pool.ntp.org` matches `time2.pool.ntp.org` but not `pool.ntp.org`).
+# [[zones]]
+# domain = "*.pool.ntp.org"
+# record_type = "CNAME"
+# value = "time.onsite"
+# ttl = 60
+
 # DNSSEC signature validation (requires mode = "recursive")
 # [dnssec]
 # enabled = false             # opt-in: verify chain of trust from root KSK

--- a/src/api.rs
+++ b/src/api.rs
@@ -425,15 +425,11 @@ async fn diagnose(
         });
     }
 
-    // Check local zones
-    let zone_match = ctx
-        .zone_map
-        .get(domain_lower.as_str())
-        .and_then(|m| m.get(&qtype));
+    let zone_hit = ctx.zone_map.lookup(domain_lower.as_str(), qtype);
     steps.push(DiagnoseStep {
         source: "local_zone".to_string(),
-        matched: zone_match.is_some(),
-        detail: zone_match.map(|records| format!("{} records", records.len())),
+        matched: zone_hit.is_some(),
+        detail: zone_hit.map(|records| format!("{} records", records.len())),
     });
 
     // Check cache

--- a/src/config.rs
+++ b/src/config.rs
@@ -862,7 +862,9 @@ mod tests {
     #[test]
     fn wildcard_matches_multi_label_descendant() {
         let map = build_zone_map(&[zone("*.example.com", "A", "10.0.0.3")]).unwrap();
-        let records = map.lookup("deep.sub.example.com", QueryType::A).expect("hit");
+        let records = map
+            .lookup("deep.sub.example.com", QueryType::A)
+            .expect("hit");
         match &records[0] {
             DnsRecord::A { domain, addr, .. } => {
                 assert_eq!(domain, "deep.sub.example.com");
@@ -1559,6 +1561,10 @@ impl ZoneMap {
     pub fn len(&self) -> usize {
         self.exact.values().map(|m| m.len()).sum::<usize>()
             + self.wildcard.values().map(|m| m.len()).sum::<usize>()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.exact.is_empty() && self.wildcard.is_empty()
     }
 
     /// `None` = no zone owns this name (fall through to next stage).

--- a/src/config.rs
+++ b/src/config.rs
@@ -789,15 +789,144 @@ mod tests {
         }];
         let map = build_zone_map(&zones).expect("PTR must load");
         let records = map
-            .get("1.0.168.192.in-addr.arpa")
-            .and_then(|m| m.get(&QueryType::PTR))
-            .expect("PTR record present");
+            .lookup("1.0.168.192.in-addr.arpa", QueryType::PTR)
+            .expect("hit");
         match &records[0] {
             DnsRecord::PTR { host, ttl, .. } => {
                 assert_eq!(host, "router.lan");
                 assert_eq!(*ttl, 300);
             }
             other => panic!("expected PTR, got {:?}", other),
+        }
+    }
+
+    fn zone(domain: &str, record_type: &str, value: &str) -> ZoneRecord {
+        ZoneRecord {
+            domain: domain.into(),
+            record_type: record_type.into(),
+            value: value.into(),
+            ttl: 300,
+        }
+    }
+
+    #[test]
+    fn wildcard_exact_match_takes_precedence() {
+        let map = build_zone_map(&[
+            zone("pool.ntp.org", "A", "10.0.0.1"),
+            zone("*.pool.ntp.org", "A", "10.0.0.2"),
+        ])
+        .unwrap();
+        let records = map.lookup("pool.ntp.org", QueryType::A).expect("hit");
+        match &records[0] {
+            DnsRecord::A { addr, .. } => assert_eq!(addr.octets(), [10, 0, 0, 1]),
+            other => panic!("expected A, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn wildcard_matches_descendant() {
+        let map = build_zone_map(&[zone("*.pool.ntp.org", "A", "10.0.0.2")]).unwrap();
+        let records = map.lookup("time2.pool.ntp.org", QueryType::A).expect("hit");
+        match &records[0] {
+            DnsRecord::A { domain, addr, .. } => {
+                assert_eq!(domain, "time2.pool.ntp.org", "owner must be QNAME");
+                assert_eq!(addr.octets(), [10, 0, 0, 2]);
+            }
+            other => panic!("expected A, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn wildcard_does_not_match_parent_itself() {
+        let map = build_zone_map(&[zone("*.pool.ntp.org", "A", "10.0.0.2")]).unwrap();
+        assert!(
+            map.lookup("pool.ntp.org", QueryType::A).is_none(),
+            "wildcard parent must not match the wildcard itself (RFC 4592 §2.1.1)"
+        );
+    }
+
+    #[test]
+    fn wildcard_longest_suffix_wins() {
+        let map = build_zone_map(&[
+            zone("*.b.c", "A", "10.0.0.1"),
+            zone("*.a.b.c", "A", "10.0.0.2"),
+        ])
+        .unwrap();
+        let records = map.lookup("x.a.b.c", QueryType::A).expect("hit");
+        match &records[0] {
+            DnsRecord::A { addr, .. } => assert_eq!(addr.octets(), [10, 0, 0, 2]),
+            other => panic!("expected A, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn wildcard_matches_multi_label_descendant() {
+        let map = build_zone_map(&[zone("*.example.com", "A", "10.0.0.3")]).unwrap();
+        let records = map.lookup("deep.sub.example.com", QueryType::A).expect("hit");
+        match &records[0] {
+            DnsRecord::A { domain, addr, .. } => {
+                assert_eq!(domain, "deep.sub.example.com");
+                assert_eq!(addr.octets(), [10, 0, 0, 3]);
+            }
+            other => panic!("expected A, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn wildcard_invalid_configs_rejected() {
+        assert!(build_zone_map(&[zone("*", "A", "10.0.0.1")]).is_err());
+        assert!(build_zone_map(&[zone("*.*.foo", "A", "10.0.0.1")]).is_err());
+        assert!(build_zone_map(&[zone("foo.*.bar", "A", "10.0.0.1")]).is_err());
+        assert!(build_zone_map(&[zone("*foo.bar", "A", "10.0.0.1")]).is_err());
+    }
+
+    #[test]
+    fn wildcard_cname_rdata_stays_literal() {
+        let map = build_zone_map(&[zone("*.pool.ntp.org", "CNAME", "time.onsite")]).unwrap();
+        let records = map.lookup("x.pool.ntp.org", QueryType::CNAME).expect("hit");
+        match &records[0] {
+            DnsRecord::CNAME { domain, host, .. } => {
+                assert_eq!(domain, "x.pool.ntp.org", "owner is QNAME");
+                assert_eq!(
+                    host, "time.onsite",
+                    "RDATA target stays literal (RFC 4592 §2.3.1)"
+                );
+            }
+            other => panic!("expected CNAME, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn wildcard_nodata_when_qtype_absent() {
+        let map = build_zone_map(&[zone("*.foo", "A", "10.0.0.1")]).unwrap();
+        let result = map.lookup("x.foo", QueryType::AAAA);
+        assert!(
+            result.as_ref().is_some_and(|r| r.is_empty()),
+            "wildcard parent matched but no AAAA — must be NODATA (Some/empty), not None (RFC 4592 §2.2.1)"
+        );
+    }
+
+    #[test]
+    fn exact_name_shadows_wildcard_across_types() {
+        let map = build_zone_map(&[
+            zone("foo.bar", "A", "10.0.0.1"),
+            zone("*.bar", "AAAA", "::1"),
+        ])
+        .unwrap();
+        let result = map.lookup("foo.bar", QueryType::AAAA);
+        assert!(
+            result.as_ref().is_some_and(|r| r.is_empty()),
+            "exact name shadows wildcard for all types (RFC 4592 §3.3.1)"
+        );
+    }
+
+    #[test]
+    fn wildcard_trailing_dot_normalized() {
+        let map = build_zone_map(&[zone("*.foo.bar.", "A", "10.0.0.1")]).unwrap();
+        let records = map.lookup("x.foo.bar", QueryType::A).expect("hit");
+        match &records[0] {
+            DnsRecord::A { addr, .. } => assert_eq!(addr.octets(), [10, 0, 0, 1]),
+            other => panic!("expected A, got {:?}", other),
         }
     }
 
@@ -1420,13 +1549,78 @@ pub fn load_config(path: &str) -> Result<ConfigLoad> {
     })
 }
 
-pub type ZoneMap = HashMap<String, HashMap<QueryType, Vec<DnsRecord>>>;
+#[derive(Default)]
+pub struct ZoneMap {
+    exact: HashMap<String, HashMap<QueryType, Vec<DnsRecord>>>,
+    wildcard: HashMap<String, HashMap<QueryType, Vec<DnsRecord>>>,
+}
+
+impl ZoneMap {
+    pub fn len(&self) -> usize {
+        self.exact.values().map(|m| m.len()).sum::<usize>()
+            + self.wildcard.values().map(|m| m.len()).sum::<usize>()
+    }
+
+    /// `None` = no zone owns this name (fall through to next stage).
+    /// `Some(rrs)` = zone owns name; empty vec is NODATA (RFC 4592 §2.2.1).
+    pub fn lookup(&self, qname: &str, qtype: QueryType) -> Option<Vec<DnsRecord>> {
+        if let Some(records) = self.exact.get(qname) {
+            return Some(records.get(&qtype).cloned().unwrap_or_default());
+        }
+        let mut rest = qname;
+        while let Some(dot) = rest.find('.') {
+            let parent = &rest[dot + 1..];
+            if parent.is_empty() {
+                break;
+            }
+            if let Some(records) = self.wildcard.get(parent) {
+                return Some(
+                    records
+                        .get(&qtype)
+                        .map(|rrs| {
+                            rrs.iter()
+                                .cloned()
+                                .map(|mut r| {
+                                    r.set_domain(qname.to_string());
+                                    r
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                );
+            }
+            rest = parent;
+        }
+        None
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_exact(records: Vec<DnsRecord>) -> Self {
+        let mut m = Self::default();
+        for r in records {
+            m.exact
+                .entry(r.domain().to_string())
+                .or_default()
+                .entry(r.query_type())
+                .or_default()
+                .push(r);
+        }
+        m
+    }
+}
 
 pub fn build_zone_map(zones: &[ZoneRecord]) -> Result<ZoneMap> {
-    let mut map: ZoneMap = HashMap::new();
+    let mut map = ZoneMap::default();
 
     for zone in zones {
-        let domain = zone.domain.to_lowercase();
+        let raw = zone.domain.to_lowercase();
+        let raw = raw.trim_end_matches('.');
+        let is_wildcard = raw.starts_with("*.");
+        let key = if is_wildcard { &raw[2..] } else { raw };
+        if key.is_empty() || key.contains('*') {
+            return Err(format!("invalid wildcard zone '{}'", raw).into());
+        }
+        let domain = key.to_string();
         let (qtype, record) = match zone.record_type.to_uppercase().as_str() {
             "A" => {
                 let addr: Ipv4Addr = zone
@@ -1505,7 +1699,13 @@ pub fn build_zone_map(zones: &[ZoneRecord]) -> Result<ZoneMap> {
             }
         };
 
-        map.entry(domain)
+        let bucket = if is_wildcard {
+            &mut map.wildcard
+        } else {
+            &mut map.exact
+        };
+        bucket
+            .entry(domain)
             .or_default()
             .entry(qtype)
             .or_default()

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -238,9 +238,10 @@ fn resolve_local(
         ));
         return Some((resp, QueryPath::Local, DnssecStatus::Indeterminate));
     }
-    if let Some(records) = ctx.zone_map.get(qname).and_then(|m| m.get(&qtype)) {
+    // RFC 4592 §2.2.1: empty answers (NODATA) still answer locally — don't leak upstream.
+    if let Some(records) = ctx.zone_map.lookup(qname, qtype) {
         let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
-        resp.answers = records.clone();
+        resp.answers = records;
         return Some((resp, QueryPath::Local, DnssecStatus::Indeterminate));
     }
     if is_special_use_domain(qname)
@@ -1300,16 +1301,11 @@ mod tests {
     #[tokio::test]
     async fn pipeline_local_zone_returns_configured_record() {
         let mut ctx = crate::testutil::test_ctx().await;
-        let mut inner = HashMap::new();
-        inner.insert(
-            QueryType::A,
-            vec![DnsRecord::A {
-                domain: "myapp.test".to_string(),
-                addr: Ipv4Addr::new(10, 0, 0, 42),
-                ttl: 300,
-            }],
-        );
-        ctx.zone_map.insert("myapp.test".to_string(), inner);
+        ctx.zone_map = crate::config::ZoneMap::from_exact(vec![DnsRecord::A {
+            domain: "myapp.test".to_string(),
+            addr: Ipv4Addr::new(10, 0, 0, 42),
+            ttl: 300,
+        }]);
         let ctx = Arc::new(ctx);
 
         let (resp, path) = resolve_in_test(&ctx, "myapp.test", QueryType::A).await;
@@ -1319,6 +1315,53 @@ mod tests {
             DnsRecord::A { addr, .. } => assert_eq!(*addr, Ipv4Addr::new(10, 0, 0, 42)),
             other => panic!("expected A record, got {:?}", other),
         }
+    }
+
+    #[tokio::test]
+    async fn pipeline_wildcard_zone_synthesizes_with_qname_owner() {
+        use crate::config::build_zone_map;
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.zone_map = build_zone_map(&[crate::config::ZoneRecord {
+            domain: "*.pool.ntp.org".into(),
+            record_type: "A".into(),
+            value: "10.20.30.40".into(),
+            ttl: 300,
+        }])
+        .unwrap();
+        let ctx = Arc::new(ctx);
+
+        let (resp, path) = resolve_in_test(&ctx, "time2.pool.ntp.org", QueryType::A).await;
+        assert_eq!(path, QueryPath::Local);
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        match &resp.answers[0] {
+            DnsRecord::A { domain, addr, .. } => {
+                assert_eq!(domain, "time2.pool.ntp.org", "owner must be QNAME");
+                assert_eq!(*addr, Ipv4Addr::new(10, 20, 30, 40));
+            }
+            other => panic!("expected A, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn pipeline_wildcard_zone_nodata_does_not_fall_through() {
+        // Wildcard parent matched but qtype absent → NOERROR/empty,
+        // NOT an upstream lookup. Upstream points at a blackhole, so a
+        // fall-through would SERVFAIL after timeout.
+        use crate::config::build_zone_map;
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.zone_map = build_zone_map(&[crate::config::ZoneRecord {
+            domain: "*.foo".into(),
+            record_type: "A".into(),
+            value: "10.0.0.1".into(),
+            ttl: 300,
+        }])
+        .unwrap();
+        let ctx = Arc::new(ctx);
+
+        let (resp, path) = resolve_in_test(&ctx, "x.foo", QueryType::AAAA).await;
+        assert_eq!(path, QueryPath::Local, "must answer locally, not upstream");
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert!(resp.answers.is_empty(), "NoData must return empty answers");
     }
 
     #[tokio::test]
@@ -1971,9 +2014,7 @@ mod tests {
             data: vec![0u8; 5000], // exceeds the 4096-byte serialization buffer
             ttl: 60,
         };
-        let mut inner = HashMap::new();
-        inner.insert(QueryType::UNKNOWN(99), vec![big_record]);
-        ctx.zone_map.insert("huge.test".to_string(), inner);
+        ctx.zone_map = crate::config::ZoneMap::from_exact(vec![big_record]);
         let ctx = Arc::new(ctx);
 
         let mut query = DnsPacket::query(0xBEEF, "huge.test", QueryType::UNKNOWN(99));

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -164,7 +164,6 @@ async fn accept_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
     use std::sync::Mutex;
 
     use rcgen::{CertificateParams, DnType, KeyPair};
@@ -233,20 +232,11 @@ mod tests {
         let upstream_addr = crate::testutil::blackhole_upstream();
 
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.zone_map = {
-            let mut m = HashMap::new();
-            let mut inner = HashMap::new();
-            inner.insert(
-                QueryType::A,
-                vec![DnsRecord::A {
-                    domain: "dot-test.example".to_string(),
-                    addr: std::net::Ipv4Addr::new(10, 0, 0, 1),
-                    ttl: 300,
-                }],
-            );
-            m.insert("dot-test.example".to_string(), inner);
-            m
-        };
+        ctx.zone_map = crate::config::ZoneMap::from_exact(vec![DnsRecord::A {
+            domain: "dot-test.example".to_string(),
+            addr: std::net::Ipv4Addr::new(10, 0, 0, 1),
+            ttl: 300,
+        }]);
         ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
             vec![crate::forward::Upstream::Udp(upstream_addr)],
             vec![],
@@ -423,20 +413,11 @@ mod tests {
         let upstream_addr = crate::testutil::blackhole_upstream();
 
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.zone_map = {
-            let mut m = HashMap::new();
-            let mut inner = HashMap::new();
-            inner.insert(
-                QueryType::A,
-                vec![DnsRecord::A {
-                    domain: "dot-test.example".to_string(),
-                    addr: std::net::Ipv4Addr::new(10, 0, 0, 1),
-                    ttl: 300,
-                }],
-            );
-            m.insert("dot-test.example".to_string(), inner);
-            m
-        };
+        ctx.zone_map = crate::config::ZoneMap::from_exact(vec![DnsRecord::A {
+            domain: "dot-test.example".to_string(),
+            addr: std::net::Ipv4Addr::new(10, 0, 0, 1),
+            ttl: 300,
+        }]);
         ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
             vec![crate::forward::Upstream::Udp(upstream_addr)],
             vec![],

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -459,7 +459,6 @@ async fn handle_upgrade(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
     use std::sync::Mutex;
 
     use rcgen::{CertificateParams, DnType, KeyPair};
@@ -527,20 +526,11 @@ mod tests {
         let upstream_addr = crate::testutil::blackhole_upstream();
 
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.zone_map = {
-            let mut m = HashMap::new();
-            let mut inner = HashMap::new();
-            inner.insert(
-                QueryType::A,
-                vec![DnsRecord::A {
-                    domain: "doh-test.example".to_string(),
-                    addr: std::net::Ipv4Addr::new(10, 0, 0, 2),
-                    ttl: 300,
-                }],
-            );
-            m.insert("doh-test.example".to_string(), inner);
-            m
-        };
+        ctx.zone_map = crate::config::ZoneMap::from_exact(vec![DnsRecord::A {
+            domain: "doh-test.example".to_string(),
+            addr: std::net::Ipv4Addr::new(10, 0, 0, 2),
+            ttl: 300,
+        }]);
         ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
             vec![crate::forward::Upstream::Udp(upstream_addr)],
             vec![],

--- a/src/record.rs
+++ b/src/record.rs
@@ -222,6 +222,24 @@ impl DnsRecord {
         }
     }
 
+    pub(crate) fn set_domain(&mut self, new_domain: String) {
+        match self {
+            DnsRecord::A { domain, .. }
+            | DnsRecord::NS { domain, .. }
+            | DnsRecord::CNAME { domain, .. }
+            | DnsRecord::PTR { domain, .. }
+            | DnsRecord::MX { domain, .. }
+            | DnsRecord::AAAA { domain, .. }
+            | DnsRecord::DNSKEY { domain, .. }
+            | DnsRecord::DS { domain, .. }
+            | DnsRecord::RRSIG { domain, .. }
+            | DnsRecord::NSEC { domain, .. }
+            | DnsRecord::NSEC3 { domain, .. }
+            | DnsRecord::SOA { domain, .. }
+            | DnsRecord::UNKNOWN { domain, .. } => *domain = new_domain,
+        }
+    }
+
     pub fn read(buffer: &mut BytePacketBuffer) -> Result<DnsRecord> {
         let mut domain = String::with_capacity(64);
         buffer.read_qname(&mut domain)?;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -198,7 +198,7 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         filter_aaaa: config.server.filter_aaaa,
     });
 
-    let zone_count: usize = ctx.zone_map.values().map(|m| m.len()).sum();
+    let zone_count: usize = ctx.zone_map.len();
     let api_url = format!("http://localhost:{}", api_port);
     print_banner(
         &config,

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -222,7 +222,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
     use std::sync::Mutex;
 
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -238,20 +237,11 @@ mod tests {
         let upstream_addr = crate::testutil::blackhole_upstream();
 
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.zone_map = {
-            let mut m = HashMap::new();
-            let mut inner = HashMap::new();
-            inner.insert(
-                QueryType::A,
-                vec![DnsRecord::A {
-                    domain: "tcp-test.example".to_string(),
-                    addr: std::net::Ipv4Addr::new(10, 0, 0, 1),
-                    ttl: 300,
-                }],
-            );
-            m.insert("tcp-test.example".to_string(), inner);
-            m
-        };
+        ctx.zone_map = crate::config::ZoneMap::from_exact(vec![DnsRecord::A {
+            domain: "tcp-test.example".to_string(),
+            addr: std::net::Ipv4Addr::new(10, 0, 0, 1),
+            ttl: 300,
+        }]);
         ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
             vec![crate::forward::Upstream::Udp(upstream_addr)],
             vec![],
@@ -398,20 +388,11 @@ mod tests {
         let upstream_addr = crate::testutil::blackhole_upstream();
 
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.zone_map = {
-            let mut m = HashMap::new();
-            let mut inner = HashMap::new();
-            inner.insert(
-                QueryType::A,
-                vec![DnsRecord::A {
-                    domain: "tcp-test.example".to_string(),
-                    addr: std::net::Ipv4Addr::new(10, 0, 0, 1),
-                    ttl: 300,
-                }],
-            );
-            m.insert("tcp-test.example".to_string(), inner);
-            m
-        };
+        ctx.zone_map = crate::config::ZoneMap::from_exact(vec![DnsRecord::A {
+            domain: "tcp-test.example".to_string(),
+            addr: std::net::Ipv4Addr::new(10, 0, 0, 1),
+            ttl: 300,
+        }]);
         ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
             vec![crate::forward::Upstream::Udp(upstream_addr)],
             vec![],

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -9,7 +9,7 @@ use tokio::net::UdpSocket;
 use crate::blocklist::BlocklistStore;
 use crate::buffer::BytePacketBuffer;
 use crate::cache::DnsCache;
-use crate::config::UpstreamMode;
+use crate::config::{UpstreamMode, ZoneMap};
 use crate::ctx::ServerCtx;
 use crate::forward::{Upstream, UpstreamPool};
 use crate::header::ResultCode;
@@ -28,7 +28,7 @@ pub async fn test_ctx() -> ServerCtx {
     let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     ServerCtx {
         socket,
-        zone_map: HashMap::new(),
+        zone_map: ZoneMap::default(),
         cache: RwLock::new(DnsCache::new(100, 60, 86400)),
         refreshing: Mutex::new(HashSet::new()),
         stats: Mutex::new(ServerStats::new()),

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -370,11 +370,23 @@ domain = "1.0.168.192.in-addr.arpa"
 record_type = "PTR"
 value = "router.lan"
 ttl = 60
+
+# RFC 4592 wildcard — exercises the wire path only (owner=QNAME
+# synthesis, NODATA does not leak upstream). Apex shadowing,
+# trailing-dot normalization, and no-apex-match are covered by unit
+# tests in src/config.rs.
+[[zones]]
+domain = "*.foo.test"
+record_type = "A"
+value = "10.0.0.2"
+ttl = 60
 CONF
 
 RUST_LOG=info "$BINARY" "$CONFIG" > "$LOG" 2>&1 &
 NUMA_PID=$!
 sleep 3
+
+DIG="dig @127.0.0.1 -p $PORT +time=5 +tries=1"
 
 echo ""
 echo "=== Local Zones ==="
@@ -395,6 +407,35 @@ check "Local PTR record (192.168.0.1 → router.lan)" \
 check "Non-local domain still resolves" \
     "." \
     "$($DIG example.com A +short)"
+
+echo ""
+echo "=== Wildcard zones (RFC 4592) ==="
+
+# Owner is synthesized to QNAME on the wire (single descendant label).
+check "Wildcard owner = QNAME (x.foo.test A)" \
+    "10.0.0.2" \
+    "$($DIG x.foo.test A +short)"
+
+# Owner synthesis also works for multi-label descendants.
+check "Wildcard multi-label (deep.sub.foo.test A)" \
+    "10.0.0.2" \
+    "$($DIG deep.sub.foo.test A +short)"
+
+# Wildcard NODATA must not leak upstream (RFC 4592 §2.2.1).
+WILD_AAAA=$($DIG x.foo.test AAAA)
+check "Wildcard NODATA: status NOERROR" \
+    "status: NOERROR" \
+    "$WILD_AAAA"
+check "Wildcard NODATA: ANSWER: 0 (no upstream leak)" \
+    "ANSWER: 0" \
+    "$WILD_AAAA"
+
+# Exact-name NODATA also stays local (RFC 1034 §4.3.2 — PR #207
+# tightens this; previously fell through to upstream).
+EXACT_AAAA=$($DIG test.local AAAA)
+check "Exact NODATA: ANSWER: 0 (no upstream leak)" \
+    "ANSWER: 0" \
+    "$EXACT_AAAA"
 
 echo ""
 echo "=== DNS-over-TCP listener (RFC 1035 §4.2.2 / RFC 7766) ==="


### PR DESCRIPTION
Closes #117. Split from #102 item 4 (reporter: @bcookatpcsd; #117 comment from @zombiehoffa flagged this as the blocker for trialing Numa).

## Summary

- Leftmost-label wildcards in `[zones]` (RFC 4592): `*.foo.bar` matches `x.foo.bar` and `deep.sub.foo.bar`, never `foo.bar` itself.
- Exact entries shadow wildcards; among wildcards, longest suffix wins.
- Owner name on the synthesized record is the QNAME; RDATA (including CNAME targets) stays literal.
- `ZoneMap` migrated from `HashMap` alias to a struct with `exact` + `wildcard` buckets. `lookup()` returns `Option<Vec<DnsRecord>>` — `None` falls through to the next pipeline stage, `Some(empty)` is NODATA.

## Behavior changes

- **NODATA from local zones no longer leaks upstream.** Pre-PR, a zone like `foo.test A = 1.2.3.4` with a query for `foo.test AAAA` fell through to upstream. Post-PR, it returns NOERROR / empty (RFC 1034 §4.3.2, and required by RFC 4592 §2.2.1 for wildcards). Strictly more correct, but observable for anyone relying on upstream fallback.
- **Trailing dot in zone domain is now stripped.** `domain = "foo.test."` was previously dead config (never matched the dot-less qname). Now it normalizes correctly.

## Validation

- 10 unit tests in `src/config.rs` covering RFC 4592 cases (exact precedence, parent-not-matched, longest suffix, multi-label descendant, invalid configs, CNAME RDATA literal, NODATA, exact-shadows-wildcard, trailing-dot normalization).
- 2 pipeline tests in `src/ctx.rs` (`pipeline_wildcard_zone_synthesizes_with_qname_owner`, `pipeline_wildcard_zone_nodata_does_not_fall_through`).
- 2 new criterion benches: `zone_lookup_miss` (~20 ns, regression-prone hot path) and `zone_lookup_wildcard_hit` (~63 ns, target <2 µs).

## Test plan

- [x] `cargo test --all` — 425 lib + 2 main + 1 integration tests pass.
- [x] `cargo clippy --lib` — clean (no new lints from this PR).
- [x] `cargo fmt --check` — clean.
- [x] `cargo bench --bench hot_path` — `zone_lookup_miss` flat (~20 ns); no Criterion-detected regression on `buffer_parse`, `cache_*`, `round_trip_cached`.
- [x] Live `dig` against numa with `pool.ntp.org A = 10.0.0.1` + `*.pool.ntp.org A = 10.0.0.2`:
  - `pool.ntp.org A` → `10.0.0.1` (exact wins)
  - `a.pool.ntp.org A` → `10.0.0.2` (owner = qname)
  - `deep.sub.pool.ntp.org A` → `10.0.0.2` (multi-label)
  - `pool.ntp.org AAAA` → NOERROR / ANSWER: 0 (no upstream leak)
  - `a.pool.ntp.org AAAA` → NOERROR / ANSWER: 0 (wildcard NODATA)
  - `example.com A` → upstream resolves (unaffected path)