### PR TITLE
feat(proxy): bring-your-own TLS cert for HTTPS proxy (#211)

### DIFF
--- a/numa.toml
+++ b/numa.toml
@@ -126,6 +126,14 @@ tls_port = 443
 tld = "numa"
 # bind_addr = "127.0.0.1"  # default; set to "0.0.0.0" for LAN access to .numa services
 
+# Bring-your-own TLS cert (e.g. Let's Encrypt). When both paths are set,
+# numa serves this cert instead of the self-signed local CA — no per-device
+# trust install needed. Requires `tld` to be a domain you actually own
+# (Let's Encrypt won't issue for `.numa`). Renew externally (certbot,
+# acme.sh, etc.) and restart numa to pick up the new cert.
+# cert_path = "/etc/letsencrypt/live/example.com/fullchain.pem"
+# key_path  = "/etc/letsencrypt/live/example.com/privkey.pem"
+
 # PROXY protocol v2 — preserves the real client IP when numa runs behind an
 # L4 front-end (dnsdist, HAProxy, nginx-stream, AWS NLB, GCP TCP LB). Empty
 # `from` allowlist (or omitted section) leaves the feature disabled.

--- a/numa.toml
+++ b/numa.toml
@@ -133,15 +133,14 @@ tld = "numa"
 # cert_path = "/etc/letsencrypt/live/example.com/fullchain.pem"
 # key_path  = "/etc/letsencrypt/live/example.com/privkey.pem"
 
-# PROXY protocol v2 — preserves the real client IP when numa runs behind an
-# L4 front-end (dnsdist, HAProxy, nginx-stream, AWS NLB, GCP TCP LB). Empty
-# `from` allowlist (or omitted section) leaves the feature disabled.
-# A non-empty list puts the listener in PROXY-required mode: connections from
-# listed senders that omit the header are dropped, and connections from
-# non-listed senders are dropped before any read.
+# ── PROXY protocol v2 ──────────────────────────────────────────────
+# Preserve the real client IP behind an L4 front-end (dnsdist,
+# HAProxy, AWS NLB). Non-empty `from` is required-mode: connections
+# outside the allowlist, or missing the header, are dropped.
+#
 # [proxy.proxy_protocol]
-# from = ["10.0.0.0/8", "127.0.0.1"]  # CIDR allowlist of trusted L4 front-ends
-# header_timeout_ms = 5000             # ms; kill stalled-header connections fast
+# from = ["10.0.0.0/8", "127.0.0.1"]  # trusted L4 front-ends
+# header_timeout_ms = 5000             # kill stalled-header connections
 
 # Pre-configured services (numa.numa is always added automatically)
 # [[services]]
@@ -194,7 +193,9 @@ tld = "numa"
 # cert_path = "/etc/numa/dot.crt"  # PEM cert; omit to use self-signed (proxy CA if available)
 # key_path = "/etc/numa/dot.key"   # PEM private key; must be set together with cert_path
 
-# PROXY v2 also attaches to DoT — same semantics as [proxy.proxy_protocol].
+# ── PROXY v2 on DoT ────────────────────────────────────────────────
+# Same semantics as [proxy.proxy_protocol] above.
+#
 # [dot.proxy_protocol]
 # from = ["10.0.0.0/8"]
 # header_timeout_ms = 5000
@@ -205,20 +206,12 @@ tld = "numa"
 # broadcast_interval_secs = 30
 # peer_timeout_secs = 90
 
-# Mobile API — persistent HTTP listener serving read-only routes
-# (/health, /ca.pem, /mobileconfig, /ca.mobileconfig) on a LAN-reachable
-# port. Consumed by the iOS/Android companion apps for discovery and
-# profile fetching, and by `numa setup-phone` for QR-based onboarding.
-#
-# Opt-in because the listener binds to the LAN by default. None of the
-# exposed routes are cryptographically sensitive (no private keys, no
-# state mutations, all idempotent GETs), but enabling it does add a new
-# listener to any device on the LAN that scans port 8765.
-#
-# Safe for home LANs. Think twice before enabling on untrusted LANs
-# (office Wi-Fi, coffee shops, etc.) — an attacker on the same network
-# could run a competing Numa instance that shadows yours via mDNS and
-# trick companion apps into installing their profile instead of yours.
+# ── Mobile API ─────────────────────────────────────────────────────
+# Read-only HTTP for the companion apps (discovery, /ca.pem,
+# /mobileconfig, QR onboarding via `numa setup-phone`). Binds to the
+# LAN by default. Don't enable on untrusted LANs (office Wi-Fi,
+# cafés) — an attacker on the same network can shadow you via mDNS
+# and serve their profile instead.
 [mobile]
 enabled = true                # opt-in to the mobile API listener
 # port = 8765                 # default; matches Discovery.swift defaultAPIPort

--- a/numa.toml
+++ b/numa.toml
@@ -126,11 +126,10 @@ tls_port = 443
 tld = "numa"
 # bind_addr = "127.0.0.1"  # default; set to "0.0.0.0" for LAN access to .numa services
 
-# Bring-your-own TLS cert (e.g. Let's Encrypt). When both paths are set,
-# numa serves this cert instead of the self-signed local CA — no per-device
-# trust install needed. Requires `tld` to be a domain you actually own
-# (Let's Encrypt won't issue for `.numa`). Renew externally (certbot,
-# acme.sh, etc.) and restart numa to pick up the new cert.
+# ── Bring-your-own TLS cert ────────────────────────────────────────
+# Skip per-device CA install. `tld` must be a domain you own. Renew
+# externally; restart to pick up.
+#
 # cert_path = "/etc/letsencrypt/live/example.com/fullchain.pem"
 # key_path  = "/etc/letsencrypt/live/example.com/privkey.pem"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -567,9 +567,6 @@ pub struct ProxyConfig {
     pub tld: String,
     #[serde(default = "default_proxy_bind_addr")]
     pub bind_addr: String,
-    /// Path to a TLS certificate (PEM). When set together with `key_path`,
-    /// the HTTPS proxy serves this cert instead of the local-CA-issued one
-    /// — lets users bring their own Let's Encrypt / external cert.
     #[serde(default)]
     pub cert_path: Option<PathBuf>,
     #[serde(default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -567,6 +567,13 @@ pub struct ProxyConfig {
     pub tld: String,
     #[serde(default = "default_proxy_bind_addr")]
     pub bind_addr: String,
+    /// Path to a TLS certificate (PEM). When set together with `key_path`,
+    /// the HTTPS proxy serves this cert instead of the local-CA-issued one
+    /// — lets users bring their own Let's Encrypt / external cert.
+    #[serde(default)]
+    pub cert_path: Option<PathBuf>,
+    #[serde(default)]
+    pub key_path: Option<PathBuf>,
     #[serde(default)]
     pub proxy_protocol: ProxyProtocolConfig,
 }
