### PR TITLE
fix: ignore root resolv search domain

### DIFF
--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -337,6 +337,12 @@ fn iter_nameservers(content: &str) -> impl Iterator<Item = &str> {
 /// Parse resolv.conf in a single pass, extracting the first non-loopback
 /// nameserver and all search domains.
 #[cfg(target_os = "linux")]
+fn normalize_search_domain(domain: &str) -> Option<String> {
+    let domain = domain.trim().trim_end_matches('.');
+    (!domain.is_empty()).then(|| domain.to_string())
+}
+
+#[cfg(target_os = "linux")]
 fn parse_resolv_conf(path: &str) -> (Option<String>, Vec<String>) {
     let text = match std::fs::read_to_string(path) {
         Ok(t) => t,
@@ -350,7 +356,9 @@ fn parse_resolv_conf(path: &str) -> (Option<String>, Vec<String>) {
         let line = line.trim();
         if line.starts_with("search") || line.starts_with("domain") {
             for domain in line.split_whitespace().skip(1) {
-                search_domains.push(domain.to_string());
+                if let Some(domain) = normalize_search_domain(domain) {
+                    search_domains.push(domain);
+                }
             }
         }
     }
@@ -2017,6 +2025,49 @@ mod tests {
         let mixed = "nameserver 127.0.0.1\nnameserver 1.1.1.1\n";
         assert!(resolv_conf_has_real_upstream(mixed));
         assert!(!resolv_conf_is_numa_managed(mixed));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn parse_resolv_conf_ignores_root_search_domain() {
+        let path = std::env::temp_dir().join(format!(
+            "numa-resolv-conf-root-search-{}",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            "nameserver 127.0.0.53\noptions edns0 trust-ad\nsearch .\n",
+        )
+        .unwrap();
+
+        let (upstream, search_domains) = parse_resolv_conf(path.to_str().unwrap());
+        let _ = std::fs::remove_file(path);
+
+        assert_eq!(upstream, None);
+        assert!(search_domains.is_empty());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn parse_resolv_conf_preserves_real_search_domains() {
+        let path = std::env::temp_dir().join(format!(
+            "numa-resolv-conf-search-domain-{}",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            "nameserver 192.168.1.1\nsearch ec2.internal compute.internal. corp.example.\n",
+        )
+        .unwrap();
+
+        let (upstream, search_domains) = parse_resolv_conf(path.to_str().unwrap());
+        let _ = std::fs::remove_file(path);
+
+        assert_eq!(upstream.as_deref(), Some("192.168.1.1"));
+        assert_eq!(
+            search_domains,
+            vec!["ec2.internal", "compute.internal", "corp.example"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- ignore root-equivalent Linux `resolv.conf` search domains like `.`
- normalize trailing dots from useful search domains before creating forwarding rules
- add regression coverage for systemd-resolved `search .` output

## Background

On Linux systems using systemd-resolved, a route-only root DNS domain (`~.`) means DNS for all domains should be routed through that link's configured resolver. This is a valid setup when Numa is installed as the local resolver and NetworkManager/systemd-resolved point the active interface at `127.0.0.1`.

systemd-resolved can expose that route-only root domain through generated `resolv.conf` as:

```text
search .
```

Before this change, Numa treated `.` like an ordinary search domain and attempted to create a conditional forwarding rule for it. If no non-loopback system resolver was available, that rule used the existing cloud/VPC fallback resolver `169.254.169.253`, producing confusing startup output such as:

```text
forwarding .. to 169.254.169.253
```

The fix changes Linux `resolv.conf` search-domain parsing so root-equivalent search domains are ignored. `search .` now produces no conditional forwarding rule instead of creating a bogus `.. -> 169.254.169.253` rule.

Useful search domains with trailing dots are still preserved after normalization. For example:

```text
search corp.example.
```

is treated as:

```text
corp.example
```

This change does not remove or alter the cloud/VPC fallback behavior. Real search domains such as `ec2.internal`, `compute.internal`, or `corp.example` can still become conditional forwarding rules and can still use the fallback resolver when appropriate. The change only prevents the DNS root (`.`), as surfaced by systemd-resolved `~.`, from being treated as a real search-domain suffix.

## Validation

- `cargo fmt --check`
- `cargo test -q parse_resolv_conf`
- `cargo test`
- `cargo clippy --lib --bins -- -D warnings`

Note: `cargo clippy --all-targets -- -D warnings` still fails on pre-existing unrelated clippy warnings in benches and test-only code.

