### PR TITLE
ci: cross-build for x86_64-unknown-freebsd on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,18 @@ jobs:
       - name: smoke test
         run: ./result/bin/numa --version
 
+  cross-build-freebsd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-freebsd
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cross
+      - name: build
+        run: cross build --target x86_64-unknown-freebsd --release
+
   integration-linux:
     needs: [check]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #220.

Adds a `cross-build-freebsd` CI job that compiles numa for `x86_64-unknown-freebsd` on every PR. The class of bug that produced #162 (a function gated `#[cfg(not(windows))]` with no FreeBSD branch in the body, producing E0308) is exactly the kind of regression a Linux+macOS+Windows CI matrix will never catch.

## Why cross, not Lima

- **Speed.** `cross-rs` uses a prebuilt Docker image with the FreeBSD sysroot baked in. ~2 min per CI run vs Lima's ~10-15 min for a fresh boot.
- **Fits the runner.** GitHub Actions has no native FreeBSD runner; cross gives us "FreeBSD build coverage" using only an `ubuntu-latest` runner.
- **Matches the reporter's arch.** xpader hit the original bug on `x86_64-unknown-freebsd`. Lima on apple silicon defaults to aarch64.

## Why build-only, not runtime

`cross` produces a FreeBSD binary that the Linux host can't execute, so this job won't `dig` against a live daemon the way the Linux/macOS integration jobs do. That's a tradeoff:

- The runtime fault mode for numa on FreeBSD has been verified end-to-end in Lima (see #220 description) — daemon runs, DNS resolves, blocking/DoT/dashboard all work.
- Adding runtime coverage would need `vmactions/freebsd-vm` (~10 min per run) or Cirrus CI (second provider). Not worth it until a FreeBSD user opens issues that warrant it.

## Test plan

- [ ] `cross-build-freebsd` job passes on this PR (validates the YAML + that #220's fix holds under x86_64 target)
- [ ] Job runs in ~2-3 min
- [ ] No regression to the other CI jobs