@@ -579,6 +586,8 @@ impl Default for ProxyConfig {
             tls_port: default_proxy_tls_port(),
             tld: default_proxy_tld(),
             bind_addr: default_proxy_bind_addr(),
+            cert_path: None,
+            key_path: None,
             proxy_protocol: ProxyProtocolConfig::default(),
         }
     }
@@ -940,6 +949,31 @@ mod tests {
     #[test]
     fn proxy_binds_localhost_by_default() {
         assert_eq!(ProxyConfig::default().bind_addr, "127.0.0.1");
+    }
+
+    #[test]
+    fn proxy_cert_and_key_paths_default_to_none() {
+        let cfg = ProxyConfig::default();
+        assert!(cfg.cert_path.is_none());
+        assert!(cfg.key_path.is_none());
+    }
+
+    #[test]
+    fn proxy_cert_and_key_paths_parse() {
+        let toml_str = r#"
+[proxy]
+cert_path = "/etc/numa/proxy/cert.pem"
+key_path = "/etc/numa/proxy/key.pem"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.proxy.cert_path.as_deref().unwrap().to_str().unwrap(),
+            "/etc/numa/proxy/cert.pem"
+        );
+        assert_eq!(
+            config.proxy.key_path.as_deref().unwrap().to_str().unwrap(),
+            "/etc/numa/proxy/key.pem"
+        );
     }
 
     #[test]

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -59,6 +59,10 @@ pub struct ServerCtx {
     pub config_dir: PathBuf,
     pub data_dir: PathBuf,
     pub tls_config: Option<ArcSwap<ServerConfig>>,
+    /// True when `tls_config` holds a user-supplied cert (`[proxy]
+    /// cert_path`/`key_path`). Suppresses cert regeneration on service
+    /// add/remove — numa doesn't own the cert and can't reissue it.
+    pub tls_byo: bool,
     pub upstream_mode: UpstreamMode,
     pub root_hints: Vec<SocketAddr>,
     pub srtt: RwLock<SrttCache>,

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -59,9 +59,7 @@ pub struct ServerCtx {
     pub config_dir: PathBuf,
     pub data_dir: PathBuf,
     pub tls_config: Option<ArcSwap<ServerConfig>>,
-    /// True when `tls_config` holds a user-supplied cert (`[proxy]
-    /// cert_path`/`key_path`). Suppresses cert regeneration on service
-    /// add/remove — numa doesn't own the cert and can't reissue it.
+    /// Set when `tls_config` is a user-supplied cert; suppresses regeneration.
     pub tls_byo: bool,
     pub upstream_mode: UpstreamMode,
     pub root_hints: Vec<SocketAddr>,

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -53,7 +53,11 @@ pub async fn start_dot(ctx: Arc<ServerCtx>, config: &DotConfig) {
                 return;
             }
         },
-        _ => match self_signed_tls(&ctx) {
+        (Some(_), None) | (None, Some(_)) => {
+            error!("[dot] cert_path and key_path must both be set — DoT disabled");
+            return;
+        }
+        (None, None) => match self_signed_tls(&ctx) {
             Some(cfg) => cfg,
             None => return,
         },

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,5 +1,4 @@
 use std::net::{IpAddr, SocketAddr};
-use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -20,29 +19,6 @@ const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn dot_alpn() -> Vec<Vec<u8>> {
     vec![b"dot".to_vec()]
-}
-
-/// Build a TLS ServerConfig for DoT from user-provided cert/key PEM files.
-fn load_tls_config(cert_path: &Path, key_path: &Path) -> crate::Result<Arc<ServerConfig>> {
-    // rustls needs a CryptoProvider installed before ServerConfig::builder().
-    // The proxy's build_tls_config also does this; we repeat it here because
-    // running DoT with user-provided certs while the proxy is disabled would
-    // otherwise panic on first handshake (no default provider).
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
-    let cert_pem = std::fs::read(cert_path)?;
-    let key_pem = std::fs::read(key_path)?;
-
-    let certs: Vec<_> = rustls_pemfile::certs(&mut &cert_pem[..]).collect::<Result<_, _>>()?;
-    let key = rustls_pemfile::private_key(&mut &key_pem[..])?
-        .ok_or("no private key found in key file")?;
-
-    let mut config = ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(certs, key)?;
-    config.alpn_protocols = dot_alpn();
-
-    Ok(Arc::new(config))
 }
 
 /// Build a self-signed DoT TLS config. Can't reuse `ctx.tls_config` (the
@@ -70,7 +46,7 @@ fn self_signed_tls(ctx: &ServerCtx) -> Option<Arc<ServerConfig>> {
 /// Start the DNS-over-TLS listener (RFC 7858).
 pub async fn start_dot(ctx: Arc<ServerCtx>, config: &DotConfig) {
     let tls_config = match (&config.cert_path, &config.key_path) {
-        (Some(cert), Some(key)) => match load_tls_config(cert, key) {
+        (Some(cert), Some(key)) => match crate::tls::load_pem_tls_config(cert, key, dot_alpn()) {
             Ok(cfg) => cfg,
             Err(e) => {
                 warn!("DoT: failed to load TLS cert/key: {} — DoT disabled", e);

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -123,10 +123,10 @@ pub async fn run(config_path: String) -> crate::Result<()> {
                 }
             },
             (Some(_), None) | (None, Some(_)) => {
-                log::warn!(
-                    "[proxy] cert_path and key_path must both be set — falling back to local CA"
+                log::error!(
+                    "[proxy] cert_path and key_path must both be set — HTTPS proxy disabled"
                 );
-                build_local_ca_tls(&config, &service_store, &resolved_data_dir)
+                (None, false)
             }
             (None, None) => build_local_ca_tls(&config, &service_store, &resolved_data_dir),
         }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -101,26 +101,37 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         .unwrap_or_else(crate::data_dir);
 
     // Build initial TLS config before ServerCtx (so ArcSwap is ready at construction)
-    let initial_tls = if config.proxy.enabled && config.proxy.tls_port > 0 {
-        let service_names = service_store.names();
-        match crate::tls::build_tls_config(
-            &config.proxy.tld,
-            &service_names,
-            Vec::new(),
-            &resolved_data_dir,
-        ) {
-            Ok(tls_config) => Some(ArcSwap::from(tls_config)),
-            Err(e) => {
-                if let Some(advisory) = crate::tls::try_data_dir_advisory(&e, &resolved_data_dir) {
-                    eprint!("{}", advisory);
-                } else {
-                    log::warn!("TLS setup failed, HTTPS proxy disabled: {}", e);
+    let (initial_tls, tls_byo) = if config.proxy.enabled && config.proxy.tls_port > 0 {
+        match (&config.proxy.cert_path, &config.proxy.key_path) {
+            (Some(cert), Some(key)) => match crate::tls::load_pem_tls_config(cert, key, Vec::new())
+            {
+                Ok(cfg) => {
+                    log::info!(
+                        "HTTPS proxy: serving user-provided cert from {}",
+                        cert.display()
+                    );
+                    (Some(ArcSwap::from(cfg)), true)
                 }
-                None
+                Err(e) => {
+                    log::warn!(
+                        "TLS setup failed, HTTPS proxy disabled: cert={} key={}: {}",
+                        cert.display(),
+                        key.display(),
+                        e
+                    );
+                    (None, false)
+                }
+            },
+            (Some(_), None) | (None, Some(_)) => {
+                log::warn!(
+                    "[proxy] cert_path and key_path must both be set — falling back to local CA"
+                );
+                build_local_ca_tls(&config, &service_store, &resolved_data_dir)
             }
+            (None, None) => build_local_ca_tls(&config, &service_store, &resolved_data_dir),
         }
     } else {
-        None
+        (None, false)
     };
 
     let doh_enabled = initial_tls.is_some();
@@ -173,6 +184,7 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         config_dir: crate::config_dir(),
         data_dir: resolved_data_dir,
         tls_config: initial_tls,
+        tls_byo,
         upstream_mode: resolved_mode,
         root_hints,
         srtt: std::sync::RwLock::new(crate::srtt::SrttCache::new(config.upstream.srtt)),
@@ -224,6 +236,25 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     }
     let (first, _, _) = futures::future::select_all(handles).await;
     first?
+}
+
+fn build_local_ca_tls(
+    config: &crate::config::Config,
+    service_store: &ServiceStore,
+    data_dir: &std::path::Path,
+) -> (Option<ArcSwap<rustls::ServerConfig>>, bool) {
+    let names = service_store.names();
+    match crate::tls::build_tls_config(&config.proxy.tld, &names, Vec::new(), data_dir) {
+        Ok(cfg) => (Some(ArcSwap::from(cfg)), false),
+        Err(e) => {
+            if let Some(advisory) = crate::tls::try_data_dir_advisory(&e, data_dir) {
+                eprint!("{}", advisory);
+            } else {
+                log::warn!("TLS setup failed, HTTPS proxy disabled: {}", e);
+            }
+            (None, false)
+        }
+    }
 }
 
 /// First port-53 bind failure routes through `try_port53_advisory` so the

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -8,7 +8,6 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
-use arc_swap::ArcSwap;
 use log::{error, info};
 use tokio::net::UdpSocket;
 
@@ -100,39 +99,8 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         .clone()
         .unwrap_or_else(crate::data_dir);
 
-    // Build initial TLS config before ServerCtx (so ArcSwap is ready at construction)
-    let (initial_tls, tls_byo) = if config.proxy.enabled && config.proxy.tls_port > 0 {
-        match (&config.proxy.cert_path, &config.proxy.key_path) {
-            (Some(cert), Some(key)) => match crate::tls::load_pem_tls_config(cert, key, Vec::new())
-            {
-                Ok(cfg) => {
-                    log::info!(
-                        "HTTPS proxy: serving user-provided cert from {}",
-                        cert.display()
-                    );
-                    (Some(ArcSwap::from(cfg)), true)
-                }
-                Err(e) => {
-                    log::warn!(
-                        "TLS setup failed, HTTPS proxy disabled: cert={} key={}: {}",
-                        cert.display(),
-                        key.display(),
-                        e
-                    );
-                    (None, false)
-                }
-            },
-            (Some(_), None) | (None, Some(_)) => {
-                log::error!(
-                    "[proxy] cert_path and key_path must both be set — HTTPS proxy disabled"
-                );
-                (None, false)
-            }
-            (None, None) => build_local_ca_tls(&config, &service_store, &resolved_data_dir),
-        }
-    } else {
-        (None, false)
-    };
+    let (initial_tls, tls_byo) =
+        crate::tls::build_proxy_tls(&config, &service_store, &resolved_data_dir);
 
     let doh_enabled = initial_tls.is_some();
     let health_meta = crate::health::HealthMeta::build(
@@ -236,25 +204,6 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     }
     let (first, _, _) = futures::future::select_all(handles).await;
     first?
-}
-
-fn build_local_ca_tls(
-    config: &crate::config::Config,
-    service_store: &ServiceStore,
-    data_dir: &std::path::Path,
-) -> (Option<ArcSwap<rustls::ServerConfig>>, bool) {
-    let names = service_store.names();
-    match crate::tls::build_tls_config(&config.proxy.tld, &names, Vec::new(), data_dir) {
-        Ok(cfg) => (Some(ArcSwap::from(cfg)), false),
-        Err(e) => {
-            if let Some(advisory) = crate::tls::try_data_dir_advisory(&e, data_dir) {
-                eprint!("{}", advisory);
-            } else {
-                log::warn!("TLS setup failed, HTTPS proxy disabled: {}", e);
-            }
-            (None, false)
-        }
-    }
 }
 
 /// First port-53 bind failure routes through `try_port53_advisory` so the

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -53,6 +53,7 @@ pub async fn test_ctx() -> ServerCtx {
         config_dir: PathBuf::from("/tmp"),
         data_dir: PathBuf::from("/tmp"),
         tls_config: None,
+        tls_byo: false,
         upstream_mode: UpstreamMode::Forward,
         root_hints: Vec::new(),
         srtt: RwLock::new(SrttCache::new(true)),

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -355,23 +355,31 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    #[test]
-    fn load_pem_tls_config_round_trip() {
-        let dir = std::env::temp_dir().join(format!("numa-test-pem-{}", std::process::id()));
+    fn fresh_temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("numa-test-{}-{}", tag, std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
 
+    fn write_self_signed_pem_pair(dir: &Path, dns: &str) -> (PathBuf, PathBuf) {
         let key_pair = KeyPair::generate().unwrap();
         let mut params = CertificateParams::default();
         params
             .subject_alt_names
-            .push(SanType::DnsName("example.test".try_into().unwrap()));
+            .push(SanType::DnsName(dns.try_into().unwrap()));
         let cert = params.self_signed(&key_pair).unwrap();
-
         let cert_path = dir.join("cert.pem");
         let key_path = dir.join("key.pem");
         std::fs::write(&cert_path, cert.pem()).unwrap();
         std::fs::write(&key_path, key_pair.serialize_pem()).unwrap();
+        (cert_path, key_path)
+    }
+
+    #[test]
+    fn load_pem_tls_config_round_trip() {
+        let dir = fresh_temp_dir("pem");
+        let (cert_path, key_path) = write_self_signed_pem_pair(&dir, "example.test");
 
         let config =
             load_pem_tls_config(&cert_path, &key_path, Vec::new()).expect("load self-signed pair");
@@ -383,21 +391,10 @@ mod tests {
     #[tokio::test]
     async fn regenerate_tls_is_noop_in_byo_mode() {
         let mut ctx = crate::testutil::test_ctx().await;
-        let dir = std::env::temp_dir().join(format!("numa-test-byo-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = fresh_temp_dir("byo");
         ctx.data_dir = dir.clone();
 
-        let key_pair = KeyPair::generate().unwrap();
-        let mut params = CertificateParams::default();
-        params
-            .subject_alt_names
-            .push(SanType::DnsName("byo.test".try_into().unwrap()));
-        let cert = params.self_signed(&key_pair).unwrap();
-        let cert_path = dir.join("cert.pem");
-        let key_path = dir.join("key.pem");
-        std::fs::write(&cert_path, cert.pem()).unwrap();
-        std::fs::write(&key_path, key_pair.serialize_pem()).unwrap();
+        let (cert_path, key_path) = write_self_signed_pem_pair(&dir, "byo.test");
         let user_cfg = load_pem_tls_config(&cert_path, &key_path, Vec::new()).unwrap();
 
         ctx.tls_config = Some(arc_swap::ArcSwap::from(Arc::clone(&user_cfg)));
@@ -416,9 +413,7 @@ mod tests {
 
     #[test]
     fn load_pem_tls_config_rejects_empty_cert() {
-        let dir = std::env::temp_dir().join(format!("numa-test-pem-empty-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = fresh_temp_dir("pem-empty");
         let cert_path = dir.join("cert.pem");
         let key_path = dir.join("key.pem");
         std::fs::write(&cert_path, b"").unwrap();

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -2,9 +2,12 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 
-use log::{info, warn};
+use arc_swap::ArcSwap;
+use log::{error, info, warn};
 
+use crate::config::Config;
 use crate::ctx::ServerCtx;
+use crate::service_store::ServiceStore;
 use rcgen::{
     BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType,
 };
@@ -43,6 +46,56 @@ pub fn regenerate_tls(ctx: &ServerCtx) {
             info!("TLS cert regenerated for {} services", names.len());
         }
         Err(e) => warn!("TLS regeneration failed: {}", e),
+    }
+}
+
+/// Decide the HTTPS proxy's initial TLS config: BYO cert if both paths
+/// are set, local-CA otherwise. Returns `(_, true)` for BYO so callers
+/// know to suppress regeneration.
+pub fn build_proxy_tls(
+    config: &Config,
+    service_store: &ServiceStore,
+    data_dir: &Path,
+) -> (Option<ArcSwap<ServerConfig>>, bool) {
+    if !config.proxy.enabled || config.proxy.tls_port == 0 {
+        return (None, false);
+    }
+    match (&config.proxy.cert_path, &config.proxy.key_path) {
+        (Some(cert), Some(key)) => match load_pem_tls_config(cert, key, Vec::new()) {
+            Ok(cfg) => {
+                info!(
+                    "HTTPS proxy: serving user-provided cert from {}",
+                    cert.display()
+                );
+                (Some(ArcSwap::from(cfg)), true)
+            }
+            Err(e) => {
+                warn!(
+                    "HTTPS proxy disabled: failed to load {}: {}",
+                    cert.display(),
+                    e
+                );
+                (None, false)
+            }
+        },
+        (Some(_), None) | (None, Some(_)) => {
+            error!("[proxy] cert_path and key_path must both be set — HTTPS proxy disabled");
+            (None, false)
+        }
+        (None, None) => {
+            let names = service_store.names();
+            match build_tls_config(&config.proxy.tld, &names, Vec::new(), data_dir) {
+                Ok(cfg) => (Some(ArcSwap::from(cfg)), false),
+                Err(e) => {
+                    if let Some(advisory) = try_data_dir_advisory(&e, data_dir) {
+                        eprint!("{}", advisory);
+                    } else {
+                        warn!("TLS setup failed, HTTPS proxy disabled: {}", e);
+                    }
+                    (None, false)
+                }
+            }
+        }
     }
 }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -28,6 +28,10 @@ pub fn regenerate_tls(ctx: &ServerCtx) {
         Some(t) => t,
         None => return,
     };
+    if ctx.tls_byo {
+        // User-provided cert: numa doesn't own it, can't reissue.
+        return;
+    }
 
     let mut names: HashSet<String> = ctx.services.lock().unwrap().names().into_iter().collect();
     names.extend(ctx.lan_peers.lock().unwrap().names());
@@ -40,6 +44,37 @@ pub fn regenerate_tls(ctx: &ServerCtx) {
         }
         Err(e) => warn!("TLS regeneration failed: {}", e),
     }
+}
+
+/// Load a TLS server config from user-supplied cert + key PEM files.
+/// Shared by the HTTPS proxy and DoT listener for their respective BYO
+/// cert paths. `alpn` is advertised in the ServerHello — empty for the
+/// proxy (negotiates per-connection), `[b"dot"]` for DoT (RFC 7858 §3.2).
+pub fn load_pem_tls_config(
+    cert_path: &Path,
+    key_path: &Path,
+    alpn: Vec<Vec<u8>>,
+) -> crate::Result<Arc<ServerConfig>> {
+    // rustls needs a CryptoProvider installed before ServerConfig::builder().
+    // Idempotent: returns Err if one is already installed (which we ignore).
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let cert_pem = std::fs::read(cert_path)?;
+    let key_pem = std::fs::read(key_path)?;
+
+    let certs: Vec<_> = rustls_pemfile::certs(&mut &cert_pem[..]).collect::<Result<_, _>>()?;
+    if certs.is_empty() {
+        return Err(format!("no certificates found in {}", cert_path.display()).into());
+    }
+    let key = rustls_pemfile::private_key(&mut &key_pem[..])?
+        .ok_or_else(|| format!("no private key found in {}", key_path.display()))?;
+
+    let mut config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)?;
+    config.alpn_protocols = alpn;
+
+    Ok(Arc::new(config))
 }
 
 /// Advisory for TLS-setup failures caused by a non-writable data dir;
@@ -315,6 +350,86 @@ mod tests {
         assert!(
             ips.contains(&std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)),
             "missing ::1 SAN"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_pem_tls_config_round_trip() {
+        let dir = std::env::temp_dir().join(format!("numa-test-pem-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let key_pair = KeyPair::generate().unwrap();
+        let mut params = CertificateParams::default();
+        params
+            .subject_alt_names
+            .push(SanType::DnsName("example.test".try_into().unwrap()));
+        let cert = params.self_signed(&key_pair).unwrap();
+
+        let cert_path = dir.join("cert.pem");
+        let key_path = dir.join("key.pem");
+        std::fs::write(&cert_path, cert.pem()).unwrap();
+        std::fs::write(&key_path, key_pair.serialize_pem()).unwrap();
+
+        let config =
+            load_pem_tls_config(&cert_path, &key_path, Vec::new()).expect("load self-signed pair");
+        assert!(config.alpn_protocols.is_empty(), "proxy ALPN stays empty");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn regenerate_tls_is_noop_in_byo_mode() {
+        let mut ctx = crate::testutil::test_ctx().await;
+        let dir = std::env::temp_dir().join(format!("numa-test-byo-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        ctx.data_dir = dir.clone();
+
+        let key_pair = KeyPair::generate().unwrap();
+        let mut params = CertificateParams::default();
+        params
+            .subject_alt_names
+            .push(SanType::DnsName("byo.test".try_into().unwrap()));
+        let cert = params.self_signed(&key_pair).unwrap();
+        let cert_path = dir.join("cert.pem");
+        let key_path = dir.join("key.pem");
+        std::fs::write(&cert_path, cert.pem()).unwrap();
+        std::fs::write(&key_path, key_pair.serialize_pem()).unwrap();
+        let user_cfg = load_pem_tls_config(&cert_path, &key_path, Vec::new()).unwrap();
+
+        ctx.tls_config = Some(arc_swap::ArcSwap::from(Arc::clone(&user_cfg)));
+        ctx.tls_byo = true;
+
+        regenerate_tls(&ctx);
+
+        let after = ctx.tls_config.as_ref().unwrap().load_full();
+        assert!(
+            Arc::ptr_eq(&user_cfg, &after),
+            "BYO cert must not be replaced by regenerate_tls"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_pem_tls_config_rejects_empty_cert() {
+        let dir = std::env::temp_dir().join(format!("numa-test-pem-empty-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let cert_path = dir.join("cert.pem");
+        let key_path = dir.join("key.pem");
+        std::fs::write(&cert_path, b"").unwrap();
+        std::fs::write(&key_path, b"").unwrap();
+
+        let err = load_pem_tls_config(&cert_path, &key_path, Vec::new())
+            .expect_err("empty PEM must fail");
+        assert!(
+            err.to_string().contains("no certificates found"),
+            "unexpected error: {}",
+            err
         );
 
         let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary
- `[proxy] cert_path` + `key_path` let numa serve a user-supplied PEM cert (Let's Encrypt or any external CA) instead of the self-signed local CA. Solves the trust-install pain raised in #211: no need to add numa's CA to every device.
- Trade-off: `proxy.tld` must be a domain you actually own. Let's Encrypt won't issue for `.numa`. Renew externally (certbot/acme.sh) and restart numa.

## Surface
- `numa.toml` `[proxy]`: optional `cert_path` + `key_path`.
- `regenerate_tls` early-returns in BYO mode — numa doesn't own the cert and can't reissue on service add/remove.
- `tls::load_pem_tls_config(cert, key, alpn)` is now shared between the HTTPS proxy (empty ALPN) and the DoT listener (`b"dot"`). DoT's private duplicate is gone — and DoT now inherits the new "no certificates found in PEM" guard.
- `tls::build_proxy_tls` owns the BYO-vs-local-CA decision; `serve.rs` startup is one line.

## Behaviour
- Both paths set + readable: serve the BYO cert. `regenerate_tls` is a no-op.
- Both paths set, load fails: warn loudly, **disable HTTPS proxy** (no silent fallback to a cert that won't match the user's domain).
- Only one of the paths set: error, **disable HTTPS proxy** (mirrors `[dot] cert_path`/`key_path` after 007e633).
- Neither set: existing local-CA flow — unchanged.

## Out of scope
- ACME / Certbot integration — Caddy/Traefik already do this better. Numa stays a DNS-first tool.
- SIGHUP reload of the cert — restart-to-roll for now.

## Test plan
- [x] `make all` green (lint + lib tests + integration)
- [x] New tests: `load_pem_tls_config_round_trip`, `load_pem_tls_config_rejects_empty_cert`, `regenerate_tls_is_noop_in_byo_mode`, `proxy_cert_and_key_paths_parse`, `proxy_cert_and_key_paths_default_to_none`
- [x] Manual end-to-end (sandbox numa on ports 5354/8080/8443/8853, self-signed pair):
    - **Proxy BYO valid** — served cert fingerprint matches on-disk file
    - **Proxy BYO bad PEM** (empty file) — `HTTPS proxy disabled: ... no certificates found`
    - **Proxy half-set** — `[proxy] cert_path and key_path must both be set — HTTPS proxy disabled`
    - **Proxy regen no-op in BYO** — adding a service via API leaves cert fingerprint unchanged
    - **Proxy local-CA fallback** — adding a service rotates the leaf; CA on disk survives across restarts (`ensure_ca` create + read branches)
    - **DoT BYO valid** — `openssl s_client -alpn dot` handshake succeeds; served fingerprint matches on-disk file
    - **DoT half-set** — `[dot] cert_path and key_path must both be set — DoT disabled`
- [x] Manual: LE-shape multi-cert chain (synthesized root → intermediate → leaf, identical layout to `fullchain.pem`). Confirmed numa parses both certs from the PEM, serves the full 2-cert chain in the TLS ServerHello, and `curl --cacert root.crt` validates without `-k` (`ssl_verify_result=0`). Didn't use a real LE cert + browser — `load_pem_tls_config` is PEM-format-agnostic and the chain handling is what was untested by the self-signed case.
