### PR TITLE
ci(release): add armv6 (Pi Zero W) build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             name: numa-linux-aarch64
+            cross: true
+          - target: arm-unknown-linux-musleabihf
+            os: ubuntu-latest
+            name: numa-linux-armv6
+            cross: true
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: numa-windows-x86_64
@@ -42,16 +47,16 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
-      - name: Install cross (aarch64)
-        if: matrix.target == 'aarch64-unknown-linux-musl'
+      - name: Install cross
+        if: matrix.cross
         run: cargo install cross
 
       - name: Build (native)
-        if: matrix.target != 'aarch64-unknown-linux-musl'
+        if: matrix.cross != true
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Build (cross)
-        if: matrix.target == 'aarch64-unknown-linux-musl'
+        if: matrix.cross
         run: cross build --release --target ${{ matrix.target }}
 
       - name: Package (Unix)

--- a/install.sh
+++ b/install.sh
@@ -17,9 +17,10 @@ esac
 # Detect architecture
 ARCH="$(uname -m)"
 case "$ARCH" in
-  x86_64|amd64)  ARCH_NAME="x86_64" ;;
-  arm64|aarch64) ARCH_NAME="aarch64" ;;
-  *)             echo "Unsupported architecture: $ARCH"; exit 1 ;;
+  x86_64|amd64)         ARCH_NAME="x86_64" ;;
+  arm64|aarch64)        ARCH_NAME="aarch64" ;;
+  armv6l|armv7l)        ARCH_NAME="armv6" ;;
+  *)                    echo "Unsupported architecture: $ARCH"; exit 1 ;;
 esac
 
 ASSET="numa-${OS_NAME}-${ARCH_NAME}.tar.gz"


### PR DESCRIPTION
## Summary
- Adds `arm-unknown-linux-musleabihf` to the release matrix, producing `numa-linux-armv6.tar.gz` alongside the existing assets. Cross-compiled via `cross-rs` (same toolchain we already use for `aarch64-unknown-linux-musl`).
- `install.sh` now recognises `armv6l` and `armv7l` from `uname -m` and maps both to the `armv6` asset.
- Refactored the cross-vs-native matrix conditions to key off a new `matrix.cross` boolean instead of name-matching the aarch64 target — future cross-compiled targets become a one-line matrix addition.

## Why
Tonight's headless setup of a Pi Zero W v1.1 (BCM2835, ARMv6, 512 MB) hit the limit on the previous matrix: \`install.sh\` exited with \"Unsupported architecture\". Pi Zero W is still in the wild (and runs Raspberry Pi OS Lite armhf perfectly), so it's worth covering. The musl static binary works on glibc distros, matching what we already do for aarch64.

## Notes
- ARMv6 instructions are forward-compatible on ARMv7+; mapping \`armv7l\` to the same \`armv6\` asset gives users running 32-bit Raspberry Pi OS on a Pi 3/4 a working install too. \`aarch64\` remains the recommended path on 64-bit hardware.
- The new \`matrix.cross\` boolean evaluates to \`undefined\` (falsy) on entries that don't set it; \`if: matrix.cross != true\` and \`if: matrix.cross\` partition the matrix correctly.

## Test plan
- [ ] CI builds \`numa-linux-armv6.tar.gz\` and uploads it as an artifact.
- [ ] Tag a release; verify the asset shows up next to the others.
- [ ] On a Pi Zero W: \`curl -fsSL https://raw.githubusercontent.com/razvandimescu/numa/main/install.sh | sh\` resolves to the armv6 asset and installs cleanly.
- [ ] Run \`numa --version\` on the Pi to confirm the binary executes.