### PR TITLE
feat(server): client-IP allow_from ACL on DNS ingress

### DIFF
--- a/numa.toml
+++ b/numa.toml
@@ -19,6 +19,17 @@ api_port = 5380
                               # still configure v6 records for local services.
                               # Default: false.
 
+# Client-IP allowlist applied to every DNS query surface (UDP/53, TCP/53,
+# DoT, DoH). Mirrors PowerDNS Recursor's `allow-from`. Empty list (default)
+# = allow anyone that can reach the listener. Set this whenever numa is
+# bound to a WAN-routable interface, or it becomes an open recursive
+# resolver. Loopback is always allowed regardless of this list, so the
+# local stub resolver keeps working even if you mis-CIDR your LAN.
+# UDP queries from non-allowed peers are silently dropped (no
+# amplification, no fingerprint). TCP/DoT/DoH connections are closed
+# before the TLS handshake; DoH returns 403.
+# allow_from = ["10.0.0.0/8", "192.168.0.0/16", "fd00::/8"]
+
 # [upstream]
 # mode = "forward"                              # "forward" (default) — relay to upstream
 #                                               # "recursive" — resolve from root hints (no address needed)

--- a/numa.toml
+++ b/numa.toml
@@ -19,15 +19,11 @@ api_port = 5380
                               # still configure v6 records for local services.
                               # Default: false.
 
