### PR TITLE
refactor: inline normalize_search_domain helper

### DIFF
--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -335,13 +335,8 @@ fn iter_nameservers(content: &str) -> impl Iterator<Item = &str> {
 }
 
 /// Parse resolv.conf in a single pass, extracting the first non-loopback
-/// nameserver and all search domains.
-#[cfg(target_os = "linux")]
-fn normalize_search_domain(domain: &str) -> Option<String> {
-    let domain = domain.trim().trim_end_matches('.');
-    (!domain.is_empty()).then(|| domain.to_string())
-}
-
+/// nameserver and all search domains. Trailing dots are stripped and the
+/// root domain (`.`, as emitted by systemd-resolved for `~.`) is dropped.
 #[cfg(target_os = "linux")]
 fn parse_resolv_conf(path: &str) -> (Option<String>, Vec<String>) {
     let text = match std::fs::read_to_string(path) {
@@ -356,8 +351,9 @@ fn parse_resolv_conf(path: &str) -> (Option<String>, Vec<String>) {
         let line = line.trim();
         if line.starts_with("search") || line.starts_with("domain") {
             for domain in line.split_whitespace().skip(1) {
-                if let Some(domain) = normalize_search_domain(domain) {
-                    search_domains.push(domain);
+                let domain = domain.trim_end_matches('.');
+                if !domain.is_empty() {
+                    search_domains.push(domain.to_string());
                 }
             }
         }


### PR DESCRIPTION
## Summary

Follow-up to #212. Inlines the `normalize_search_domain` helper into `parse_resolv_conf`:

- **−4 lines net** (5 insertions, 9 deletions); one function and one `#[cfg]` gate removed
- Drops a redundant `.trim()` — `split_whitespace` already strips surrounding whitespace
- Restores the `parse_resolv_conf` doc comment to its function (previously the new helper was inserted between the docstring and `parse_resolv_conf`)
- Behavior unchanged — the trailing-dot / root-domain normalization is now expressed inline at the only call site

## Validation

- `cargo fmt --check`
- `cargo test --lib parse_resolv_conf` — both PR-#212 regression tests still pass (`parse_resolv_conf_ignores_root_search_domain`, `parse_resolv_conf_preserves_real_search_domains`)
- End-to-end docker test with crafted `/etc/resolv.conf` (`search .` and `search corp.example.`) — same observed behavior as #212: no `forwarding .. to ...` log, trailing dots stripped from forwarding-rule logs

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test --lib parse_resolv_conf`
- [x] End-to-end docker reproduction (alpine + crafted resolv.conf)