### PR TITLE
fix(freebsd): unblock cargo build, hint at rc.d setup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,9 +192,10 @@ fn daemon_data_dir() -> std::path::PathBuf {
             std::path::Path::new("/var/lib/numa").exists(),
         ))
     }
-    #[cfg(target_os = "macos")]
+    #[cfg(not(target_os = "linux"))]
     {
-        // macOS uses the Homebrew prefix convention; no FHS migration needed.
+        // macOS (Homebrew) and FreeBSD/other BSDs (ports/pkg) share the
+        // `/usr/local/var` convention; no FHS migration needed.
         std::path::PathBuf::from("/usr/local/var/numa")
     }
 }

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -1113,6 +1113,13 @@ const SYSTEMD_UNIT: &str = "/etc/systemd/system/numa.service";
 const SKIP_DNS_NOTICE: &str =
     "  --no-system-dns: system DNS unchanged. Point clients at 127.0.0.1 yourself.";
 
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+fn unsupported_os_err(op: &str) -> String {
+    format!(
+        "{op} not supported on this OS — run `numa` directly under an rc.d/init script and set /etc/resolv.conf to 127.0.0.1 manually"
+    )
+}
+
 /// Install Numa as a system service that starts on boot and auto-restarts.
 ///
 /// `skip_system_dns = true` registers the service but leaves the host's DNS
@@ -1129,7 +1136,7 @@ pub fn install_service(skip_system_dns: bool) -> Result<(), String> {
     #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
     let result = {
         let _ = skip_system_dns;
-        Err::<(), String>("service installation not supported on this OS".to_string())
+        Err::<(), String>(unsupported_os_err("service installation"))
     };
 
     if result.is_ok() {
@@ -1166,7 +1173,7 @@ pub fn start_service(skip_system_dns: bool) -> Result<(), String> {
     #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
     {
         let _ = skip_system_dns;
-        Err("service start not supported on this OS".to_string())
+        Err(unsupported_os_err("service start"))
     }
 }
 
@@ -1195,7 +1202,7 @@ pub fn stop_service() -> Result<(), String> {
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
     {
-        Err("service stop not supported on this OS".to_string())
+        Err(unsupported_os_err("service stop"))
     }
 }
 
@@ -1217,7 +1224,7 @@ pub fn uninstall_service() -> Result<(), String> {
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
     {
-        Err("service uninstallation not supported on this OS".to_string())
+        Err(unsupported_os_err("service uninstallation"))
     }
 }
 
@@ -1245,7 +1252,7 @@ pub fn restart_service() -> Result<(), String> {
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
     {
-        Err("service restart not supported on this OS".to_string())
+        Err(unsupported_os_err("service restart"))
     }
 }
 
@@ -1318,7 +1325,7 @@ pub fn service_status() -> Result<(), String> {
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
     {
-        Err("service status not supported on this OS".to_string())
+        Err(unsupported_os_err("service status"))
     }
 }
 


### PR DESCRIPTION
Closes #162.

## Problem

`daemon_data_dir()` in `src/lib.rs` is gated `#[cfg(not(windows))]`, but its body only branches on `linux` and `macos`. On FreeBSD (or any other non-Linux, non-macOS, non-Windows unix), both inner `#[cfg]` blocks evaluate false, leaving an empty body in a function declared to return `PathBuf`:

```
error[E0308]: mismatched types
   --> src/lib.rs:187:25
    |
187 | fn daemon_data_dir() -> std::path::PathBuf {
    |    ---------------      ^^^^^^^^^^^^^^^^^^ expected `PathBuf`, found `()`
    |    implicitly returns `()` as its body has no tail or `return` expression
```

Reported by @xpader in #162; confirmed independently by @bcookatpcsd. Blocks `cargo install numa` on FreeBSD.

## Fix

Change the macOS branch to `#[cfg(not(target_os = "linux"))]` so it covers macOS, FreeBSD, and other non-Linux unix. `/usr/local/var/numa` is the Homebrew prefix on macOS *and* the standard `pkg`/ports prefix on the BSDs, so the path matches platform convention everywhere.

## Bonus

While verifying end-to-end in a Lima FreeBSD 15.0 aarch64 VM, the daemon itself runs cleanly — DNS, blocking, API, dashboard, DoT all work. Only the system-integration commands (`numa install`, `numa service start`, etc.) decline. They already errored cleanly via existing `cfg(not(any(...)))` fallbacks, but the messages were terse ("service installation not supported on this OS"). Wrapped the six service messages in a small helper so they all read:

> service installation not supported on this OS — run \`numa\` directly under an rc.d/init script and set /etc/resolv.conf to 127.0.0.1 manually

This gives FreeBSD/OpenBSD/NetBSD users a clear pointer to the manual setup rather than leaving them guessing.

## Test plan

- [x] `cargo build --release` succeeds in Lima FreeBSD 15.0 aarch64 (with fix)
- [x] `cargo build --release` fails with E0308 at `src/lib.rs:187` (without fix — confirms repro of #162)
- [x] `dig @127.0.0.1 -p 5354 example.com` returns valid A records from the FreeBSD-hosted daemon
- [x] `/health` endpoint returns 200 + JSON
- [x] `numa install` exits 1 with the new helpful error message
- [x] `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt --check` pass on macOS
- [x] CI green on Linux/macOS/Windows (no behavior change on those platforms)

## Out of scope

- Writing an rc.d service template + `system_dns_freebsd.rs` to make `numa install` actually do something on FreeBSD. The current "errors cleanly with a pointer" UX is sufficient for a v1 FreeBSD release; we can expand if a FreeBSD user opens a follow-up issue.
- The `log::info` unused-import + `SKIP_DNS_NOTICE` dead-const warnings that appear on FreeBSD builds (only visible there because CI doesn't run on FreeBSD).