-# Client-IP allowlist applied to every DNS query surface (UDP/53, TCP/53,
-# DoT, DoH). Mirrors PowerDNS Recursor's `allow-from`. Empty list (default)
-# = allow anyone that can reach the listener. Set this whenever numa is
-# bound to a WAN-routable interface, or it becomes an open recursive
-# resolver. Loopback is always allowed regardless of this list, so the
-# local stub resolver keeps working even if you mis-CIDR your LAN.
-# UDP queries from non-allowed peers are silently dropped (no
-# amplification, no fingerprint). TCP/DoT/DoH connections are closed
-# before the TLS handshake; DoH returns 403.
+# ── Client-IP allowlist ────────────────────────────────────────────
+# Required on WAN-facing binds, or numa becomes an open recursive
+# resolver. Loopback always allowed. Denied peers: silent UDP drop,
+# TLS close pre-handshake, DoH 403.
+#
 # allow_from = ["10.0.0.0/8", "192.168.0.0/16", "fd00::/8"]
 
 # [upstream]

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -1,0 +1,121 @@
+//! Client-IP allowlist for the DNS query surfaces (UDP/53, TCP/53, DoT,
+//! DoH). Prevents numa being abused as a public open recursive resolver
+//! when bound to a WAN interface.
+//!
+//! Naming mirrors PowerDNS Recursor's `allow-from`. Empty list = feature
+//! disabled (allow all). Non-empty = listed CIDRs/IPs are allowed,
+//! everyone else is dropped pre-handshake.
+//!
+//! **Loopback is always allowed**, regardless of `allow_from`. The local
+//! machine's stub resolver (and the dashboard's `dig @127.0.0.1` probes)
+//! must keep working even when the ACL is misconfigured.
+//!
+//! When PROXY v2 is in play, the ACL checks the resolved client IP
+//! (post-header), not the L4 hop. That's the whole point of PP2.
+
+use std::net::IpAddr;
+
+use ipnet::IpNet;
+use log::warn;
+
+#[derive(Clone, Debug, Default)]
+pub struct AllowFromAcl {
+    nets: Vec<IpNet>,
+}
+
+impl AllowFromAcl {
+    pub fn from_entries(entries: &[String]) -> Result<Self, String> {
+        let mut nets = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let net: IpNet = entry
+                .parse()
+                .or_else(|_| entry.parse::<IpAddr>().map(IpNet::from))
+                .map_err(|_| format!("invalid CIDR or IP in allow_from: {entry:?}"))?;
+            if matches!(&net, IpNet::V4(n) if n.prefix_len() == 0)
+                || matches!(&net, IpNet::V6(n) if n.prefix_len() == 0)
+            {
+                warn!(
+                    "allow_from contains {} — any IP on the Internet will be permitted to query numa",
+                    entry
+                );
+            }
+            nets.push(net);
+        }
+        Ok(AllowFromAcl { nets })
+    }
+
+    pub fn allows(&self, peer: IpAddr) -> bool {
+        if self.nets.is_empty() || peer.is_loopback() {
+            return true;
+        }
+        self.nets.iter().any(|n| n.contains(&peer))
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        !self.nets.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn acl(entries: &[&str]) -> AllowFromAcl {
+        AllowFromAcl::from_entries(&entries.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+            .unwrap()
+    }
+
+    #[test]
+    fn empty_acl_allows_everything() {
+        let a = AllowFromAcl::default();
+        assert!(!a.is_enabled());
+        assert!(a.allows("1.2.3.4".parse().unwrap()));
+        assert!(a.allows("2001:db8::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_v4_allows_in_range_blocks_out_of_range() {
+        let a = acl(&["192.168.0.0/16"]);
+        assert!(a.is_enabled());
+        assert!(a.allows("192.168.1.5".parse().unwrap()));
+        assert!(!a.allows("10.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_v6_allows_in_range_blocks_out_of_range() {
+        let a = acl(&["2001:db8::/32"]);
+        assert!(a.allows("2001:db8::5".parse().unwrap()));
+        assert!(!a.allows("2001:db9::5".parse().unwrap()));
+    }
+
+    #[test]
+    fn bare_ip_is_treated_as_host_route() {
+        let a = acl(&["10.1.2.3", "fe80::1"]);
+        assert!(a.allows("10.1.2.3".parse().unwrap()));
+        assert!(!a.allows("10.1.2.4".parse().unwrap()));
+        assert!(a.allows("fe80::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn loopback_always_allowed_even_when_acl_is_set() {
+        let a = acl(&["192.168.1.0/24"]);
+        assert!(a.allows("127.0.0.1".parse().unwrap()));
+        assert!(a.allows("127.0.0.2".parse().unwrap()));
+        assert!(a.allows("::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn invalid_entry_rejects() {
+        assert!(AllowFromAcl::from_entries(&["not-a-cidr".to_string()]).is_err());
+        assert!(AllowFromAcl::from_entries(&["192.168.1.0/40".to_string()]).is_err());
+    }
+
+    #[test]
+    fn mixed_v4_and_v6_entries() {
+        let a = acl(&["10.0.0.0/8", "2001:db8::/32", "172.16.0.5"]);
+        assert!(a.allows("10.1.2.3".parse().unwrap()));
+        assert!(a.allows("2001:db8::abcd".parse().unwrap()));
+        assert!(a.allows("172.16.0.5".parse().unwrap()));
+        assert!(!a.allows("8.8.8.8".parse().unwrap()));
+    }
+}

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -1,22 +1,29 @@
-//! Client-IP allowlist for the DNS query surfaces (UDP/53, TCP/53, DoT,
-//! DoH). Prevents numa being abused as a public open recursive resolver
-//! when bound to a WAN interface.
-//!
-//! Naming mirrors PowerDNS Recursor's `allow-from`. Empty list = feature
-//! disabled (allow all). Non-empty = listed CIDRs/IPs are allowed,
-//! everyone else is dropped pre-handshake.
-//!
-//! **Loopback is always allowed**, regardless of `allow_from`. The local
-//! machine's stub resolver (and the dashboard's `dig @127.0.0.1` probes)
-//! must keep working even when the ACL is misconfigured.
-//!
-//! When PROXY v2 is in play, the ACL checks the resolved client IP
-//! (post-header), not the L4 hop. That's the whole point of PP2.
+//! Client-IP allowlist for DNS query surfaces. Loopback is always allowed
+//! regardless of `allow_from` — local stub resolvers must keep working
+//! even when the ACL is misconfigured. Under PROXY v2 the check runs on
+//! the resolved client IP (post-header), not the L4 hop.
 
 use std::net::IpAddr;
 
 use ipnet::IpNet;
 use log::warn;
+
+pub(crate) fn parse_cidr_list(entries: &[String], context: &str) -> Result<Vec<IpNet>, String> {
+    let mut nets = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let net: IpNet = entry
+            .parse()
+            .or_else(|_| entry.parse::<IpAddr>().map(IpNet::from))
+            .map_err(|_| format!("invalid CIDR or IP in {context}: {entry:?}"))?;
+        if matches!(&net, IpNet::V4(n) if n.prefix_len() == 0)
+            || matches!(&net, IpNet::V6(n) if n.prefix_len() == 0)
+        {
+            warn!("{context} contains world-routable {entry} — any IP on the Internet will match");
+        }
+        nets.push(net);
+    }
+    Ok(nets)
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct AllowFromAcl {
@@ -25,23 +32,9 @@ pub struct AllowFromAcl {
 
 impl AllowFromAcl {
     pub fn from_entries(entries: &[String]) -> Result<Self, String> {
-        let mut nets = Vec::with_capacity(entries.len());
-        for entry in entries {
-            let net: IpNet = entry
-                .parse()
-                .or_else(|_| entry.parse::<IpAddr>().map(IpNet::from))
-                .map_err(|_| format!("invalid CIDR or IP in allow_from: {entry:?}"))?;
-            if matches!(&net, IpNet::V4(n) if n.prefix_len() == 0)
-                || matches!(&net, IpNet::V6(n) if n.prefix_len() == 0)
-            {
-                warn!(
-                    "allow_from contains {} — any IP on the Internet will be permitted to query numa",
-                    entry
-                );
-            }
-            nets.push(net);
-        }
-        Ok(AllowFromAcl { nets })
+        Ok(AllowFromAcl {
+            nets: parse_cidr_list(entries, "allow_from")?,
+        })
     }
 
     pub fn allows(&self, peer: IpAddr) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,12 +105,7 @@ pub struct ServerConfig {
     /// listener in PROXY-required mode.
     #[serde(default)]
     pub proxy_protocol: ProxyProtocolConfig,
-    /// Client-IP allowlist applied to every DNS query surface (UDP/53,
-    /// TCP/53, DoT, DoH). Mirrors PowerDNS Recursor's `allow-from`.
-    /// Empty list (default) = feature disabled, numa answers anyone that
-    /// can reach the listener — fine on a LAN bind, dangerous on
-    /// `0.0.0.0:53` exposed to the WAN. Loopback is always allowed
-    /// regardless of this list, so the local stub resolver keeps working.
+    /// CIDR allowlist applied at every DNS surface. Empty = disabled.
     #[serde(default)]
     pub allow_from: Vec<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,6 +105,14 @@ pub struct ServerConfig {
     /// listener in PROXY-required mode.
     #[serde(default)]
     pub proxy_protocol: ProxyProtocolConfig,
+    /// Client-IP allowlist applied to every DNS query surface (UDP/53,
+    /// TCP/53, DoT, DoH). Mirrors PowerDNS Recursor's `allow-from`.
+    /// Empty list (default) = feature disabled, numa answers anyone that
+    /// can reach the listener — fine on a LAN bind, dangerous on
+    /// `0.0.0.0:53` exposed to the WAN. Loopback is always allowed
+    /// regardless of this list, so the local stub resolver keeps working.
+    #[serde(default)]
+    pub allow_from: Vec<String>,
 }
 
 impl Default for ServerConfig {
@@ -116,6 +124,7 @@ impl Default for ServerConfig {
             data_dir: None,
             filter_aaaa: false,
             proxy_protocol: ProxyProtocolConfig::default(),
+            allow_from: Vec::new(),
         }
     }
 }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -82,9 +82,6 @@ pub struct ServerCtx {
     /// answer) instead of hitting cache/forwarding/upstream. Local data
     /// (overrides, zones, .numa proxy, blocklist sinkhole) is unaffected.
     pub filter_aaaa: bool,
-    /// Client-IP allowlist for every DNS query surface (UDP/53, TCP/53,
-    /// DoT, DoH). Empty = allow all (default, current behavior). Loopback
-    /// is always allowed by the type, regardless of contents.
     pub allow_from: crate::acl::AllowFromAcl,
 }
 

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -82,6 +82,10 @@ pub struct ServerCtx {
     /// answer) instead of hitting cache/forwarding/upstream. Local data
     /// (overrides, zones, .numa proxy, blocklist sinkhole) is unaffected.
     pub filter_aaaa: bool,
+    /// Client-IP allowlist for every DNS query surface (UDP/53, TCP/53,
+    /// DoT, DoH). Empty = allow all (default, current behavior). Loopback
+    /// is always allowed by the type, regardless of contents.
+    pub allow_from: crate::acl::AllowFromAcl,
 }
 
 /// Transport-agnostic DNS resolution. Runs the full pipeline (overrides, blocklist,

--- a/src/doh.rs
+++ b/src/doh.rs
@@ -21,6 +21,14 @@ pub async fn doh_post(State(state): State<super::proxy::DohState>, req: Request)
         return StatusCode::NOT_FOUND.into_response();
     }
 
+    // ACL applies to the DNS query surface only — service-proxy routes on
+    // the same TLS listener are unaffected.
+    if let Some(addr) = state.remote_addr {
+        if !state.ctx.allow_from.allows(addr.ip()) {
+            return StatusCode::FORBIDDEN.into_response();
+        }
+    }
+
     let content_type = req
         .headers()
         .get(hyper::header::CONTENT_TYPE)

--- a/src/doh.rs
+++ b/src/doh.rs
@@ -21,10 +21,13 @@ pub async fn doh_post(State(state): State<super::proxy::DohState>, req: Request)
         return StatusCode::NOT_FOUND.into_response();
     }
 
-    // ACL applies to the DNS query surface only — service-proxy routes on
-    // the same TLS listener are unaffected.
-    if let Some(addr) = state.remote_addr {
-        if !state.ctx.allow_from.allows(addr.ip()) {
+    // Gate DoH only — service-proxy routes on the same TLS listener
+    // aren't subject to the DNS ACL. Fail closed when the peer is unknown.
+    if state.ctx.allow_from.is_enabled() {
+        let allowed = state
+            .remote_addr
+            .is_some_and(|a| state.ctx.allow_from.allows(a.ip()));
+        if !allowed {
             return StatusCode::FORBIDDEN.into_response();
         }
     }

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -123,6 +123,12 @@ async fn accept_loop(
                 return;
             };
 
+            if !ctx.allow_from.allows(remote_addr.ip()) {
+                // Close before TLS handshake — no fingerprint, no cert exposure.
+                debug!("DoT: dropping {} — not in allow_from", remote_addr);
+                return;
+            }
+
             let tls_stream =
                 match tokio::time::timeout(HANDSHAKE_TIMEOUT, acceptor.accept(stream)).await {
                     Ok(Ok(s)) => s,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod acl;
 pub mod api;
 pub mod blocklist;
 pub mod bootstrap_resolver;

--- a/src/pp2.rs
+++ b/src/pp2.rs
@@ -43,24 +43,8 @@ impl PpConfig {
         if cfg.from.is_empty() {
             return Ok(None);
         }
-        let mut from = Vec::with_capacity(cfg.from.len());
-        for entry in &cfg.from {
-            let net: IpNet = entry
-                .parse()
-                .or_else(|_| entry.parse::<IpAddr>().map(IpNet::from))
-                .map_err(|_| format!("invalid CIDR or IP in proxy_protocol.from: {entry:?}"))?;
-            if matches!(&net, IpNet::V4(n) if n.prefix_len() == 0)
-                || matches!(&net, IpNet::V6(n) if n.prefix_len() == 0)
-            {
-                warn!(
-                    "proxy_protocol.from contains world-routable {} — any sender on the Internet will be permitted to spoof source IPs",
-                    entry
-                );
-            }
-            from.push(net);
-        }
         Ok(Some(PpConfig {
-            from,
+            from: crate::acl::parse_cidr_list(&cfg.from, "proxy_protocol.from")?,
             header_timeout: Duration::from_millis(cfg.header_timeout_ms),
         }))
     }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -8,7 +8,7 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
-use log::{error, info};
+use log::{debug, error, info};
 use tokio::net::UdpSocket;
 
 use crate::blocklist::{download_blocklists, parse_blocklist, BlocklistStore};
@@ -122,6 +122,17 @@ pub async fn run(config_path: String) -> crate::Result<()> {
 
     let ca_pem = std::fs::read_to_string(resolved_data_dir.join("ca.pem")).ok();
 
+    let allow_from = crate::acl::AllowFromAcl::from_entries(&config.server.allow_from)
+        .map_err(|e| format!("invalid [server].allow_from: {e}"))?;
+    if allow_from.is_enabled() {
+        let n = config.server.allow_from.len();
+        info!(
+            "client-IP allow_from enabled — {} entr{} (loopback always allowed)",
+            n,
+            if n == 1 { "y" } else { "ies" }
+        );
+    }
+
     let sockets = bind_udp_listeners(&config.server.bind_addr).await?;
 
     let ctx = Arc::new(ServerCtx {
@@ -169,6 +180,7 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         mobile_enabled: config.mobile.enabled,
         mobile_port: config.mobile.port,
         filter_aaaa: config.server.filter_aaaa,
+        allow_from,
     });
 
     let zone_count: usize = ctx.zone_map.len();
@@ -388,6 +400,11 @@ async fn udp_serve_loop(
         let Some((src_addr, dns_len)) = pp.apply(&mut buffer.buf, len, peer) else {
             continue;
         };
+        if !ctx.allow_from.allows(src_addr.ip()) {
+            // Silent drop: no reply means no amplification, no fingerprint.
+            debug!("UDP: dropping {} — not in allow_from", src_addr);
+            continue;
+        }
         // Response goes to the kernel UDP peer (e.g. dnsdist), not the
         // PROXY-extracted logical source — otherwise the reply skips the
         // front-end and never reaches the original client.

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -125,11 +125,9 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     let allow_from = crate::acl::AllowFromAcl::from_entries(&config.server.allow_from)
         .map_err(|e| format!("invalid [server].allow_from: {e}"))?;
     if allow_from.is_enabled() {
-        let n = config.server.allow_from.len();
         info!(
-            "client-IP allow_from enabled — {} entr{} (loopback always allowed)",
-            n,
-            if n == 1 { "y" } else { "ies" }
+            "client-IP allow_from enabled with {} entries (loopback always allowed)",
+            config.server.allow_from.len()
         );
     }
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -87,6 +87,11 @@ async fn accept_loop(listener: TcpListener, pp: Option<Arc<PpConfig>>, ctx: Arc<
                 return;
             };
 
+            if !ctx.allow_from.allows(remote_addr.ip()) {
+                debug!("TCP: dropping {} — not in allow_from", remote_addr);
+                return;
+            }
+
             handle_framed_dns_connection(stream, remote_addr, &ctx, Transport::Tcp).await;
         });
     }

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -65,6 +65,7 @@ pub async fn test_ctx() -> ServerCtx {
         mobile_enabled: false,
         mobile_port: 8765,
         filter_aaaa: false,
+        allow_from: crate::acl::AllowFromAcl::default(),
     }
 }
 


### PR DESCRIPTION
## Summary
- New `[server].allow_from` CIDR allowlist applied to every DNS query surface (UDP/53, TCP/53, DoT, DoH route). Mirrors PowerDNS Recursor's `allow-from`.
- Empty list (default) keeps current open-listener behavior — non-breaking. Non-empty restricts queries to the listed CIDRs plus loopback.
- Loopback is always allowed regardless of contents, so the local stub resolver / dashboard probes keep working even with a mis-CIDRed LAN.
- Deny semantics chosen to minimise abuse signal: UDP silent drop (no amplification, no fingerprint), TCP/DoT closed before TLS handshake, DoH returns 403.
- PROXY v2 listeners check the resolved client IP (post-header), not the L4 hop.

Closes #230 — first piece of the anti-amplification stack discussed there. Tracking the rest (RRL with TC-slip, RFC 8482 ANY-refusal, DNS cookies, split allow_recursion) as follow-ups.

## Out of scope
Applied only to DNS surfaces. The `.numa` HTTP/HTTPS service proxy is unaffected on purpose — same trust boundary in most deployments, but the user's question was DNS-specific. Easy follow-up if anyone asks.

## Test plan
- [x] `cargo test --lib acl::` — 7 new unit tests (CIDR v4/v6, bare IP, loopback exemption, invalid entries, mixed v4+v6, empty default)
- [x] `make lint` clean (fmt + clippy -D warnings + audit)
- [x] Full suite: 441 lib tests pass
- [x] Docker smoke against a built numa image: in-range CIDR answered, out-of-range UDP silently dropped, out-of-range TCP closed pre-handshake, loopback exempt under restrictive ACL.