### PR TITLE
fix(ci): install clippy component on macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: clippy
         run: cargo clippy -- -D warnings
       - name: test
@@ -129,6 +131,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: build
         run: cargo build --release
       - name: install / verify / re-install / uninstall

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: clippy
         run: cargo clippy -- -D warnings


### PR DESCRIPTION
## Summary

- macOS runner image `macos-15-arm64/20260511.0048` (released 2026-05-13) no longer ships `clippy` pre-installed.
- `cargo clippy` falls through to `rustup-init`, which fails with `error: unexpected argument 'clippy' found`.
- Linux already has `components: rustfmt, clippy` on `dtolnay/rust-toolchain@stable`; this applies the same pattern to the macOS job.
- Windows currently still bundles clippy in its toolchain — leaving it unchanged to keep this PR minimal. If it breaks the same way, the same two-line fix applies.

## Why now

Caught by the failing `check-macos / clippy` step on #207 (wildcard zones). Every PR will be red on macOS until this lands; main was last green on 25810094042 (PR #206 merge) before the image rollout.

## Test plan

- [ ] CI: `check-macos / clippy` passes on this PR