### PR TITLE
ci: cache nix store + cancel superseded PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ on:
       - 'scripts/serve-site.sh'
       - 'scripts/generate-blog-index.sh'
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -81,6 +85,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'Cargo.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
       - name: build
         run: nix build .#numa
       - name: smoke test


### PR DESCRIPTION
Two targeted changes against the dominant CI cost. Recent runs are pinned at ~8.5 min wall clock with `nix-build` alone consuming 8m26s of that (other jobs all under 3 min).

## Changes

**1. Cache the Nix store** (`nix-community/cache-nix-action@v6`) in the `nix-build` job. Keyed on `flake.lock` + `flake.nix` + `Cargo.lock` so the cache invalidates only when something that actually affects the derivation changes. `restore-prefixes-first-match` gives partial hits when `Cargo.lock` churns but the dep tree mostly overlaps.

Expected impact: `nix-build` from ~8 min → ~30s on cache hits, ~1-2 min on partial misses. Wall-clock CI: ~8.5 min → ~2-3 min on the typical PR push.

**2. Top-level `concurrency` group** with `cancel-in-progress` gated to PR events only:

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Rapid PR pushes (force-push, fix typo, push again) now supersede the in-flight run instead of completing all of them. Pushes to `main` are never cancelled, so any branch-protection-required runs always complete.

## Test plan

- [ ] First PR run is cold (no cache yet) — establishes the cache; should take ~similar to today
- [ ] Push a trivial commit to this PR — second run should hit the cache and be much faster
- [ ] Push two commits within a few seconds — only the latest run survives, the earlier one is cancelled
- [ ] Run on `main` after merge — pushes to main are NOT cancelled (`cancel-in-progress` is false for non-PR events)