### PR TITLE
feat(server): per-client domain policy [[client_policy]]

### DIFF
--- a/src/acl.rs
+++ b/src/acl.rs
@@ -98,43 +98,63 @@ mod tests {
             .unwrap()
     }
 
+    fn matcher(include: &[&str], exclude: &[&str]) -> CidrMatcher {
+        CidrMatcher::from_entries(
+            &include.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            &exclude.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            "test",
+        )
+        .unwrap()
+    }
+
+    fn check_allows(a: &AllowFromAcl, cases: &[(&str, bool)]) {
+        for &(peer, want) in cases {
+            assert_eq!(a.allows(peer.parse().unwrap()), want, "{peer}");
+        }
+    }
+
+    fn check_matches(m: &CidrMatcher, cases: &[(&str, bool)]) {
+        for &(peer, want) in cases {
+            assert_eq!(m.matches(peer.parse().unwrap()), want, "{peer}");
+        }
+    }
+
     #[test]
     fn empty_acl_allows_everything() {
         let a = AllowFromAcl::default();
         assert!(!a.is_enabled());
-        assert!(a.allows("1.2.3.4".parse().unwrap()));
-        assert!(a.allows("2001:db8::1".parse().unwrap()));
+        check_allows(&a, &[("1.2.3.4", true), ("2001:db8::1", true)]);
     }
 
     #[test]
     fn cidr_v4_allows_in_range_blocks_out_of_range() {
         let a = acl(&["192.168.0.0/16"]);
         assert!(a.is_enabled());
-        assert!(a.allows("192.168.1.5".parse().unwrap()));
-        assert!(!a.allows("10.0.0.1".parse().unwrap()));
+        check_allows(&a, &[("192.168.1.5", true), ("10.0.0.1", false)]);
     }
 
     #[test]
     fn cidr_v6_allows_in_range_blocks_out_of_range() {
-        let a = acl(&["2001:db8::/32"]);
-        assert!(a.allows("2001:db8::5".parse().unwrap()));
-        assert!(!a.allows("2001:db9::5".parse().unwrap()));
+        check_allows(
+            &acl(&["2001:db8::/32"]),
+            &[("2001:db8::5", true), ("2001:db9::5", false)],
+        );
     }
 
     #[test]
     fn bare_ip_is_treated_as_host_route() {
-        let a = acl(&["10.1.2.3", "fe80::1"]);
-        assert!(a.allows("10.1.2.3".parse().unwrap()));
-        assert!(!a.allows("10.1.2.4".parse().unwrap()));
-        assert!(a.allows("fe80::1".parse().unwrap()));
+        check_allows(
+            &acl(&["10.1.2.3", "fe80::1"]),
+            &[("10.1.2.3", true), ("10.1.2.4", false), ("fe80::1", true)],
+        );
     }
 
     #[test]
     fn loopback_always_allowed_even_when_acl_is_set() {
-        let a = acl(&["192.168.1.0/24"]);
-        assert!(a.allows("127.0.0.1".parse().unwrap()));
-        assert!(a.allows("127.0.0.2".parse().unwrap()));
-        assert!(a.allows("::1".parse().unwrap()));
+        check_allows(
+            &acl(&["192.168.1.0/24"]),
+            &[("127.0.0.1", true), ("127.0.0.2", true), ("::1", true)],
+        );
     }
 
     #[test]
@@ -147,62 +167,64 @@ mod tests {
     fn ipv4_mapped_client_matches_v4_rule() {
         // Dual-stack `[::]` binds deliver IPv4 peers as `::ffff:a.b.c.d`;
         // an IPv4 CIDR allowlist must still match (and still reject out-of-range).
-        let a = acl(&["192.168.1.0/24"]);
-        assert!(a.allows("::ffff:192.168.1.50".parse().unwrap()));
-        assert!(!a.allows("::ffff:10.0.0.1".parse().unwrap()));
+        check_allows(
+            &acl(&["192.168.1.0/24"]),
+            &[("::ffff:192.168.1.50", true), ("::ffff:10.0.0.1", false)],
+        );
     }
 
     #[test]
     fn ipv4_mapped_loopback_always_allowed() {
         // IPv4-mapped loopback on a dual-stack bind must pass through too.
-        let a = acl(&["192.168.1.0/24"]);
-        assert!(a.allows("::ffff:127.0.0.1".parse().unwrap()));
+        check_allows(&acl(&["192.168.1.0/24"]), &[("::ffff:127.0.0.1", true)]);
     }
 
     #[test]
     fn mixed_v4_and_v6_entries() {
-        let a = acl(&["10.0.0.0/8", "2001:db8::/32", "172.16.0.5"]);
-        assert!(a.allows("10.1.2.3".parse().unwrap()));
-        assert!(a.allows("2001:db8::abcd".parse().unwrap()));
-        assert!(a.allows("172.16.0.5".parse().unwrap()));
-        assert!(!a.allows("8.8.8.8".parse().unwrap()));
-    }
-
-    fn matcher(include: &[&str], exclude: &[&str]) -> CidrMatcher {
-        CidrMatcher::from_entries(
-            &include.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
-            &exclude.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
-            "test",
-        )
-        .unwrap()
+        check_allows(
+            &acl(&["10.0.0.0/8", "2001:db8::/32", "172.16.0.5"]),
+            &[
+                ("10.1.2.3", true),
+                ("2001:db8::abcd", true),
+                ("172.16.0.5", true),
+                ("8.8.8.8", false),
+            ],
+        );
     }
 
     #[test]
     fn exclude_subtracts_from_include() {
-        let m = matcher(&["192.168.1.0/24"], &["192.168.1.254"]);
-        assert!(m.matches("192.168.1.50".parse().unwrap()));
-        assert!(!m.matches("192.168.1.254".parse().unwrap()));
+        check_matches(
+            &matcher(&["192.168.1.0/24"], &["192.168.1.254"]),
+            &[("192.168.1.50", true), ("192.168.1.254", false)],
+        );
     }
 
     #[test]
     fn exclude_wins_over_nested_include() {
         // A more-specific include does not override an exclude — subtraction,
         // not longest-prefix.
-        let m = matcher(&["192.168.1.0/24", "192.168.1.254/32"], &["192.168.1.254"]);
-        assert!(!m.matches("192.168.1.254".parse().unwrap()));
+        check_matches(
+            &matcher(&["192.168.1.0/24", "192.168.1.254/32"], &["192.168.1.254"]),
+            &[("192.168.1.254", false)],
+        );
     }
 
     #[test]
     fn exclude_matches_v4_mapped_peer() {
-        let m = matcher(&["192.168.1.0/24"], &["192.168.1.254"]);
-        assert!(!m.matches("::ffff:192.168.1.254".parse().unwrap()));
-        assert!(m.matches("::ffff:192.168.1.50".parse().unwrap()));
+        check_matches(
+            &matcher(&["192.168.1.0/24"], &["192.168.1.254"]),
+            &[
+                ("::ffff:192.168.1.254", false),
+                ("::ffff:192.168.1.50", true),
+            ],
+        );
     }
 
     #[test]
     fn empty_include_matches_nothing() {
         let m = CidrMatcher::default();
         assert!(m.is_empty());
-        assert!(!m.matches("192.168.1.1".parse().unwrap()));
+        check_matches(&m, &[("192.168.1.1", false)]);
     }
 }

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -25,27 +25,64 @@ pub(crate) fn parse_cidr_list(entries: &[String], context: &str) -> Result<Vec<I
     Ok(nets)
 }
 
