### PR TITLE
fix(dashboard): honor configured proxy TLD in service names

### DIFF
--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -717,14 +717,14 @@ body {
         <div class="panel-header">
           <div style="flex:1;">
             <span class="panel-title">Local Services</span>
-            <div style="font-size:0.68rem;color:var(--text-dim);margin-top:0.15rem;">Give localhost apps clean .numa URLs. Persistent, with HTTP proxy.</div>
+            <div style="font-size:0.68rem;color:var(--text-dim);margin-top:0.15rem;">Give localhost apps clean URLs. Persistent, with HTTP proxy.</div>
           </div>
           <span id="lanToggle" style="font-family:var(--font-mono);font-size:0.68rem;cursor:default;user-select:none;" title=""></span>
         </div>
         <div class="panel-body">
           <form class="override-form" id="serviceForm" onsubmit="return addService(event)">
             <div class="override-form-row">
-              <input type="text" id="svcName" placeholder="name (becomes name.numa)" required style="flex:2">
+              <input type="text" id="svcName" placeholder="service name" required style="flex:2">
               <input type="number" id="svcPort" placeholder="port (e.g. 3000)" required min="1" max="65535" style="flex:1">
             </div>
             <button type="submit" class="btn btn-add">Add Service</button>
@@ -849,6 +849,7 @@ function formatTime(epoch) {
 }
 
 let mobilePort = 8765;
+let proxyTld = 'numa';
 function togglePhoneSetup() {
   const pop = document.getElementById('phoneSetupPopover');
   const isOpen = pop.style.display !== 'none';
@@ -1165,6 +1166,8 @@ async function refresh() {
     document.getElementById('statusDot').className = 'status-dot';
     document.getElementById('statusText').textContent = 'connected';
 
+    if (stats.proxy_tld) proxyTld = stats.proxy_tld;
+
     // Stats cards
     const q = stats.queries;
     document.getElementById('totalQueries').textContent = formatNumber(q.total);
@@ -1459,7 +1462,7 @@ function renderServices(entries) {
     <div class="service-item">
       <span class="health-dot ${e.healthy ? 'up' : 'down'}" title="${e.healthy ? 'running' : 'not reachable'}"></span>
       <div class="service-info">
-        <div class="service-name"><a href="${h(e.url)}" target="_blank">${name}.numa</a>${lanBadge}</div>
+        <div class="service-name"><a href="${h(e.url)}" target="_blank">${name}.${h(proxyTld)}</a>${lanBadge}</div>
         <div class="service-port">localhost:${parseInt(e.target_port)||0} &rarr; proxied</div>
         ${routeLines}
         ${e.name === 'numa' ? '' : `<div style="margin-top:0.3rem;"><button onclick="toggleRouteForm('${name}')" style="font-size:0.7rem;padding:0.1rem 0.4rem;background:var(--emerald);color:var(--bg);border:none;border-radius:4px;cursor:pointer;">+ route</button><div id="routeForm-${name}" style="display:none;margin-top:0.3rem;"><div style="display:flex;gap:0.3rem;align-items:center;"><input type="text" id="routePath-${name}" placeholder="/path" style="flex:2;padding:0.25rem 0.4rem;font-size:0.75rem;"><input type="number" id="routePort-${name}" value="${parseInt(e.target_port)||0}" min="1" max="65535" style="flex:1;padding:0.25rem 0.4rem;font-size:0.75rem;"><label style="font-size:0.7rem;color:var(--text-dim);display:flex;align-items:center;gap:0.2rem;"><input type="checkbox" id="routeStrip-${name}">strip</label><button onclick="addRoute('${name}')" style="font-size:0.7rem;padding:0.2rem 0.5rem;background:var(--emerald);color:var(--bg);border:none;border-radius:4px;cursor:pointer;">add</button></div><div class="override-error" id="routeError-${name}" style="display:none;font-size:0.7rem;"></div></div></div>`}

--- a/src/api.rs
+++ b/src/api.rs
@@ -171,6 +171,7 @@ struct StatsResponse {
     mode: &'static str, // "recursive" or "forward" — never "auto" at runtime
     config_path: String,
     data_dir: String,
+    proxy_tld: String,
     dnssec: bool,
     srtt: bool,
     queries: QueriesStats,
@@ -567,6 +568,7 @@ async fn stats(State(ctx): State<Arc<ServerCtx>>) -> Json<StatsResponse> {
         mode: ctx.upstream_mode.as_str(),
         config_path: ctx.config_path.clone(),
         data_dir: ctx.data_dir.to_string_lossy().to_string(),
+        proxy_tld: ctx.proxy_tld.clone(),
         dnssec: ctx.dnssec_enabled,
         srtt: srtt_enabled,
         queries: QueriesStats {


### PR DESCRIPTION
## Summary
- Dashboard rendered every local service as `<name>.numa` regardless of the configured `proxy.tld`. The link href was correct, so clicks worked — but the displayed suffix lied (issue #211, second half).
- Expose `proxy_tld` via `/stats` and use it in the rendered service-name link.
- Drop the hardcoded `.numa` example from the panel description and input placeholder so the static HTML stays TLD-agnostic (no first-paint flash for users on a custom TLD).

## Test plan
- [x] `make all` green (lint + 434 tests)
- [x] Manual: load dashboard with default config — service names render as `<name>.numa` (unchanged).
- [x] Manual: set `proxy.tld = "lab"` in `numa.toml`, restart — service names render as `<name>.lab`, no `.numa` flash on first paint.