### PR TITLE
ci: match nested markdown in paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'site/**'
       - 'blog/**'
       - 'drafts/**'
-      - '*.md'
+      - '**/*.md'
       - 'scripts/serve-site.sh'
       - 'scripts/generate-blog-index.sh'
   pull_request:
@@ -16,7 +16,7 @@ on:
       - 'site/**'
       - 'blog/**'
       - 'drafts/**'
-      - '*.md'
+      - '**/*.md'
       - 'scripts/serve-site.sh'
       - 'scripts/generate-blog-index.sh'
 

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -27,7 +27,7 @@ on:
       - 'site/**'
       - 'blog/**'
       - 'drafts/**'
-      - '*.md'
+      - '**/*.md'
       - 'scripts/serve-site.sh'
       - 'scripts/generate-blog-index.sh'
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- `*.md` in `paths-ignore` only matches files at the repo root — nested markdown (`recipes/*.md`, `docs/**/*.md`, `packaging/**/*.md`) slips through and triggers full CI on docs-only changes.
- On `publish-aur.yml`, the same leak causes a fresh AUR `numa-git` publish for every nested-markdown commit landed on `main`.
- Switching the three occurrences to `**/*.md` matches the entire tree, so docs-only commits skip CI and AUR.

## Test plan
- [ ] Merge, then push a docs-only commit touching a nested `.md` (e.g. `recipes/dnsdist-front.md`) — CI and AUR-publish should both skip.
- [ ] Verify root-level markdown (`README.md`, `CHANGELOG.md`) still skips as before.