### PR TITLE
feat(server): accept a list of bind addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Machine A (192.168.1.5)              Machine B (192.168.1.20)
 
 From Machine B: `curl http://api.numa` → proxied to Machine A's port 8000. Enable with `numa lan on`.
 
-**Hub mode**: run one instance with `bind_addr = "0.0.0.0:53"` and point other devices' DNS to it — they get ad blocking + `.numa` resolution without installing anything.
+**Hub mode**: run one instance with `bind_addr = "0.0.0.0:53"` and point other devices' DNS to it — they get ad blocking + `.numa` resolution without installing anything. `bind_addr` also accepts a list to bind a specific subset of interfaces.
 
 ## Docker
 

--- a/numa.toml
+++ b/numa.toml
@@ -1,5 +1,5 @@
 [server]
-bind_addr = "0.0.0.0:53"
+bind_addr = "0.0.0.0:53"           # or a list: ["10.0.0.1:53", "127.0.0.1:53"]
 api_port = 5380
 # api_bind_addr = "127.0.0.1"  # default; set to "0.0.0.0" for LAN dashboard access
 # data_dir = "/var/lib/numa"  # where numa stores TLS CA and cert material

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,8 +83,8 @@ pub fn merge_forwarding_rules(
 
 #[derive(Deserialize)]
 pub struct ServerConfig {
-    #[serde(default = "default_bind_addr")]
-    pub bind_addr: String,
+    #[serde(default = "default_bind_addrs", deserialize_with = "string_or_vec")]
+    pub bind_addr: Vec<String>,
     #[serde(default = "default_api_port")]
     pub api_port: u16,
     #[serde(default = "default_api_bind_addr")]
@@ -110,7 +110,7 @@ pub struct ServerConfig {
 impl Default for ServerConfig {
     fn default() -> Self {
         ServerConfig {
-            bind_addr: default_bind_addr(),
+            bind_addr: default_bind_addrs(),
             api_port: default_api_port(),
             api_bind_addr: default_api_bind_addr(),
             data_dir: None,
@@ -129,11 +129,11 @@ fn default_api_bind_addr() -> String {
 #[cfg(windows)]
 pub const NUMA_LOOPBACK_IP: &str = "127.0.0.2";
 
-fn default_bind_addr() -> String {
+fn default_bind_addrs() -> Vec<String> {
     #[cfg(windows)]
-    return format!("{}:53", NUMA_LOOPBACK_IP);
+    return vec![format!("{}:53", NUMA_LOOPBACK_IP)];
     #[cfg(not(windows))]
-    return "0.0.0.0:53".to_string();
+    return vec!["0.0.0.0:53".to_string()];
 }
 
 pub const DEFAULT_API_PORT: u16 = 5380;
@@ -979,6 +979,23 @@ mod tests {
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.server.api_bind_addr, "0.0.0.0");
         assert_eq!(config.proxy.bind_addr, "0.0.0.0");
+    }
+
+    #[test]
+    fn server_bind_addr_accepts_string_or_list() {
+        let single: Config = toml::from_str(
+            r#"[server]
+            bind_addr = "127.0.0.1:53""#,
+        )
+        .unwrap();
+        assert_eq!(single.server.bind_addr, vec!["127.0.0.1:53"]);
+
+        let list: Config = toml::from_str(
+            r#"[server]
+            bind_addr = ["127.0.0.1:53", "10.0.0.1:53"]"#,
+        )
+        .unwrap();
+        assert_eq!(list.server.bind_addr, vec!["127.0.0.1:53", "10.0.0.1:53"]);
     }
 
     #[test]

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -33,7 +33,6 @@ use crate::stats::{QueryPath, ServerStats, Transport};
 use crate::system_dns::ForwardingRule;
 
 pub struct ServerCtx {
-    pub socket: UdpSocket,
     pub zone_map: ZoneMap,
     /// std::sync::RwLock (not tokio) — locks must never be held across .await points.
     pub cache: RwLock<DnsCache>,
@@ -542,6 +541,7 @@ pub async fn handle_query(
     src_addr: SocketAddr,
     respond_to: SocketAddr,
     ctx: &Arc<ServerCtx>,
+    reply_socket: &Arc<UdpSocket>,
     transport: Transport,
 ) -> crate::Result<()> {
     let query = match DnsPacket::from_buffer(&mut buffer) {
@@ -553,7 +553,9 @@ pub async fn handle_query(
     };
     match resolve_query(query, &buffer.buf[..raw_len], src_addr, ctx, transport).await {
         Ok((resp_buffer, _)) => {
-            ctx.socket.send_to(resp_buffer.filled(), respond_to).await?;
+            reply_socket
+                .send_to(resp_buffer.filled(), respond_to)
+                .await?;
         }
         Err(e) => {
             warn!("{} | RESOLVE ERROR | {}", src_addr, e);
@@ -2145,5 +2147,54 @@ mod tests {
 
         assert!(resp.header.truncated_message, "TC bit must be set");
         assert!(resp.edns.is_some(), "TC response must mirror client's OPT");
+    }
+
+    #[tokio::test]
+    async fn handle_query_reply_leaves_provided_socket() {
+        use tokio::net::UdpSocket;
+
+        let sock_a = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+        let sock_b = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+        let addr_a = sock_a.local_addr().unwrap();
+        let addr_b = sock_b.local_addr().unwrap();
+
+        let client = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let client_addr = client.local_addr().unwrap();
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.zone_map = crate::config::ZoneMap::from_exact(vec![DnsRecord::A {
+            domain: "multi.test".into(),
+            addr: Ipv4Addr::new(10, 0, 0, 1),
+            ttl: 60,
+        }]);
+        let ctx = Arc::new(ctx);
+
+        let query = DnsPacket::query(0xBEEF, "multi.test", QueryType::A);
+        let mut tmp = BytePacketBuffer::new();
+        query.write(&mut tmp).unwrap();
+        let wire = tmp.buf[..tmp.pos].to_vec();
+
+        let mut rbuf = [0u8; 512];
+        for (sock, addr) in [(&sock_a, addr_a), (&sock_b, addr_b)] {
+            handle_query(
+                BytePacketBuffer::from_bytes(&wire),
+                wire.len(),
+                client_addr,
+                client_addr,
+                &ctx,
+                sock,
+                Transport::Udp,
+            )
+            .await
+            .unwrap();
+            let (_, src) = tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                client.recv_from(&mut rbuf),
+            )
+            .await
+            .expect("reply within 1s")
+            .unwrap();
+            assert_eq!(src, addr, "reply must come from the receiving socket");
+        }
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -138,21 +138,9 @@ pub async fn run(config_path: String) -> crate::Result<()> {
 
     let ca_pem = std::fs::read_to_string(resolved_data_dir.join("ca.pem")).ok();
 
-    let socket = match UdpSocket::bind(&config.server.bind_addr).await {
-        Ok(s) => s,
-        Err(e) => {
-            if let Some(advisory) =
-                crate::system_dns::try_port53_advisory(&config.server.bind_addr, &e)
-            {
-                eprint!("{}", advisory);
-                std::process::exit(1);
-            }
-            return Err(e.into());
-        }
-    };
+    let sockets = bind_udp_listeners(&config.server.bind_addr).await?;
 
     let ctx = Arc::new(ServerCtx {
-        socket,
         zone_map: build_zone_map(&config.zones)?,
         cache: RwLock::new(DnsCache::new(
             config.cache.max_entries,
@@ -211,7 +199,11 @@ pub async fn run(config_path: String) -> crate::Result<()> {
 
     info!(
         "numa listening on {}, upstream {}, {} zone records, cache max {}, API on port {}",
-        config.server.bind_addr, upstream_label, zone_count, config.cache.max_entries, api_port,
+        config.server.bind_addr.join(", "),
+        upstream_label,
+        zone_count,
+        config.cache.max_entries,
+        api_port,
     );
 
     spawn_background_services(&ctx, &config, &bootstrap_resolver, api_port)?;
@@ -222,7 +214,32 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         .ok()
         .flatten();
 
-    udp_serve_loop(&ctx, udp_pp.as_ref()).await
+    let mut handles = Vec::with_capacity(sockets.len());
+    for socket in sockets {
+        let ctx = Arc::clone(&ctx);
+        let pp = udp_pp.clone();
+        handles.push(tokio::spawn(async move {
+            udp_serve_loop(&ctx, socket, pp.as_ref()).await
+        }));
+    }
+    let (first, _, _) = futures::future::select_all(handles).await;
+    first?
+}
+
+/// First port-53 bind failure routes through `try_port53_advisory` so the
+/// "another resolver owns :53" UX still fires; any other bind error is fatal.
+async fn bind_udp_listeners(addrs: &[String]) -> crate::Result<Vec<Arc<UdpSocket>>> {
+    let mut sockets = Vec::with_capacity(addrs.len());
+    for addr in addrs {
+        let sock = UdpSocket::bind(addr).await.inspect_err(|e| {
+            if let Some(advisory) = crate::system_dns::try_port53_advisory(addr, e) {
+                eprint!("{}", advisory);
+                std::process::exit(1);
+            }
+        })?;
+        sockets.push(Arc::new(sock));
+    }
+    Ok(sockets)
 }
 
 fn spawn_background_services(
@@ -347,9 +364,9 @@ fn spawn_background_services(
         });
     }
 
-    {
+    for tcp_bind in &config.server.bind_addr {
         let tcp_ctx = Arc::clone(ctx);
-        let tcp_bind = config.server.bind_addr.clone();
+        let tcp_bind = tcp_bind.clone();
         let tcp_pp = config.server.proxy_protocol.clone();
         tokio::spawn(async move {
             crate::tcp::start_tcp(tcp_ctx, &tcp_bind, &tcp_pp).await;
@@ -361,12 +378,13 @@ fn spawn_background_services(
 
 async fn udp_serve_loop(
     ctx: &Arc<ServerCtx>,
+    socket: Arc<UdpSocket>,
     udp_pp: Option<&crate::pp2::PpConfig>,
 ) -> crate::Result<()> {
     #[allow(clippy::infinite_loop)]
     loop {
         let mut buffer = BytePacketBuffer::new();
-        let (len, peer) = match ctx.socket.recv_from(&mut buffer.buf).await {
+        let (len, peer) = match socket.recv_from(&mut buffer.buf).await {
             Ok(r) => r,
             Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {
                 // Windows delivers ICMP port-unreachable as ConnectionReset on UDP sockets
@@ -382,9 +400,18 @@ async fn udp_serve_loop(
         // PROXY-extracted logical source — otherwise the reply skips the
         // front-end and never reaches the original client.
         let ctx = Arc::clone(ctx);
+        let reply_socket = Arc::clone(&socket);
         tokio::spawn(async move {
-            if let Err(e) =
-                handle_query(buffer, dns_len, src_addr, peer, &ctx, Transport::Udp).await
+            if let Err(e) = handle_query(
+                buffer,
+                dns_len,
+                src_addr,
+                peer,
+                &ctx,
+                &reply_socket,
+                Transport::Udp,
+            )
+            .await
             {
                 error!("{} | HANDLER ERROR | {}", src_addr, e);
             }
@@ -422,6 +449,7 @@ fn print_banner(
     };
     let data_label = ctx.data_dir.display().to_string();
     let services_label = ctx.config_dir.join("services.json").display().to_string();
+    let bind_label = config.server.bind_addr.join(", ");
 
     let tag_line = "DNS that governs itself";
     let v = crate::version();
@@ -431,7 +459,7 @@ fn print_banner(
     // title row (variable-length once the version carries a +SHA suffix)
     // would overflow.
     let val_w = [
-        config.server.bind_addr.len(),
+        bind_label.len(),
         api_url.len(),
         upstream_label.len(),
         config_label.len(),
@@ -468,7 +496,7 @@ fn print_banner(
     eprint!("{o}  ║{r} {title}");
     eprintln!("{}{o}║{r}", " ".repeat(title_pad));
     eprintln!("{o}  ╠{bar_top}╣{r}");
-    row("DNS", g, &config.server.bind_addr);
+    row("DNS", g, &bind_label);
     row("API", g, api_url);
     row("Dashboard", g, api_url);
     row(

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -229,14 +229,21 @@ pub async fn run(config_path: String) -> crate::Result<()> {
 /// First port-53 bind failure routes through `try_port53_advisory` so the
 /// "another resolver owns :53" UX still fires; any other bind error is fatal.
 async fn bind_udp_listeners(addrs: &[String]) -> crate::Result<Vec<Arc<UdpSocket>>> {
+    if addrs.is_empty() {
+        return Err("server.bind_addr is empty — set at least one address".into());
+    }
     let mut sockets = Vec::with_capacity(addrs.len());
     for addr in addrs {
-        let sock = UdpSocket::bind(addr).await.inspect_err(|e| {
-            if let Some(advisory) = crate::system_dns::try_port53_advisory(addr, e) {
-                eprint!("{}", advisory);
-                std::process::exit(1);
+        let sock = match UdpSocket::bind(addr).await {
+            Ok(s) => s,
+            Err(e) => {
+                if let Some(advisory) = crate::system_dns::try_port53_advisory(addr, &e) {
+                    eprint!("{}", advisory);
+                    std::process::exit(1);
+                }
+                return Err(e.into());
             }
-        })?;
+        };
         sockets.push(Arc::new(sock));
     }
     Ok(sockets)
@@ -790,5 +797,16 @@ async fn cache_warm_loop(ctx: Arc<ServerCtx>, domains: Vec<String>) {
                 warm_domain(&ctx, domain).await;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn bind_udp_listeners_rejects_empty() {
+        let err = bind_udp_listeners(&[]).await.unwrap_err();
+        assert!(err.to_string().contains("bind_addr is empty"));
     }
 }

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -25,9 +25,7 @@ use crate::stats::ServerStats;
 /// Minimal `ServerCtx` for tests. Override fields after construction
 /// (all fields are `pub`), then wrap in `Arc`.
 pub async fn test_ctx() -> ServerCtx {
-    let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     ServerCtx {
-        socket,
         zone_map: ZoneMap::default(),
         cache: RwLock::new(DnsCache::new(100, 60, 86400)),
         refreshing: Mutex::new(HashSet::new()),


### PR DESCRIPTION
## Summary

- `[server].bind_addr` now accepts an array (`["10.0.0.1:53", "127.0.0.1:53"]`) in addition to the existing single-string form — backwards-compatible via the existing `string_or_vec` deserializer.
- Each address gets its own UDP + TCP listener; UDP replies leave the socket the query arrived on so the response source IP matches what the client wrote to (otherwise clients drop the reply).
- Closes #113 — requested by @bcookatpcsd to expose :53 on a curated set of interfaces (LAN + loopback + Tailscale) without wildcard binding or pf rules on FreeBSD.

## Test plan

- [x] `cargo test --lib` — 433 pass (new `handle_query_reply_leaves_provided_socket` regression test exercises the reply-from-receiving-socket invariant with two distinct loopback sockets).
- [x] `make all` (fmt + clippy + tests) green.
- [x] End-to-end smoke in debian:bookworm container: `bind_addr = ["127.0.0.1:5354", "127.0.0.2:5354"]` (loopback aliases), `dig` answers on both; `dig @127.0.0.3` (added as alias but not in `bind_addr`) returns no answer — confirming numa bound only the configured addresses, not a wildcard.
- [x] Backwards compat: `server_bind_addr_accepts_string_or_list` unit test, all 433 lib tests using single-string `bind_addr` still pass, and the project's own `numa.toml` continues to use the single-string form.

Single-string default unchanged. Interface-name form (`"eth0"`), and the same Vec treatment for `api_bind_addr` / `dot.bind_addr` / `mobile.bind_addr` / `proxy.bind_addr`, are intentionally deferred to follow-ups.