### PR TITLE
feat(proxy): optional target_host for proxied services (#211)

### DIFF
--- a/numa.toml
+++ b/numa.toml
@@ -144,6 +144,7 @@ tld = "numa"
 # [[services]]
 # name = "api"
 # target_port = 8000
+# target_host = "192.168.1.50"  # optional, defaults to localhost
 
 # Example zone records:
 # [[zones]]

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -727,6 +727,9 @@ body {
               <input type="text" id="svcName" placeholder="service name" required style="flex:2">
               <input type="number" id="svcPort" placeholder="port (e.g. 3000)" required min="1" max="65535" style="flex:1">
             </div>
+            <div class="override-form-row">
+              <input type="text" id="svcHost" placeholder="target host (optional, defaults to localhost)" style="flex:3">
+            </div>
             <button type="submit" class="btn btn-add">Add Service</button>
             <div class="override-error" id="serviceError"></div>
           </form>
@@ -1463,7 +1466,7 @@ function renderServices(entries) {
       <span class="health-dot ${e.healthy ? 'up' : 'down'}" title="${e.healthy ? 'running' : 'not reachable'}"></span>
       <div class="service-info">
         <div class="service-name"><a href="${h(e.url)}" target="_blank">${name}.${h(proxyTld)}</a>${lanBadge}</div>
-        <div class="service-port">localhost:${parseInt(e.target_port)||0} &rarr; proxied</div>
+        <div class="service-port">${h(e.target_host || 'localhost')}:${parseInt(e.target_port)||0} &rarr; proxied</div>
         ${routeLines}
         ${e.name === 'numa' ? '' : `<div style="margin-top:0.3rem;"><button onclick="toggleRouteForm('${name}')" style="font-size:0.7rem;padding:0.1rem 0.4rem;background:var(--emerald);color:var(--bg);border:none;border-radius:4px;cursor:pointer;">+ route</button><div id="routeForm-${name}" style="display:none;margin-top:0.3rem;"><div style="display:flex;gap:0.3rem;align-items:center;"><input type="text" id="routePath-${name}" placeholder="/path" style="flex:2;padding:0.25rem 0.4rem;font-size:0.75rem;"><input type="number" id="routePort-${name}" value="${parseInt(e.target_port)||0}" min="1" max="65535" style="flex:1;padding:0.25rem 0.4rem;font-size:0.75rem;"><label style="font-size:0.7rem;color:var(--text-dim);display:flex;align-items:center;gap:0.2rem;"><input type="checkbox" id="routeStrip-${name}">strip</label><button onclick="addRoute('${name}')" style="font-size:0.7rem;padding:0.2rem 0.5rem;background:var(--emerald);color:var(--bg);border:none;border-radius:4px;cursor:pointer;">add</button></div><div class="override-error" id="routeError-${name}" style="display:none;font-size:0.7rem;"></div></div></div>`}
       </div>
@@ -1516,10 +1519,12 @@ async function addService(event) {
   const errEl = document.getElementById('serviceError');
   errEl.style.display = 'none';
   try {
+    const host = document.getElementById('svcHost').value.trim();
     const body = {
       name: document.getElementById('svcName').value.trim(),
       target_port: parseInt(document.getElementById('svcPort').value) || 0,
     };
+    if (host) body.target_host = host;
     const res = await fetch(API + '/services', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -1531,6 +1536,7 @@ async function addService(event) {
     }
     document.getElementById('svcName').value = '';
     document.getElementById('svcPort').value = '';
+    document.getElementById('svcHost').value = '';
     refresh();
   } catch (err) {
     errEl.textContent = err.message;

--- a/src/api.rs
+++ b/src/api.rs
@@ -781,6 +781,8 @@ async fn blocking_allowlist_remove(
 struct ServiceResponse {
     name: String,
     target_port: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_host: Option<String>,
     url: String,
     healthy: bool,
     lan_accessible: bool,
@@ -793,10 +795,12 @@ struct ServiceResponse {
 struct CreateServiceRequest {
     name: String,
     target_port: u16,
+    #[serde(default)]
+    target_host: Option<String>,
 }
 
 async fn list_services(State(ctx): State<Arc<ServerCtx>>) -> Json<Vec<ServiceResponse>> {
-    let entries: Vec<_> = {
+    let entries: Vec<(crate::service_store::ServiceEntry, &'static str)> = {
         let store = ctx.services.lock().unwrap();
         store
             .list()
@@ -807,12 +811,7 @@ async fn list_services(State(ctx): State<Arc<ServerCtx>>) -> Json<Vec<ServiceRes
                 } else {
                     "api"
                 };
-                (
-                    e.name.clone(),
-                    e.target_port,
-                    e.routes.clone(),
-                    source.to_string(),
-                )
+                (e.clone(), source)
             })
             .collect()
     };
@@ -820,38 +819,34 @@ async fn list_services(State(ctx): State<Arc<ServerCtx>>) -> Json<Vec<ServiceRes
 
     let lan_ip = crate::lan::detect_lan_ip();
 
-    let check_futures: Vec<_> = entries
-        .iter()
-        .map(|(_, port, _, _)| {
-            let port = *port;
-            let localhost = std::net::SocketAddr::from(([127, 0, 0, 1], port));
-            let lan_addr = lan_ip.map(|ip| std::net::SocketAddr::new(ip.into(), port));
-            async move {
-                let healthy = check_tcp(localhost).await;
-                let lan_accessible = match lan_addr {
-                    Some(addr) => check_tcp(addr).await,
-                    None => false,
-                };
-                (healthy, lan_accessible)
-            }
-        })
-        .collect();
+    let check_futures = entries.iter().map(|(e, _)| {
+        let port = e.target_port;
+        let host = e.target_host.clone().unwrap_or_else(|| "localhost".into());
+        let lan_addr = lan_ip.map(|ip| std::net::SocketAddr::new(ip.into(), port));
+        async move {
+            let healthy = check_tcp((host.as_str(), port)).await;
+            let lan_accessible = match lan_addr {
+                Some(addr) => check_tcp(addr).await,
+                None => false,
+            };
+            (healthy, lan_accessible)
+        }
+    });
     let check_results = futures::future::join_all(check_futures).await;
 
-    let results: Vec<_> = entries
+    let results = entries
         .into_iter()
         .zip(check_results)
-        .map(
-            |((name, port, routes, source), (healthy, lan_accessible))| ServiceResponse {
-                url: format!("http://{}.{}", name, tld),
-                name,
-                target_port: port,
-                healthy,
-                lan_accessible,
-                routes,
-                source,
-            },
-        )
+        .map(|((e, source), (healthy, lan_accessible))| ServiceResponse {
+            url: format!("http://{}.{}", e.name, tld),
+            name: e.name,
+            target_port: e.target_port,
+            target_host: e.target_host,
+            healthy,
+            lan_accessible,
+            routes: e.routes,
+            source: source.to_string(),
+        })
         .collect();
     Json(results)
 }
@@ -878,18 +873,42 @@ async fn create_service(
     if req.target_port == 0 {
         return Err((StatusCode::BAD_REQUEST, "target_port must be > 0".into()));
     }
+    let target_host = match req.target_host.as_deref().map(str::trim) {
+        Some("") | Some("localhost") | Some("127.0.0.1") | None => None,
+        Some(h) => {
+            if h.len() > 253 {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "target_host must be at most 253 characters".into(),
+                ));
+            }
+            // Reject control chars + whitespace + obvious scheme/path bleed.
+            if h.chars()
+                .any(|c| c.is_control() || c.is_whitespace() || c == '/' || c == ':')
+            {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "target_host must be a bare hostname or IP (no scheme, port, or path)".into(),
+                ));
+            }
+            Some(h.to_string())
+        }
+    };
 
     let tld = &ctx.proxy_tld;
     let is_new = !ctx.services.lock().unwrap().has_name(&name);
-    ctx.services.lock().unwrap().insert(&name, req.target_port);
+    ctx.services
+        .lock()
+        .unwrap()
+        .insert(&name, req.target_port, target_host.clone());
     if is_new {
         crate::tls::regenerate_tls(&ctx);
     }
 
-    let localhost = std::net::SocketAddr::from(([127, 0, 0, 1], req.target_port));
+    let probe_host = target_host.as_deref().unwrap_or("localhost");
     let lan_addr =
         crate::lan::detect_lan_ip().map(|ip| std::net::SocketAddr::new(ip.into(), req.target_port));
-    let (healthy, lan_accessible) = tokio::join!(check_tcp(localhost), async {
+    let (healthy, lan_accessible) = tokio::join!(check_tcp((probe_host, req.target_port)), async {
         match lan_addr {
             Some(a) => check_tcp(a).await,
             None => false,
@@ -901,6 +920,7 @@ async fn create_service(
             url: format!("http://{}.{}", name, tld),
             name,
             target_port: req.target_port,
+            target_host,
             healthy,
             lan_accessible,
             routes: Vec::new(),
@@ -1046,10 +1066,10 @@ fn serve_font(data: &'static [u8]) -> impl IntoResponse {
     )
 }
 
-async fn check_tcp(addr: std::net::SocketAddr) -> bool {
+async fn check_tcp<A: tokio::net::ToSocketAddrs>(target: A) -> bool {
     tokio::time::timeout(
         std::time::Duration::from_millis(100),
-        tokio::net::TcpStream::connect(addr),
+        tokio::net::TcpStream::connect(target),
     )
     .await
     .map(|r| r.is_ok())
@@ -1256,6 +1276,117 @@ mod tests {
             .unwrap();
         let body = axum::body::to_bytes(resp.into_body(), 10000).await.unwrap();
         assert!(!String::from_utf8_lossy(&body).contains("testapp"));
+    }
+
+    #[tokio::test]
+    async fn create_service_accepts_target_host() {
+        let ctx = test_ctx().await;
+        let a = router(ctx.clone());
+
+        let resp = a
+            .clone()
+            .oneshot(
+                Request::post("/services")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"name":"nas","target_port":80,"target_host":"192.168.1.50"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = axum::body::to_bytes(resp.into_body(), 10000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["target_host"], "192.168.1.50");
+
+        // Round-trip via list
+        let resp = a
+            .oneshot(Request::get("/services").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), 10000).await.unwrap();
+        let list: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let entry = list
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["name"] == "nas")
+            .expect("listed service");
+        assert_eq!(entry["target_host"], "192.168.1.50");
+    }
+
+    #[tokio::test]
+    async fn create_service_strips_default_target_host() {
+        // "localhost", "127.0.0.1", and the empty/whitespace string all
+        // collapse to the default (None) so listings stay clean.
+        for (i, host) in ["localhost", "127.0.0.1", "", "   "].iter().enumerate() {
+            let ctx = test_ctx().await;
+            let a = router(ctx);
+            let name = format!("app{}", i);
+            let body = format!(
+                r#"{{"name":"{}","target_port":3000,"target_host":"{}"}}"#,
+                name, host
+            );
+            let resp = a
+                .oneshot(
+                    Request::post("/services")
+                        .header("content-type", "application/json")
+                        .body(Body::from(body))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::CREATED, "host={:?}", host);
+            let resp_body = axum::body::to_bytes(resp.into_body(), 10000).await.unwrap();
+            let json: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+            assert!(
+                json.get("target_host").map(|v| v.is_null()).unwrap_or(true),
+                "host={:?} should collapse to default but got: {}",
+                host,
+                json
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn create_service_rejects_overlong_target_host() {
+        let ctx = test_ctx().await;
+        let a = router(ctx);
+        let long_host = "a".repeat(254);
+        let body = format!(
+            r#"{{"name":"app","target_port":80,"target_host":"{}"}}"#,
+            long_host
+        );
+        let resp = a
+            .oneshot(
+                Request::post("/services")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn create_service_rejects_target_host_with_scheme() {
+        let ctx = test_ctx().await;
+        let a = router(ctx);
+
+        let resp = a
+            .oneshot(
+                Request::post("/services")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"name":"app","target_port":80,"target_host":"http://x.y"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1087,6 +1087,39 @@ mod tests {
         Arc::new(crate::testutil::test_ctx().await)
     }
 
+    async fn get_req(app: &Router, path: &str) -> http::Response<Body> {
+        app.clone()
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+    }
+
+    async fn delete_req(app: &Router, path: &str) -> http::Response<Body> {
+        app.clone()
+            .oneshot(Request::delete(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+    }
+
+    async fn post_json(app: &Router, path: &str, body: &str) -> http::Response<Body> {
+        app.clone()
+            .oneshot(
+                Request::post(path)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn body_json(resp: http::Response<Body>) -> serde_json::Value {
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
     #[tokio::test]
     async fn health_returns_ok() {
         let ctx = test_ctx().await;
@@ -1133,88 +1166,34 @@ mod tests {
 
     #[tokio::test]
     async fn overrides_crud() {
-        let ctx = test_ctx().await;
-        let a = router(ctx.clone());
+        let a = router(test_ctx().await);
 
-        // Create
-        let resp = a
-            .clone()
-            .oneshot(
-                Request::post("/overrides")
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        r#"{"domain":"test.dev","target":"1.2.3.4","duration_secs":60}"#,
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let resp = post_json(
+            &a,
+            "/overrides",
+            r#"{"domain":"test.dev","target":"1.2.3.4","duration_secs":60}"#,
+        )
+        .await;
         assert!(resp.status().is_success());
 
-        // List
-        let resp = a
-            .clone()
-            .oneshot(Request::get("/overrides").body(Body::empty()).unwrap())
+        let body = axum::body::to_bytes(get_req(&a, "/overrides").await.into_body(), 10000)
             .await
             .unwrap();
-        let body = axum::body::to_bytes(resp.into_body(), 10000).await.unwrap();
         assert!(String::from_utf8_lossy(&body).contains("test.dev"));
 
-        // Get
-        let resp = a
-            .clone()
-            .oneshot(
-                Request::get("/overrides/test.dev")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+        assert_eq!(get_req(&a, "/overrides/test.dev").await.status(), 200);
+        assert!(delete_req(&a, "/overrides/test.dev")
             .await
-            .unwrap();
-        assert_eq!(resp.status(), 200);
-
-        // Delete
-        let resp = a
-            .clone()
-            .oneshot(
-                Request::delete("/overrides/test.dev")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert!(resp.status().is_success());
-
-        // Verify deleted
-        let resp = a
-            .oneshot(
-                Request::get("/overrides/test.dev")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), 404);
+            .status()
+            .is_success());
+        assert_eq!(get_req(&a, "/overrides/test.dev").await.status(), 404);
     }
 
     #[tokio::test]
     async fn cache_list_and_flush() {
-        let ctx = test_ctx().await;
-        let a = router(ctx.clone());
-
-        // List (empty)
-        let resp = a
-            .clone()
-            .oneshot(Request::get("/cache").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), 200);
-
-        // Flush
-        let resp = a
-            .oneshot(Request::delete("/cache").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
-        assert!(resp.status().is_success());
+        let a = router(test_ctx().await);
+        assert_eq!(get_req(&a, "/cache").await.status(), 200);
+        assert!(delete_req(&a, "/cache").await.status().is_success());
     }
 
     #[tokio::test]
@@ -1232,81 +1211,41 @@ mod tests {
 
     #[tokio::test]
     async fn services_crud() {
-        let ctx = test_ctx().await;
-        let a = router(ctx);
+        let a = router(test_ctx().await);
 
-        // Add service
-        let resp = a
-            .clone()
-            .oneshot(
-                Request::post("/services")
-                    .header("content-type", "application/json")
-                    .body(Body::from(r#"{"name":"testapp","target_port":3000}"#))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let resp = post_json(&a, "/services", r#"{"name":"testapp","target_port":3000}"#).await;
         assert!(resp.status().is_success());
 
-        // List
-        let resp = a
-            .clone()
-            .oneshot(Request::get("/services").body(Body::empty()).unwrap())
+        let body = axum::body::to_bytes(get_req(&a, "/services").await.into_body(), 10000)
             .await
             .unwrap();
-        let body = axum::body::to_bytes(resp.into_body(), 10000).await.unwrap();
         assert!(String::from_utf8_lossy(&body).contains("testapp"));
 
-        // Delete
-        let resp = a
-            .clone()
-            .oneshot(
-                Request::delete("/services/testapp")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+        assert!(delete_req(&a, "/services/testapp")
             .await
-            .unwrap();
-        assert!(resp.status().is_success());
+            .status()
+            .is_success());
 
-        // Verify deleted
-        let resp = a
-            .oneshot(Request::get("/services").body(Body::empty()).unwrap())
+        let body = axum::body::to_bytes(get_req(&a, "/services").await.into_body(), 10000)
             .await
             .unwrap();
-        let body = axum::body::to_bytes(resp.into_body(), 10000).await.unwrap();
         assert!(!String::from_utf8_lossy(&body).contains("testapp"));
     }
 
     #[tokio::test]
     async fn create_service_accepts_target_host() {
-        let ctx = test_ctx().await;
-        let a = router(ctx.clone());
+        let a = router(test_ctx().await);
 
-        let resp = a
-            .clone()
-            .oneshot(
-                Request::post("/services")
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        r#"{"name":"nas","target_port":80,"target_host":"192.168.1.50"}"#,
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let resp = post_json(
+            &a,
+            "/services",
+            r#"{"name":"nas","target_port":80,"target_host":"192.168.1.50"}"#,
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::CREATED);
-        let body = axum::body::to_bytes(resp.into_body(), 10000).await.unwrap();
-        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(json["target_host"], "192.168.1.50");
+        assert_eq!(body_json(resp).await["target_host"], "192.168.1.50");
 
-        // Round-trip via list
-        let resp = a
-            .oneshot(Request::get("/services").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
-        let body = axum::body::to_bytes(resp.into_body(), 10000).await.unwrap();
-        let list: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let list = body_json(get_req(&a, "/services").await).await;
         let entry = list
             .as_array()
             .unwrap()
@@ -1321,25 +1260,14 @@ mod tests {
         // "localhost", "127.0.0.1", and the empty/whitespace string all
         // collapse to the default (None) so listings stay clean.
         for (i, host) in ["localhost", "127.0.0.1", "", "   "].iter().enumerate() {
-            let ctx = test_ctx().await;
-            let a = router(ctx);
-            let name = format!("app{}", i);
+            let a = router(test_ctx().await);
             let body = format!(
-                r#"{{"name":"{}","target_port":3000,"target_host":"{}"}}"#,
-                name, host
+                r#"{{"name":"app{}","target_port":3000,"target_host":"{}"}}"#,
+                i, host
             );
-            let resp = a
-                .oneshot(
-                    Request::post("/services")
-                        .header("content-type", "application/json")
-                        .body(Body::from(body))
-                        .unwrap(),
-                )
-                .await
-                .unwrap();
+            let resp = post_json(&a, "/services", &body).await;
             assert_eq!(resp.status(), StatusCode::CREATED, "host={:?}", host);
-            let resp_body = axum::body::to_bytes(resp.into_body(), 10000).await.unwrap();
-            let json: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+            let json = body_json(resp).await;
             assert!(
                 json.get("target_host").map(|v| v.is_null()).unwrap_or(true),
                 "host={:?} should collapse to default but got: {}",
@@ -1351,41 +1279,24 @@ mod tests {
 
     #[tokio::test]
     async fn create_service_rejects_overlong_target_host() {
-        let ctx = test_ctx().await;
-        let a = router(ctx);
-        let long_host = "a".repeat(254);
+        let a = router(test_ctx().await);
         let body = format!(
             r#"{{"name":"app","target_port":80,"target_host":"{}"}}"#,
-            long_host
+            "a".repeat(254)
         );
-        let resp = a
-            .oneshot(
-                Request::post("/services")
-                    .header("content-type", "application/json")
-                    .body(Body::from(body))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let resp = post_json(&a, "/services", &body).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]
     async fn create_service_rejects_target_host_with_scheme() {
-        let ctx = test_ctx().await;
-        let a = router(ctx);
-
-        let resp = a
-            .oneshot(
-                Request::post("/services")
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        r#"{"name":"app","target_port":80,"target_host":"http://x.y"}"#,
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let a = router(test_ctx().await);
+        let resp = post_json(
+            &a,
+            "/services",
+            r#"{"name":"app","target_port":80,"target_host":"http://x.y"}"#,
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -641,6 +641,8 @@ pub struct ServiceConfig {
     pub name: String,
     pub target_port: u16,
     #[serde(default)]
+    pub target_host: Option<String>,
+    #[serde(default)]
     pub routes: Vec<crate::service_store::RouteEntry>,
 }
 

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1391,7 +1391,7 @@ mod tests {
     #[tokio::test]
     async fn pipeline_tld_proxy_resolves_service() {
         let ctx = crate::testutil::test_ctx().await;
-        ctx.services.lock().unwrap().insert("grafana", 3000);
+        ctx.services.lock().unwrap().insert("grafana", 3000, None);
         let ctx = Arc::new(ctx);
 
         let (resp, path) = resolve_in_test(&ctx, "grafana.numa", QueryType::A).await;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -335,7 +335,11 @@ async fn proxy_handler(State(state): State<ProxyState>, req: Request) -> axum::r
         let store = state.ctx.services.lock().unwrap();
         if let Some(entry) = store.lookup(&service_name) {
             let (port, path) = entry.resolve_route(&request_path);
-            ("localhost".to_string(), port, path)
+            let host = entry
+                .target_host
+                .clone()
+                .unwrap_or_else(|| "localhost".into());
+            (host, port, path)
         } else {
             let mut peers = state.ctx.lan_peers.lock().unwrap();
             match peers.lookup(&service_name) {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -74,9 +74,14 @@ pub async fn run(config_path: String) -> crate::Result<()> {
 
     // Build service store: config services + persisted user services
     let mut service_store = ServiceStore::new();
-    service_store.insert_from_config("numa", config.server.api_port, Vec::new());
+    service_store.insert_from_config("numa", config.server.api_port, None, Vec::new());
     for svc in &config.services {
-        service_store.insert_from_config(&svc.name, svc.target_port, svc.routes.clone());
+        service_store.insert_from_config(
+            &svc.name,
+            svc.target_port,
+            svc.target_host.clone(),
+            svc.routes.clone(),
+        );
     }
     service_store.load_persisted();
 

--- a/src/service_store.rs
+++ b/src/service_store.rs
@@ -9,6 +9,8 @@ pub struct ServiceEntry {
     pub name: String,
     pub target_port: u16,
     #[serde(default)]
+    pub target_host: Option<String>,
+    #[serde(default)]
     pub routes: Vec<RouteEntry>,
 }
 
@@ -78,7 +80,13 @@ impl ServiceStore {
     }
 
     /// Insert a service from numa.toml config (not persisted)
-    pub fn insert_from_config(&mut self, name: &str, target_port: u16, routes: Vec<RouteEntry>) {
+    pub fn insert_from_config(
+        &mut self,
+        name: &str,
+        target_port: u16,
+        target_host: Option<String>,
+        routes: Vec<RouteEntry>,
+    ) {
         let key = name.to_lowercase();
         self.config_services.insert(key.clone());
         self.entries.insert(
@@ -86,19 +94,21 @@ impl ServiceStore {
             ServiceEntry {
                 name: key,
                 target_port,
+                target_host,
                 routes,
             },
         );
     }
 
     /// Insert a user-defined service (persisted to ~/.config/numa/services.json)
-    pub fn insert(&mut self, name: &str, target_port: u16) {
+    pub fn insert(&mut self, name: &str, target_port: u16, target_host: Option<String>) {
         let key = name.to_lowercase();
         self.entries.insert(
             key.clone(),
             ServiceEntry {
                 name: key,
                 target_port,
+                target_host,
                 routes: Vec::new(),
             },
         );
@@ -228,6 +238,7 @@ mod tests {
         ServiceEntry {
             name: "app".into(),
             target_port: port,
+            target_host: None,
             routes,
         }
     }
@@ -324,7 +335,7 @@ mod tests {
     #[test]
     fn add_route_to_existing_service() {
         let mut store = test_store();
-        store.insert_from_config("app", 3000, vec![]);
+        store.insert_from_config("app", 3000, None, vec![]);
         assert!(store.add_route("app", "/api".into(), 4000, false));
         let entry = store.lookup("app").unwrap();
         assert_eq!(entry.routes.len(), 1);
@@ -340,7 +351,7 @@ mod tests {
     #[test]
     fn add_route_deduplicates_by_path() {
         let mut store = test_store();
-        store.insert_from_config("app", 3000, vec![]);
+        store.insert_from_config("app", 3000, None, vec![]);
         store.add_route("app", "/api".into(), 4000, false);
         store.add_route("app", "/api".into(), 5000, true);
         let entry = store.lookup("app").unwrap();
@@ -352,7 +363,7 @@ mod tests {
     #[test]
     fn remove_route_returns_true_when_found() {
         let mut store = test_store();
-        store.insert_from_config("app", 3000, vec![route("/api", 4000, false)]);
+        store.insert_from_config("app", 3000, None, vec![route("/api", 4000, false)]);
         assert!(store.remove_route("app", "/api"));
         assert!(store.lookup("app").unwrap().routes.is_empty());
     }
@@ -360,14 +371,14 @@ mod tests {
     #[test]
     fn remove_route_returns_false_when_missing() {
         let mut store = test_store();
-        store.insert_from_config("app", 3000, vec![]);
+        store.insert_from_config("app", 3000, None, vec![]);
         assert!(!store.remove_route("app", "/nope"));
     }
 
     #[test]
     fn lookup_is_case_insensitive() {
         let mut store = test_store();
-        store.insert_from_config("MyApp", 3000, vec![]);
+        store.insert_from_config("MyApp", 3000, None, vec![]);
         assert!(store.lookup("myapp").is_some());
         assert!(store.lookup("MYAPP").is_some());
     }


### PR DESCRIPTION
## Summary
- Lets `[[services]]` proxy to a host other than `localhost` — closes the "no more hard-coded to localhost" half of #211, so numa can stand in for an nginx reverse proxy pointing at other LAN boxes.
- `target_host` is optional; absence preserves the prior loopback behaviour, and `services.json` from older releases parses untouched via `#[serde(default)]`.

## Surface
- `numa.toml` `[[services]]`: optional `target_host = "192.168.1.50"` (hostname or IP).
- REST: `POST /services` accepts `target_host`; `GET /services` returns it; explicit `"localhost"` / `"127.0.0.1"` / empty string coerce to `null` for clean listings.
- Dashboard: optional "target host" input on the add-service form; service listing renders the resolved host instead of a hardcoded `localhost:`.
- Validation: ≤253 chars; rejects strings with scheme, port, path, control chars, or whitespace.

## Out of scope
- BYO TLS cert (Let's Encrypt) — the other half of #211. Coming in a follow-up PR.

## Test plan
- [x] `make all` green (lint + 441 lib tests + integration)
- [x] New tests: `create_service_accepts_target_host`, `create_service_strips_default_target_host`, `create_service_rejects_target_host_with_scheme`, `create_service_rejects_overlong_target_host`
- [x] Manual: registered `pi` with `target_host=192.168.1.12` (LAN IP, tunneled to a Pi running `python3 -m http.server`), hit `http://pi.numa` via PR-build proxy, got back the Pi's page. Strip cases (`localhost` / `127.0.0.1` / empty / whitespace) all collapsed to default; validation rejects (scheme / port-in-host / 254-char / embedded whitespace) all returned 400.
- [x] Manual: dashboard form has the `svcHost` input; listing JS renders `${e.target_host || 'localhost'}:${e.target_port} → proxied` so the new value flows through.