+/// Membership over an include set minus an exclude set, shared by `allow_from`
+/// and per-client policy. Canonicalizes the peer once here so v4-mapped IPv6
+/// (`::ffff:a.b.c.d`) from a dual-stack bind matches v4 CIDRs. Exclusion is set
+/// subtraction (not longest-prefix), so it always wins. Loopback / empty-set
+/// *policy* stays in the callers — they differ (allow vs passthrough).
+#[derive(Clone, Debug, Default)]
+pub(crate) struct CidrMatcher {
+    include: Vec<IpNet>,
+    exclude: Vec<IpNet>,
+}
+
+impl CidrMatcher {
+    pub(crate) fn from_entries(
+        include: &[String],
+        exclude: &[String],
+        context: &str,
+    ) -> Result<Self, String> {
+        Ok(CidrMatcher {
+            include: parse_cidr_list(include, context)?,
+            exclude: parse_cidr_list(exclude, &format!("{context} exclude"))?,
+        })
+    }
+
+    pub(crate) fn matches(&self, ip: IpAddr) -> bool {
+        let ip = ip.to_canonical();
+        if self.exclude.iter().any(|n| n.contains(&ip)) {
+            return false;
+        }
+        self.include.iter().any(|n| n.contains(&ip))
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.include.is_empty()
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct AllowFromAcl {
-    nets: Vec<IpNet>,
+    matcher: CidrMatcher,
 }
 
 impl AllowFromAcl {
     pub fn from_entries(entries: &[String]) -> Result<Self, String> {
         Ok(AllowFromAcl {
-            nets: parse_cidr_list(entries, "allow_from")?,
+            matcher: CidrMatcher::from_entries(entries, &[], "allow_from")?,
         })
     }
 
     pub fn allows(&self, peer: IpAddr) -> bool {
-        if self.nets.is_empty() || peer.is_loopback() {
+        let peer = peer.to_canonical();
+        if self.matcher.is_empty() || peer.is_loopback() {
             return true;
         }
-        self.nets.iter().any(|n| n.contains(&peer))
+        self.matcher.matches(peer)
     }
 
     pub fn is_enabled(&self) -> bool {
-        !self.nets.is_empty()
+        !self.matcher.is_empty()
     }
 }
 
@@ -110,5 +147,60 @@ mod tests {
         assert!(a.allows("2001:db8::abcd".parse().unwrap()));
         assert!(a.allows("172.16.0.5".parse().unwrap()));
         assert!(!a.allows("8.8.8.8".parse().unwrap()));
+    }
+
+    #[test]
+    fn allow_from_matches_v4_mapped_client() {
+        // Dual-stack `[::]` binds deliver IPv4 peers as `::ffff:a.b.c.d`; the
+        // canonicalization in CidrMatcher must let a v4 CIDR still match.
+        let a = acl(&["192.168.0.0/16"]);
+        assert!(a.allows("::ffff:192.168.1.5".parse().unwrap()));
+        assert!(!a.allows("::ffff:10.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn allow_from_v4_mapped_loopback_is_allowed() {
+        // `::ffff:127.0.0.1` is not `Ipv6Addr::is_loopback`; canonicalizing
+        // before the loopback check keeps a v4-mapped loopback bypassed.
+        let a = acl(&["192.168.0.0/16"]);
+        assert!(a.allows("::ffff:127.0.0.1".parse().unwrap()));
+    }
+
+    fn matcher(include: &[&str], exclude: &[&str]) -> CidrMatcher {
+        CidrMatcher::from_entries(
+            &include.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            &exclude.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            "test",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn exclude_subtracts_from_include() {
+        let m = matcher(&["192.168.1.0/24"], &["192.168.1.254"]);
+        assert!(m.matches("192.168.1.50".parse().unwrap()));
+        assert!(!m.matches("192.168.1.254".parse().unwrap()));
+    }
+
+    #[test]
+    fn exclude_wins_over_nested_include() {
+        // A more-specific include does not override an exclude — subtraction,
+        // not longest-prefix.
+        let m = matcher(&["192.168.1.0/24", "192.168.1.254/32"], &["192.168.1.254"]);
+        assert!(!m.matches("192.168.1.254".parse().unwrap()));
+    }
+
+    #[test]
+    fn exclude_matches_v4_mapped_peer() {
+        let m = matcher(&["192.168.1.0/24"], &["192.168.1.254"]);
+        assert!(!m.matches("::ffff:192.168.1.254".parse().unwrap()));
+        assert!(m.matches("::ffff:192.168.1.50".parse().unwrap()));
+    }
+
+    #[test]
+    fn empty_include_matches_nothing() {
+        let m = CidrMatcher::default();
+        assert!(m.is_empty());
+        assert!(!m.matches("192.168.1.1".parse().unwrap()));
     }
 }

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 
 use log::{info, warn};
 
+#[derive(Debug)]
 pub struct BlocklistStore {
     domains: HashSet<String>,
     allowlist: HashSet<String>,
@@ -234,7 +235,7 @@ pub fn parse_blocklist(text: &str) -> HashSet<String> {
     domains
 }
 
-fn normalize(domain: &str) -> String {
+pub(crate) fn normalize(domain: &str) -> String {
     domain.to_lowercase().trim_end_matches('.').to_string()
 }
 

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -235,7 +235,7 @@ pub fn parse_blocklist(text: &str) -> HashSet<String> {
     domains
 }
 
-pub(crate) fn normalize(domain: &str) -> String {
+fn normalize(domain: &str) -> String {
     domain.to_lowercase().trim_end_matches('.').to_string()
 }
 

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -79,8 +79,9 @@ impl ClientPolicySet {
         self.rules.len()
     }
 
-    /// First matching rule wins. Within a rule, allow beats block (via the
-    /// underlying `BlocklistStore` semantics).
+    /// Rules layer in declaration order: the first rule with an explicit
+    /// Block/Allow for `qname` wins; a client-matching rule silent on `qname`
+    /// falls through to the next. Within a rule, allow beats block.
     pub fn evaluate(&self, peer: IpAddr, qname: &str) -> Decision {
         // Dual-stack `[::]` binds deliver IPv4 clients as `::ffff:a.b.c.d`;
         // canonicalize so IPv4 CIDR rules and the loopback check still match.
@@ -221,7 +222,33 @@ mod tests {
     }
 
     #[test]
-    fn first_matching_rule_wins() {
+    fn silent_rule_falls_through_to_later_rule() {
+        // Rule 0 matches .50 but is silent on reddit → falls through to rule 1
+        // (the /24), which blocks it. Rule 0 still owns its own domain.
+        let set = ClientPolicySet::from_configs(&[
+            cfg(&["192.168.1.50"], &["youtube.com"], &[]),
+            cfg(&["192.168.1.0/24"], &["reddit.com"], &[]),
+        ])
+        .unwrap();
+        assert_eq!(
+            set.evaluate(ip("192.168.1.50"), "reddit.com"),
+            Decision::Block
+        );
+        assert_eq!(
+            set.evaluate(ip("192.168.1.50"), "youtube.com"),
+            Decision::Block
+        );
+        // .99 only matches rule 1, which is silent on youtube → passthrough.
+        assert_eq!(
+            set.evaluate(ip("192.168.1.99"), "youtube.com"),
+            Decision::Passthrough
+        );
+    }
+
+    #[test]
+    fn earlier_allow_beats_later_block() {
+        // For an overlapping client, the earlier rule's explicit decision wins:
+        // rule 0 allows the domain, the broader rule 1 blocks it → Allow.
         let set = ClientPolicySet::from_configs(&[
             cfg(&["192.168.1.50"], &[], &["news.ycombinator.com"]),
             cfg(&["192.168.1.0/24"], &["news.ycombinator.com"], &[]),

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -1,0 +1,245 @@
+//! Per-client domain policies: block or allow specific domains for specific
+//! client IPs. Each rule is a `BlocklistStore` scoped to a set of client CIDRs
+//! — the matcher, normalizer, and allowlist semantics are the same as the
+//! global adblock path, so policy rules and global blocking can't drift.
+//!
+//! Loopback bypass mirrors `allow_from`: stub resolvers on the same host
+//! never hit the per-client path.
+
+use std::collections::HashSet;
+use std::net::IpAddr;
+
+use ipnet::IpNet;
+use serde::Deserialize;
+
+use crate::acl::parse_cidr_list;
+use crate::blocklist::{normalize, BlocklistStore};
+
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct ClientPolicyConfig {
+    #[serde(default)]
+    pub clients: Vec<String>,
+    #[serde(default)]
+    pub block: Vec<String>,
+    #[serde(default)]
+    pub allow: Vec<String>,
+}
+
+#[derive(Debug)]
+struct ClientPolicy {
+    nets: Vec<IpNet>,
+    store: BlocklistStore,
+}
+
+#[derive(Debug, Default)]
+pub struct ClientPolicySet {
+    rules: Vec<ClientPolicy>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Decision {
+    Block,
+    Allow,
+    Passthrough,
+}
+
+impl ClientPolicySet {
+    pub fn from_configs(configs: &[ClientPolicyConfig]) -> Result<Self, String> {
+        let mut rules = Vec::with_capacity(configs.len());
+        for (idx, cfg) in configs.iter().enumerate() {
+            let ctx = format!("client_policy[{idx}].clients");
+            if cfg.clients.is_empty() {
+                return Err(format!("{ctx}: must list at least one CIDR or IP"));
+            }
+            if cfg.block.is_empty() && cfg.allow.is_empty() {
+                return Err(format!(
+                    "client_policy[{idx}]: must specify `block` or `allow` (or both)"
+                ));
+            }
+            let blocks: HashSet<String> = cfg
+                .block
+                .iter()
+                .map(|s| normalize(strip_wildcard(s)))
+                .collect();
+            let mut store = BlocklistStore::new();
+            store.swap_domains(blocks, vec![]);
+            for a in &cfg.allow {
+                store.add_to_allowlist(strip_wildcard(a));
+            }
+            rules.push(ClientPolicy {
+                nets: parse_cidr_list(&cfg.clients, &ctx)?,
+                store,
+            });
+        }
+        Ok(ClientPolicySet { rules })
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        !self.rules.is_empty()
+    }
+
+    pub fn rule_count(&self) -> usize {
+        self.rules.len()
+    }
+
+    /// First matching rule wins. Within a rule, allow beats block (via the
+    /// underlying `BlocklistStore` semantics).
+    pub fn evaluate(&self, peer: IpAddr, qname: &str) -> Decision {
+        if self.rules.is_empty() || peer.is_loopback() {
+            return Decision::Passthrough;
+        }
+        for rule in &self.rules {
+            if !rule.nets.iter().any(|n| n.contains(&peer)) {
+                continue;
+            }
+            let r = rule.store.check(qname);
+            if r.blocked {
+                return Decision::Block;
+            }
+            if r.matched_rule.is_some() {
+                return Decision::Allow;
+            }
+        }
+        Decision::Passthrough
+    }
+}
+
+fn strip_wildcard(s: &str) -> &str {
+    s.strip_prefix("*.").unwrap_or(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(clients: &[&str], block: &[&str], allow: &[&str]) -> ClientPolicyConfig {
+        ClientPolicyConfig {
+            clients: clients.iter().map(|s| s.to_string()).collect(),
+            block: block.iter().map(|s| s.to_string()).collect(),
+            allow: allow.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn empty_set_passes_through() {
+        let set = ClientPolicySet::default();
+        assert!(!set.is_enabled());
+        assert_eq!(
+            set.evaluate(ip("192.168.1.50"), "example.com"),
+            Decision::Passthrough
+        );
+    }
+
+    #[test]
+    fn blocks_matching_client() {
+        let set =
+            ClientPolicySet::from_configs(&[cfg(&["192.168.1.50/32"], &["youtube.com"], &[])])
+                .unwrap();
+        assert_eq!(
+            set.evaluate(ip("192.168.1.50"), "m.youtube.com"),
+            Decision::Block
+        );
+        assert_eq!(
+            set.evaluate(ip("192.168.1.99"), "m.youtube.com"),
+            Decision::Passthrough
+        );
+    }
+
+    #[test]
+    fn star_prefix_blocks_subdomains_and_apex() {
+        let set =
+            ClientPolicySet::from_configs(&[cfg(&["10.0.0.0/8"], &["*.tiktok.com"], &[])]).unwrap();
+        assert_eq!(
+            set.evaluate(ip("10.0.0.5"), "vm.tiktok.com"),
+            Decision::Block
+        );
+        assert_eq!(set.evaluate(ip("10.0.0.5"), "tiktok.com"), Decision::Block);
+    }
+
+    #[test]
+    fn allow_overrides_block_within_rule() {
+        let set = ClientPolicySet::from_configs(&[cfg(
+            &["192.168.1.50"],
+            &["example.com"],
+            &["safe.example.com"],
+        )])
+        .unwrap();
+        assert_eq!(
+            set.evaluate(ip("192.168.1.50"), "safe.example.com"),
+            Decision::Allow
+        );
+        assert_eq!(
+            set.evaluate(ip("192.168.1.50"), "ads.example.com"),
+            Decision::Block
+        );
+    }
+
+    #[test]
+    fn first_matching_rule_wins() {
+        let set = ClientPolicySet::from_configs(&[
+            cfg(&["192.168.1.50"], &[], &["news.ycombinator.com"]),
+            cfg(&["192.168.1.0/24"], &["news.ycombinator.com"], &[]),
+        ])
+        .unwrap();
+        assert_eq!(
+            set.evaluate(ip("192.168.1.50"), "news.ycombinator.com"),
+            Decision::Allow
+        );
+        assert_eq!(
+            set.evaluate(ip("192.168.1.99"), "news.ycombinator.com"),
+            Decision::Block
+        );
+    }
+
+    #[test]
+    fn loopback_always_passthrough() {
+        let set =
+            ClientPolicySet::from_configs(&[cfg(&["127.0.0.0/8"], &["example.com"], &[])]).unwrap();
+        assert_eq!(
+            set.evaluate(ip("127.0.0.1"), "example.com"),
+            Decision::Passthrough
+        );
+        assert_eq!(
+            set.evaluate(ip("::1"), "example.com"),
+            Decision::Passthrough
+        );
+    }
+
+    #[test]
+    fn ipv6_client_cidr() {
+        let set =
+            ClientPolicySet::from_configs(&[cfg(&["2001:db8::/32"], &["tracker.example"], &[])])
+                .unwrap();
+        assert_eq!(
+            set.evaluate(ip("2001:db8::abcd"), "tracker.example"),
+            Decision::Block
+        );
+        assert_eq!(
+            set.evaluate(ip("2001:db9::abcd"), "tracker.example"),
+            Decision::Passthrough
+        );
+    }
+
+    #[test]
+    fn rejects_empty_clients() {
+        let err = ClientPolicySet::from_configs(&[cfg(&[], &["x.com"], &[])]).unwrap_err();
+        assert!(err.contains("at least one CIDR"));
+    }
+
+    #[test]
+    fn rejects_empty_block_and_allow() {
+        let err = ClientPolicySet::from_configs(&[cfg(&["192.168.1.0/24"], &[], &[])]).unwrap_err();
+        assert!(err.contains("`block` or `allow`"));
+    }
+
+    #[test]
+    fn rejects_invalid_cidr() {
+        let err =
+            ClientPolicySet::from_configs(&[cfg(&["not-a-cidr"], &["x.com"], &[])]).unwrap_err();
+        assert!(err.contains("invalid CIDR"));
+    }
+}

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -109,6 +109,7 @@ impl ClientPolicySet {
 
 #[cfg(test)]
 mod tests {
+    use super::Decision::{Allow, Block, Passthrough};
     use super::*;
 
     fn cfg(from: &[&str], block: &[&str], allow: &[&str]) -> ClientPolicyConfig {
@@ -129,80 +130,78 @@ mod tests {
         }
     }
 
-    fn ip(s: &str) -> IpAddr {
-        s.parse().unwrap()
+    fn policy(rules: &[ClientPolicyConfig]) -> ClientPolicySet {
+        ClientPolicySet::from_configs(rules).unwrap()
+    }
+
+    /// Assert `(peer, qname) -> Decision` for each case against one rule set.
+    fn check(set: &ClientPolicySet, cases: &[(&str, &str, Decision)]) {
+        for (peer, qname, want) in cases {
+            let got = set.evaluate(peer.parse().unwrap(), qname);
+            assert_eq!(got, *want, "{peer} / {qname}");
+        }
     }
 
     #[test]
     fn empty_set_passes_through() {
         let set = ClientPolicySet::default();
         assert!(!set.is_enabled());
-        assert_eq!(
-            set.evaluate(ip("192.168.1.50"), "example.com"),
-            Decision::Passthrough
-        );
+        check(&set, &[("192.168.1.50", "example.com", Passthrough)]);
     }
 
     #[test]
     fn blocks_matching_client() {
-        let set =
-            ClientPolicySet::from_configs(&[cfg(&["192.168.1.50/32"], &["youtube.com"], &[])])
-                .unwrap();
-        assert_eq!(
-            set.evaluate(ip("192.168.1.50"), "m.youtube.com"),
-            Decision::Block
-        );
-        assert_eq!(
-            set.evaluate(ip("192.168.1.99"), "m.youtube.com"),
-            Decision::Passthrough
+        let set = policy(&[cfg(&["192.168.1.50/32"], &["youtube.com"], &[])]);
+        check(
+            &set,
+            &[
+                ("192.168.1.50", "m.youtube.com", Block),
+                ("192.168.1.99", "m.youtube.com", Passthrough),
+            ],
         );
     }
 
     #[test]
     fn star_prefix_blocks_subdomains_and_apex() {
-        let set =
-            ClientPolicySet::from_configs(&[cfg(&["10.0.0.0/8"], &["*.tiktok.com"], &[])]).unwrap();
-        assert_eq!(
-            set.evaluate(ip("10.0.0.5"), "vm.tiktok.com"),
-            Decision::Block
+        let set = policy(&[cfg(&["10.0.0.0/8"], &["*.tiktok.com"], &[])]);
+        check(
+            &set,
+            &[
+                ("10.0.0.5", "vm.tiktok.com", Block),
+                ("10.0.0.5", "tiktok.com", Block),
+            ],
         );
-        assert_eq!(set.evaluate(ip("10.0.0.5"), "tiktok.com"), Decision::Block);
     }
 
     #[test]
     fn adblock_syntax_is_parsed_like_global_list() {
         // `||host^` and `$options` must be stripped, matching parse_blocklist.
-        let set = ClientPolicySet::from_configs(&[cfg(
+        let set = policy(&[cfg(
             &["10.0.0.0/8"],
             &["||tracker.com^", "ads.net$third-party"],
             &[],
-        )])
-        .unwrap();
-        assert_eq!(set.evaluate(ip("10.0.0.5"), "tracker.com"), Decision::Block);
-        assert_eq!(
-            set.evaluate(ip("10.0.0.5"), "sub.tracker.com"),
-            Decision::Block
+        )]);
+        check(
+            &set,
+            &[
+                ("10.0.0.5", "tracker.com", Block),
+                ("10.0.0.5", "sub.tracker.com", Block),
+                ("10.0.0.5", "ads.net", Block),
+            ],
         );
-        assert_eq!(set.evaluate(ip("10.0.0.5"), "ads.net"), Decision::Block);
     }
 
     #[test]
     fn dotless_entry_does_not_blanket_block_a_tld() {
         // `*.com` normalizes to bare `com`, which parse_blocklist drops (no dot),
         // so it must NOT sinkhole the whole TLD; a valid sibling still blocks.
-        let set = ClientPolicySet::from_configs(&[cfg(
-            &["192.168.1.0/24"],
-            &["*.com", "ads.example"],
-            &[],
-        )])
-        .unwrap();
-        assert_eq!(
-            set.evaluate(ip("192.168.1.5"), "youtube.com"),
-            Decision::Passthrough
-        );
-        assert_eq!(
-            set.evaluate(ip("192.168.1.5"), "ads.example"),
-            Decision::Block
+        let set = policy(&[cfg(&["192.168.1.0/24"], &["*.com", "ads.example"], &[])]);
+        check(
+            &set,
+            &[
+                ("192.168.1.5", "youtube.com", Passthrough),
+                ("192.168.1.5", "ads.example", Block),
+            ],
         );
     }
 
@@ -217,19 +216,17 @@ mod tests {
 
     #[test]
     fn allow_overrides_block_within_rule() {
-        let set = ClientPolicySet::from_configs(&[cfg(
+        let set = policy(&[cfg(
             &["192.168.1.50"],
             &["example.com"],
             &["safe.example.com"],
-        )])
-        .unwrap();
-        assert_eq!(
-            set.evaluate(ip("192.168.1.50"), "safe.example.com"),
-            Decision::Allow
-        );
-        assert_eq!(
-            set.evaluate(ip("192.168.1.50"), "ads.example.com"),
-            Decision::Block
+        )]);
+        check(
+            &set,
+            &[
+                ("192.168.1.50", "safe.example.com", Allow),
+                ("192.168.1.50", "ads.example.com", Block),
+            ],
         );
     }
 
@@ -237,23 +234,18 @@ mod tests {
     fn silent_rule_falls_through_to_later_rule() {
         // Rule 0 matches .50 but is silent on reddit → falls through to rule 1
         // (the /24), which blocks it. Rule 0 still owns its own domain.
-        let set = ClientPolicySet::from_configs(&[
+        // .99 only matches rule 1, which is silent on youtube → passthrough.
+        let set = policy(&[
             cfg(&["192.168.1.50"], &["youtube.com"], &[]),
             cfg(&["192.168.1.0/24"], &["reddit.com"], &[]),
-        ])
-        .unwrap();
-        assert_eq!(
-            set.evaluate(ip("192.168.1.50"), "reddit.com"),
-            Decision::Block
-        );
-        assert_eq!(
-            set.evaluate(ip("192.168.1.50"), "youtube.com"),
-            Decision::Block
-        );
-        // .99 only matches rule 1, which is silent on youtube → passthrough.
-        assert_eq!(
-            set.evaluate(ip("192.168.1.99"), "youtube.com"),
-            Decision::Passthrough
+        ]);
+        check(
+            &set,
+            &[
+                ("192.168.1.50", "reddit.com", Block),
+                ("192.168.1.50", "youtube.com", Block),
+                ("192.168.1.99", "youtube.com", Passthrough),
+            ],
         );
     }
 
@@ -261,37 +253,30 @@ mod tests {
     fn earlier_allow_beats_later_block() {
         // For an overlapping client, the earlier rule's explicit decision wins:
         // rule 0 allows the domain, the broader rule 1 blocks it → Allow.
-        let set = ClientPolicySet::from_configs(&[
+        let set = policy(&[
             cfg(&["192.168.1.50"], &[], &["news.ycombinator.com"]),
             cfg(&["192.168.1.0/24"], &["news.ycombinator.com"], &[]),
-        ])
-        .unwrap();
-        assert_eq!(
-            set.evaluate(ip("192.168.1.50"), "news.ycombinator.com"),
-            Decision::Allow
-        );
-        assert_eq!(
-            set.evaluate(ip("192.168.1.99"), "news.ycombinator.com"),
-            Decision::Block
+        ]);
+        check(
+            &set,
+            &[
+                ("192.168.1.50", "news.ycombinator.com", Allow),
+                ("192.168.1.99", "news.ycombinator.com", Block),
+            ],
         );
     }
 
     #[test]
     fn loopback_always_passthrough() {
-        let set =
-            ClientPolicySet::from_configs(&[cfg(&["127.0.0.0/8"], &["example.com"], &[])]).unwrap();
-        assert_eq!(
-            set.evaluate(ip("127.0.0.1"), "example.com"),
-            Decision::Passthrough
-        );
-        assert_eq!(
-            set.evaluate(ip("::1"), "example.com"),
-            Decision::Passthrough
-        );
-        // IPv4-mapped loopback on a dual-stack bind must also pass through.
-        assert_eq!(
-            set.evaluate(ip("::ffff:127.0.0.1"), "example.com"),
-            Decision::Passthrough
+        // Plain, v6, and IPv4-mapped loopback on a dual-stack bind all bypass.
+        let set = policy(&[cfg(&["127.0.0.0/8"], &["example.com"], &[])]);
+        check(
+            &set,
+            &[
+                ("127.0.0.1", "example.com", Passthrough),
+                ("::1", "example.com", Passthrough),
+                ("::ffff:127.0.0.1", "example.com", Passthrough),
+            ],
         );
     }
 
@@ -299,31 +284,25 @@ mod tests {
     fn ipv4_mapped_client_matches_v4_rule() {
         // Dual-stack `[::]` binds deliver IPv4 peers as `::ffff:a.b.c.d`;
         // an IPv4 CIDR rule must still match (regression for #239 follow-up).
-        let set =
-            ClientPolicySet::from_configs(&[cfg(&["192.168.1.50/32"], &["youtube.com"], &[])])
-                .unwrap();
-        assert_eq!(
-            set.evaluate(ip("::ffff:192.168.1.50"), "m.youtube.com"),
-            Decision::Block
-        );
-        assert_eq!(
-            set.evaluate(ip("::ffff:192.168.1.99"), "m.youtube.com"),
-            Decision::Passthrough
+        let set = policy(&[cfg(&["192.168.1.50/32"], &["youtube.com"], &[])]);
+        check(
+            &set,
+            &[
+                ("::ffff:192.168.1.50", "m.youtube.com", Block),
+                ("::ffff:192.168.1.99", "m.youtube.com", Passthrough),
+            ],
         );
     }
 
     #[test]
     fn ipv6_client_cidr() {
-        let set =
-            ClientPolicySet::from_configs(&[cfg(&["2001:db8::/32"], &["tracker.example"], &[])])
-                .unwrap();
-        assert_eq!(
-            set.evaluate(ip("2001:db8::abcd"), "tracker.example"),
-            Decision::Block
-        );
-        assert_eq!(
-            set.evaluate(ip("2001:db9::abcd"), "tracker.example"),
-            Decision::Passthrough
+        let set = policy(&[cfg(&["2001:db8::/32"], &["tracker.example"], &[])]);
+        check(
+            &set,
+            &[
+                ("2001:db8::abcd", "tracker.example", Block),
+                ("2001:db9::abcd", "tracker.example", Passthrough),
+            ],
         );
     }
 
@@ -349,41 +328,19 @@ mod tests {
     #[test]
     fn exclude_carves_a_host_out_of_the_range() {
         // "filter the whole /24 except my own device" — the driving use case.
-        let set = ClientPolicySet::from_configs(&[cfg_ex(
+        // The excluded device matches no rule → passthrough (unfiltered).
+        let set = policy(&[cfg_ex(
             &["192.168.1.0/24"],
             &["192.168.1.254"],
             &["youtube.com"],
             &[],
-        )])
-        .unwrap();
-        assert_eq!(
-            set.evaluate(ip("192.168.1.50"), "youtube.com"),
-            Decision::Block
-        );
-        // The excluded device is unfiltered: it matches no rule → passthrough.
-        assert_eq!(
-            set.evaluate(ip("192.168.1.254"), "youtube.com"),
-            Decision::Passthrough
-        );
-    }
-
-    #[test]
-    fn excluded_v4_mapped_peer_is_unfiltered() {
-        // Exclusion must survive dual-stack canonicalization too.
-        let set = ClientPolicySet::from_configs(&[cfg_ex(
-            &["192.168.1.0/24"],
-            &["192.168.1.254"],
-            &["youtube.com"],
-            &[],
-        )])
-        .unwrap();
-        assert_eq!(
-            set.evaluate(ip("::ffff:192.168.1.254"), "youtube.com"),
-            Decision::Passthrough
-        );
-        assert_eq!(
-            set.evaluate(ip("::ffff:192.168.1.50"), "youtube.com"),
-            Decision::Block
+        )]);
+        check(
+            &set,
+            &[
+                ("192.168.1.50", "youtube.com", Block),
+                ("192.168.1.254", "youtube.com", Passthrough),
+            ],
         );
     }
 }

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -8,16 +8,17 @@
 
 use std::net::IpAddr;
 
-use ipnet::IpNet;
 use serde::Deserialize;
 
-use crate::acl::parse_cidr_list;
+use crate::acl::CidrMatcher;
 use crate::blocklist::{parse_blocklist, BlocklistStore};
 
 #[derive(Deserialize, Clone, Debug, Default)]
 pub struct ClientPolicyConfig {
     #[serde(default)]
     pub from: Vec<String>,
+    #[serde(default)]
+    pub exclude: Vec<String>,
     #[serde(default)]
     pub block: Vec<String>,
     #[serde(default)]
@@ -26,7 +27,7 @@ pub struct ClientPolicyConfig {
 
 #[derive(Debug)]
 struct ClientPolicy {
-    nets: Vec<IpNet>,
+    nets: CidrMatcher,
     store: BlocklistStore,
 }
 
@@ -46,16 +47,16 @@ impl ClientPolicySet {
     pub fn from_configs(configs: &[ClientPolicyConfig]) -> Result<Self, String> {
         let mut rules = Vec::with_capacity(configs.len());
         for (idx, cfg) in configs.iter().enumerate() {
-            let ctx = format!("client_policy[{idx}].from");
+            let ctx = format!("client_policy[{idx}]");
             if cfg.from.is_empty() {
-                return Err(format!("{ctx}: must list at least one CIDR or IP"));
+                return Err(format!("{ctx}.from: must list at least one CIDR or IP"));
             }
             // Reuse the global blocklist parser so per-client and global lists can't drift.
             let blocks = parse_blocklist(&cfg.block.join("\n"));
             let allows = parse_blocklist(&cfg.allow.join("\n"));
             if blocks.is_empty() && allows.is_empty() {
                 return Err(format!(
-                    "client_policy[{idx}]: must specify at least one valid domain in `block` or `allow`"
+                    "{ctx}: must specify at least one valid domain in `block` or `allow`"
                 ));
             }
             let mut store = BlocklistStore::new();
@@ -64,7 +65,7 @@ impl ClientPolicySet {
                 store.add_to_allowlist(a);
             }
             rules.push(ClientPolicy {
-                nets: parse_cidr_list(&cfg.from, &ctx)?,
+                nets: CidrMatcher::from_entries(&cfg.from, &cfg.exclude, &format!("{ctx}.from"))?,
                 store,
             });
         }
@@ -83,14 +84,15 @@ impl ClientPolicySet {
     /// Block/Allow for `qname` wins; a client-matching rule silent on `qname`
     /// falls through to the next. Within a rule, allow beats block.
     pub fn evaluate(&self, peer: IpAddr, qname: &str) -> Decision {
-        // Dual-stack `[::]` binds deliver IPv4 clients as `::ffff:a.b.c.d`;
-        // canonicalize so IPv4 CIDR rules and the loopback check still match.
+        // Canonicalize so the loopback bypass also covers `::ffff:127.0.0.1`
+        // from a dual-stack bind. Loopback wins over any `exclude` — a loopback
+        // peer never reaches the matcher, so it cannot be filtered.
         let peer = peer.to_canonical();
         if self.rules.is_empty() || peer.is_loopback() {
             return Decision::Passthrough;
         }
         for rule in &self.rules {
-            if !rule.nets.iter().any(|n| n.contains(&peer)) {
+            if !rule.nets.matches(peer) {
                 continue;
             }
             let r = rule.store.check(qname);
@@ -110,8 +112,18 @@ mod tests {
     use super::*;
 
     fn cfg(from: &[&str], block: &[&str], allow: &[&str]) -> ClientPolicyConfig {
+        cfg_ex(from, &[], block, allow)
+    }
+
+    fn cfg_ex(
+        from: &[&str],
+        exclude: &[&str],
+        block: &[&str],
+        allow: &[&str],
+    ) -> ClientPolicyConfig {
         ClientPolicyConfig {
             from: from.iter().map(|s| s.to_string()).collect(),
+            exclude: exclude.iter().map(|s| s.to_string()).collect(),
             block: block.iter().map(|s| s.to_string()).collect(),
             allow: allow.iter().map(|s| s.to_string()).collect(),
         }
@@ -332,5 +344,46 @@ mod tests {
         let err =
             ClientPolicySet::from_configs(&[cfg(&["not-a-cidr"], &["x.com"], &[])]).unwrap_err();
         assert!(err.contains("invalid CIDR"));
+    }
+
+    #[test]
+    fn exclude_carves_a_host_out_of_the_range() {
+        // "filter the whole /24 except my own device" — the driving use case.
+        let set = ClientPolicySet::from_configs(&[cfg_ex(
+            &["192.168.1.0/24"],
+            &["192.168.1.254"],
+            &["youtube.com"],
+            &[],
+        )])
+        .unwrap();
+        assert_eq!(
+            set.evaluate(ip("192.168.1.50"), "youtube.com"),
+            Decision::Block
+        );
+        // The excluded device is unfiltered: it matches no rule → passthrough.
+        assert_eq!(
+            set.evaluate(ip("192.168.1.254"), "youtube.com"),
+            Decision::Passthrough
+        );
+    }
+
+    #[test]
+    fn excluded_v4_mapped_peer_is_unfiltered() {
+        // Exclusion must survive dual-stack canonicalization too.
+        let set = ClientPolicySet::from_configs(&[cfg_ex(
+            &["192.168.1.0/24"],
+            &["192.168.1.254"],
+            &["youtube.com"],
+            &[],
+        )])
+        .unwrap();
+        assert_eq!(
+            set.evaluate(ip("::ffff:192.168.1.254"), "youtube.com"),
+            Decision::Passthrough
+        );
+        assert_eq!(
+            set.evaluate(ip("::ffff:192.168.1.50"), "youtube.com"),
+            Decision::Block
+        );
     }
 }

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -162,23 +162,13 @@ mod tests {
     }
 
     #[test]
-    fn star_prefix_blocks_subdomains_and_apex() {
-        let set = policy(&[cfg(&["10.0.0.0/8"], &["*.tiktok.com"], &[])]);
-        check(
-            &set,
-            &[
-                ("10.0.0.5", "vm.tiktok.com", Block),
-                ("10.0.0.5", "tiktok.com", Block),
-            ],
-        );
-    }
-
-    #[test]
     fn adblock_syntax_is_parsed_like_global_list() {
-        // `||host^` and `$options` must be stripped, matching parse_blocklist.
+        // `||host^`, `*.host`, and `$options` must all be stripped to the bare
+        // domain, matching parse_blocklist — and the *apex* ends up blocked, not
+        // just subdomains (so `*.tiktok.com` is not subdomain-only).
         let set = policy(&[cfg(
             &["10.0.0.0/8"],
-            &["||tracker.com^", "ads.net$third-party"],
+            &["||tracker.com^", "*.tiktok.com", "ads.net$third-party"],
             &[],
         )]);
         check(
@@ -186,6 +176,7 @@ mod tests {
             &[
                 ("10.0.0.5", "tracker.com", Block),
                 ("10.0.0.5", "sub.tracker.com", Block),
+                ("10.0.0.5", "tiktok.com", Block),
                 ("10.0.0.5", "ads.net", Block),
             ],
         );

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -17,7 +17,7 @@ use crate::blocklist::{parse_blocklist, BlocklistStore};
 #[derive(Deserialize, Clone, Debug, Default)]
 pub struct ClientPolicyConfig {
     #[serde(default)]
-    pub clients: Vec<String>,
+    pub from: Vec<String>,
     #[serde(default)]
     pub block: Vec<String>,
     #[serde(default)]
@@ -46,8 +46,8 @@ impl ClientPolicySet {
     pub fn from_configs(configs: &[ClientPolicyConfig]) -> Result<Self, String> {
         let mut rules = Vec::with_capacity(configs.len());
         for (idx, cfg) in configs.iter().enumerate() {
-            let ctx = format!("client_policy[{idx}].clients");
-            if cfg.clients.is_empty() {
+            let ctx = format!("client_policy[{idx}].from");
+            if cfg.from.is_empty() {
                 return Err(format!("{ctx}: must list at least one CIDR or IP"));
             }
             // Reuse the global blocklist parser so per-client and global lists can't drift.
@@ -64,7 +64,7 @@ impl ClientPolicySet {
                 store.add_to_allowlist(a);
             }
             rules.push(ClientPolicy {
-                nets: parse_cidr_list(&cfg.clients, &ctx)?,
+                nets: parse_cidr_list(&cfg.from, &ctx)?,
                 store,
             });
         }
@@ -108,9 +108,9 @@ impl ClientPolicySet {
 mod tests {
     use super::*;
 
-    fn cfg(clients: &[&str], block: &[&str], allow: &[&str]) -> ClientPolicyConfig {
+    fn cfg(from: &[&str], block: &[&str], allow: &[&str]) -> ClientPolicyConfig {
         ClientPolicyConfig {
-            clients: clients.iter().map(|s| s.to_string()).collect(),
+            from: from.iter().map(|s| s.to_string()).collect(),
             block: block.iter().map(|s| s.to_string()).collect(),
             allow: allow.iter().map(|s| s.to_string()).collect(),
         }

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -85,6 +85,9 @@ impl ClientPolicySet {
     /// First matching rule wins. Within a rule, allow beats block (via the
     /// underlying `BlocklistStore` semantics).
     pub fn evaluate(&self, peer: IpAddr, qname: &str) -> Decision {
+        // Dual-stack `[::]` binds deliver IPv4 clients as `::ffff:a.b.c.d`;
+        // canonicalize so IPv4 CIDR rules and the loopback check still match.
+        let peer = peer.to_canonical();
         if self.rules.is_empty() || peer.is_loopback() {
             return Decision::Passthrough;
         }
@@ -205,6 +208,28 @@ mod tests {
         );
         assert_eq!(
             set.evaluate(ip("::1"), "example.com"),
+            Decision::Passthrough
+        );
+        // IPv4-mapped loopback on a dual-stack bind must also pass through.
+        assert_eq!(
+            set.evaluate(ip("::ffff:127.0.0.1"), "example.com"),
+            Decision::Passthrough
+        );
+    }
+
+    #[test]
+    fn ipv4_mapped_client_matches_v4_rule() {
+        // Dual-stack `[::]` binds deliver IPv4 peers as `::ffff:a.b.c.d`;
+        // an IPv4 CIDR rule must still match (regression for #239 follow-up).
+        let set =
+            ClientPolicySet::from_configs(&[cfg(&["192.168.1.50/32"], &["youtube.com"], &[])])
+                .unwrap();
+        assert_eq!(
+            set.evaluate(ip("::ffff:192.168.1.50"), "m.youtube.com"),
+            Decision::Block
+        );
+        assert_eq!(
+            set.evaluate(ip("::ffff:192.168.1.99"), "m.youtube.com"),
             Decision::Passthrough
         );
     }

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -6,14 +6,13 @@
 //! Loopback bypass mirrors `allow_from`: stub resolvers on the same host
 //! never hit the per-client path.
 
-use std::collections::HashSet;
 use std::net::IpAddr;
 
 use ipnet::IpNet;
 use serde::Deserialize;
 
 use crate::acl::parse_cidr_list;
-use crate::blocklist::{normalize, BlocklistStore};
+use crate::blocklist::{parse_blocklist, BlocklistStore};
 
 #[derive(Deserialize, Clone, Debug, Default)]
 pub struct ClientPolicyConfig {
@@ -51,20 +50,18 @@ impl ClientPolicySet {
             if cfg.clients.is_empty() {
                 return Err(format!("{ctx}: must list at least one CIDR or IP"));
             }
-            if cfg.block.is_empty() && cfg.allow.is_empty() {
+            // Reuse the global blocklist parser so per-client and global lists can't drift.
+            let blocks = parse_blocklist(&cfg.block.join("\n"));
+            let allows = parse_blocklist(&cfg.allow.join("\n"));
+            if blocks.is_empty() && allows.is_empty() {
                 return Err(format!(
-                    "client_policy[{idx}]: must specify `block` or `allow` (or both)"
+                    "client_policy[{idx}]: must specify at least one valid domain in `block` or `allow`"
                 ));
             }
-            let blocks: HashSet<String> = cfg
-                .block
-                .iter()
-                .map(|s| normalize(strip_wildcard(s)))
-                .collect();
             let mut store = BlocklistStore::new();
             store.swap_domains(blocks, vec![]);
-            for a in &cfg.allow {
-                store.add_to_allowlist(strip_wildcard(a));
+            for a in &allows {
+                store.add_to_allowlist(a);
             }
             rules.push(ClientPolicy {
                 nets: parse_cidr_list(&cfg.clients, &ctx)?,
@@ -105,10 +102,6 @@ impl ClientPolicySet {
         }
         Decision::Passthrough
     }
-}
-
-fn strip_wildcard(s: &str) -> &str {
-    s.strip_prefix("*.").unwrap_or(s)
 }
 
 #[cfg(test)]
@@ -161,6 +154,52 @@ mod tests {
             Decision::Block
         );
         assert_eq!(set.evaluate(ip("10.0.0.5"), "tiktok.com"), Decision::Block);
+    }
+
+    #[test]
+    fn adblock_syntax_is_parsed_like_global_list() {
+        // `||host^` and `$options` must be stripped, matching parse_blocklist.
+        let set = ClientPolicySet::from_configs(&[cfg(
+            &["10.0.0.0/8"],
+            &["||tracker.com^", "ads.net$third-party"],
+            &[],
+        )])
+        .unwrap();
+        assert_eq!(set.evaluate(ip("10.0.0.5"), "tracker.com"), Decision::Block);
+        assert_eq!(
+            set.evaluate(ip("10.0.0.5"), "sub.tracker.com"),
+            Decision::Block
+        );
+        assert_eq!(set.evaluate(ip("10.0.0.5"), "ads.net"), Decision::Block);
+    }
+
+    #[test]
+    fn dotless_entry_does_not_blanket_block_a_tld() {
+        // `*.com` normalizes to bare `com`, which parse_blocklist drops (no dot),
+        // so it must NOT sinkhole the whole TLD; a valid sibling still blocks.
+        let set = ClientPolicySet::from_configs(&[cfg(
+            &["192.168.1.0/24"],
+            &["*.com", "ads.example"],
+            &[],
+        )])
+        .unwrap();
+        assert_eq!(
+            set.evaluate(ip("192.168.1.5"), "youtube.com"),
+            Decision::Passthrough
+        );
+        assert_eq!(
+            set.evaluate(ip("192.168.1.5"), "ads.example"),
+            Decision::Block
+        );
+    }
+
+    #[test]
+    fn rule_with_only_invalid_domains_is_rejected() {
+        // A rule whose lists parse to nothing (junk / dotless) errors at load
+        // instead of silently becoming a no-op.
+        assert!(
+            ClientPolicySet::from_configs(&[cfg(&["10.0.0.0/8"], &["*", "com"], &[])]).is_err()
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,8 @@ pub struct Config {
     pub mobile: MobileConfig,
     #[serde(default)]
     pub forwarding: Vec<ForwardingRuleConfig>,
+    #[serde(default)]
+    pub client_policy: Vec<crate::client_policy::ClientPolicyConfig>,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1719,6 +1719,7 @@ mod tests {
                 from: from.iter().map(|s| s.to_string()).collect(),
                 block: block.iter().map(|s| s.to_string()).collect(),
                 allow: allow.iter().map(|s| s.to_string()).collect(),
+                ..Default::default()
             },
         ])
         .unwrap()

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1710,13 +1710,13 @@ mod tests {
     }
 
     fn ctx_with_policy(
-        clients: &[&str],
+        from: &[&str],
         block: &[&str],
         allow: &[&str],
     ) -> crate::client_policy::ClientPolicySet {
         crate::client_policy::ClientPolicySet::from_configs(&[
             crate::client_policy::ClientPolicyConfig {
-                clients: clients.iter().map(|s| s.to_string()).collect(),
+                from: from.iter().map(|s| s.to_string()).collect(),
                 block: block.iter().map(|s| s.to_string()).collect(),
                 allow: allow.iter().map(|s| s.to_string()).collect(),
             },

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -84,6 +84,7 @@ pub struct ServerCtx {
     /// (overrides, zones, .numa proxy, blocklist sinkhole) is unaffected.
     pub filter_aaaa: bool,
     pub allow_from: crate::acl::AllowFromAcl,
+    pub client_policy: crate::client_policy::ClientPolicySet,
 }
 
 /// Transport-agnostic DNS resolution. Runs the full pipeline (overrides, blocklist,
@@ -281,7 +282,25 @@ fn resolve_local(
     {
         return Some(resolve_proxy_tld(query, src_addr, qname, qtype, ctx));
     }
-    if ctx.blocklist.read().unwrap().is_blocked(qname) {
+    let mut policy_allow = false;
+    if ctx.client_policy.is_enabled() {
+        match ctx.client_policy.evaluate(src_addr.ip(), qname) {
+            crate::client_policy::Decision::Block => {
+                let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
+                resp.answers.push(sinkhole_record(
+                    qname,
+                    qtype,
+                    std::net::Ipv4Addr::UNSPECIFIED,
+                    std::net::Ipv6Addr::UNSPECIFIED,
+                    60,
+                ));
+                return Some((resp, QueryPath::Blocked, DnssecStatus::Indeterminate));
+            }
+            crate::client_policy::Decision::Allow => policy_allow = true,
+            crate::client_policy::Decision::Passthrough => {}
+        }
+    }
+    if !policy_allow && ctx.blocklist.read().unwrap().is_blocked(qname) {
         let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
         resp.answers.push(sinkhole_record(
             qname,
@@ -1670,6 +1689,127 @@ mod tests {
             }
             other => panic!("expected UNKNOWN record, got {:?}", other),
         }
+    }
+
+    async fn resolve_from_src(
+        ctx: &Arc<ServerCtx>,
+        src: SocketAddr,
+        domain: &str,
+        qtype: QueryType,
+    ) -> (DnsPacket, QueryPath) {
+        let query = DnsPacket::query(0xBEEF, domain, qtype);
+        let mut buf = BytePacketBuffer::new();
+        query.write(&mut buf).unwrap();
+        let raw = &buf.buf[..buf.pos];
+        let (resp_buf, path) = resolve_query(query, raw, src, ctx, Transport::Udp)
+            .await
+            .unwrap();
+        let mut resp_parse_buf = BytePacketBuffer::from_bytes(resp_buf.filled());
+        let resp = DnsPacket::from_buffer(&mut resp_parse_buf).unwrap();
+        (resp, path)
+    }
+
+    fn ctx_with_policy(
+        clients: &[&str],
+        block: &[&str],
+        allow: &[&str],
+    ) -> crate::client_policy::ClientPolicySet {
+        crate::client_policy::ClientPolicySet::from_configs(&[
+            crate::client_policy::ClientPolicyConfig {
+                clients: clients.iter().map(|s| s.to_string()).collect(),
+                block: block.iter().map(|s| s.to_string()).collect(),
+                allow: allow.iter().map(|s| s.to_string()).collect(),
+            },
+        ])
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn pipeline_client_policy_blocks_matching_client() {
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.client_policy = ctx_with_policy(&["192.168.1.50/32"], &["youtube.com"], &[]);
+        let ctx = Arc::new(ctx);
+
+        let blocked_src: SocketAddr = "192.168.1.50:5000".parse().unwrap();
+        let (resp, path) = resolve_from_src(&ctx, blocked_src, "m.youtube.com", QueryType::A).await;
+        assert_eq!(path, QueryPath::Blocked);
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        match &resp.answers[0] {
+            DnsRecord::A { addr, .. } => assert_eq!(*addr, Ipv4Addr::UNSPECIFIED),
+            other => panic!("expected sinkhole A record, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn pipeline_client_policy_skips_unmatched_client() {
+        // Different client IP — policy must not apply. Falls through to
+        // forwarding, so we set up an upstream that confirms the query escaped.
+        let upstream_resp =
+            crate::testutil::a_record_response("youtube.com", Ipv4Addr::new(8, 8, 8, 8), 60);
+        let upstream_addr = crate::testutil::mock_upstream(upstream_resp).await;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.client_policy = ctx_with_policy(&["192.168.1.50/32"], &["youtube.com"], &[]);
+        ctx.forwarding_rules = vec![ForwardingRule::new(
+            "youtube.com".to_string(),
+            UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]),
+        )];
+        let ctx = Arc::new(ctx);
+
+        let other_src: SocketAddr = "192.168.1.99:5000".parse().unwrap();
+        let (resp, path) = resolve_from_src(&ctx, other_src, "youtube.com", QueryType::A).await;
+        assert_eq!(path, QueryPath::Forwarded);
+        match &resp.answers[0] {
+            DnsRecord::A { addr, .. } => assert_eq!(*addr, Ipv4Addr::new(8, 8, 8, 8)),
+            other => panic!("expected forwarded A record, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn pipeline_client_policy_allow_bypasses_global_blocklist() {
+        // Domain is in the global blocklist; client has an allow rule for it.
+        let upstream_resp =
+            crate::testutil::a_record_response("ads.example.com", Ipv4Addr::new(1, 2, 3, 4), 60);
+        let upstream_addr = crate::testutil::mock_upstream(upstream_resp).await;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        let mut domains = std::collections::HashSet::new();
+        domains.insert("ads.example.com".to_string());
+        ctx.blocklist.write().unwrap().swap_domains(domains, vec![]);
+        ctx.client_policy = ctx_with_policy(&["192.168.1.50"], &[], &["ads.example.com"]);
+        ctx.forwarding_rules = vec![ForwardingRule::new(
+            "example.com".to_string(),
+            UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]),
+        )];
+        let ctx = Arc::new(ctx);
+
+        let exempt_src: SocketAddr = "192.168.1.50:5000".parse().unwrap();
+        let (resp, path) =
+            resolve_from_src(&ctx, exempt_src, "ads.example.com", QueryType::A).await;
+        assert_eq!(path, QueryPath::Forwarded);
+        match &resp.answers[0] {
+            DnsRecord::A { addr, .. } => assert_eq!(*addr, Ipv4Addr::new(1, 2, 3, 4)),
+            other => panic!(
+                "expected forwarded A record (allow bypass), got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn pipeline_client_policy_loopback_falls_through_to_global_blocklist() {
+        // A policy that would block this domain for 127/8 must NOT trap the
+        // local stub resolver — loopback is always passthrough. Global
+        // blocklist still applies.
+        let mut ctx = crate::testutil::test_ctx().await;
+        let mut domains = std::collections::HashSet::new();
+        domains.insert("ads.tracker.test".to_string());
+        ctx.blocklist.write().unwrap().swap_domains(domains, vec![]);
+        ctx.client_policy = ctx_with_policy(&["127.0.0.0/8"], &["unrelated.test"], &[]);
+        let ctx = Arc::new(ctx);
+
+        let (_, path) = resolve_in_test(&ctx, "ads.tracker.test", QueryType::A).await;
+        assert_eq!(path, QueryPath::Blocked, "global blocklist still applies");
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod blocklist;
 pub mod bootstrap_resolver;
 pub mod buffer;
 pub mod cache;
+pub mod client_policy;
 pub mod config;
 pub mod ctx;
 pub mod dnssec;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -131,6 +131,15 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         );
     }
 
+    let client_policy = crate::client_policy::ClientPolicySet::from_configs(&config.client_policy)
+        .map_err(|e| format!("invalid [[client_policy]]: {e}"))?;
+    if client_policy.is_enabled() {
+        info!(
+            "per-client policies enabled: {} rule(s) (loopback always passthrough)",
+            client_policy.rule_count()
+        );
+    }
+
     let sockets = bind_udp_listeners(&config.server.bind_addr).await?;
 
     let ctx = Arc::new(ServerCtx {
@@ -179,6 +188,7 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         mobile_port: config.mobile.port,
         filter_aaaa: config.server.filter_aaaa,
         allow_from,
+        client_policy,
     });
 
     let zone_count: usize = ctx.zone_map.len();

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -66,6 +66,7 @@ pub async fn test_ctx() -> ServerCtx {
         mobile_port: 8765,
         filter_aaaa: false,
         allow_from: crate::acl::AllowFromAcl::default(),
+        client_policy: crate::client_policy::ClientPolicySet::default(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `[[client_policy]]` TOML section: per-client-IP `block` / `allow` rules, evaluated before the global blocklist.
- Each rule is a `BlocklistStore` scoped to a set of client CIDRs (`from`) — reuses the global blocklist parser/matcher/allowlist, so per-client and global blocking can't drift.
- **`exclude` carves hosts/ranges back out of `from`** (set subtraction — exclusion always wins), so *"filter the whole /24 except my own device"* is a single rule rather than cross-rule precedence.
- `Decision::Allow` bypasses the global blocklist (parental "carve out an exception for this one device" use case).
- Loopback is always `Passthrough` (mirrors `allow_from`) and **cannot be excluded** — the bypass wins. First matching rule wins; within a rule, allow beats block.
- **Shared `CidrMatcher { include, exclude }`** now backs both `allow_from` and `client_policy` with a single canonicalization point. This collapses two duplicated CIDR matchers and **closes the `allow_from` dual-stack gap** — `::ffff:` v4-mapped peers (and v4-mapped loopback) now match v4 CIDRs.

Example:

```toml
[[client_policy]]
from    = ["192.168.1.0/24"]
exclude = ["192.168.1.50"]      # my own device — left unfiltered
block   = ["youtube.com", "*.tiktok.com"]

[[client_policy]]
from  = ["192.168.1.100/32"]
block = ["reddit.com"]
allow = ["ads.example.com"]      # bypasses global blocklist for this client
```

## Known follow-ups

Deferred, not blockers:

- **Remote/reusable domain lists per client** (`block_sources` / `allow_sources`) — separate follow-up PR. It turns the static per-rule store into a refresh-on-timer one (shared with the global list loader); kept out so this PR stays a clean "client targeting" change.
- `/blocking/pause` — should pausing global blocking also pause per-client blocks? (Today it doesn't.)

Resolved in review: `Decision::Allow` stays narrow — it un-blocks a domain for the matching client but does **not** bypass `filter_aaaa` (network-capability shaping is orthogonal to content policy).

## Test plan

- [x] Unit tests in `client_policy::tests` (block/allow/rule precedence/loopback/IPv6 CIDR/adblock-syntax parity/validation errors + `exclude` subtraction + dual-stack)
- [x] Unit tests in `acl::tests` (`CidrMatcher` exclusion semantics + `allow_from` v4-mapped client & loopback)
- [x] Pipeline tests in `ctx::tests::pipeline_client_policy_*` (matching client blocked, unmatched client forwarded, allow bypasses global blocklist, loopback falls through to global blocklist)
- [x] `cargo test` (482 pass), `cargo fmt --check`, and `clippy` (clean on changed files) green locally — full `make lint` gate runs in CI
- [x] Manual: drop one device into a `block` rule on a live numa, confirm sinkhole + verify other devices on the LAN resolve normally
