### PR TITLE
feat(zones): chase CNAMEs in local zone resolution (#237)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -911,6 +911,29 @@ mod tests {
     }
 
     #[test]
+    fn cname_returned_when_qtype_absent() {
+        // RFC 1034 §3.6.2: a query on a CNAME owner for a different qtype must
+        // return the CNAME so the chase layer can follow it. Exact + wildcard.
+        let map = build_zone_map(&[
+            zone("alias.test", "CNAME", "real.test"),
+            zone("*.svc.home", "CNAME", "proxy.home"),
+        ])
+        .unwrap();
+
+        let exact = map.lookup("alias.test", QueryType::A).expect("hit");
+        assert!(matches!(&exact[0], DnsRecord::CNAME { host, .. } if host == "real.test"));
+
+        let wild = map.lookup("git.svc.home", QueryType::A).expect("hit");
+        match &wild[0] {
+            DnsRecord::CNAME { domain, host, .. } => {
+                assert_eq!(domain, "git.svc.home", "wildcard owner must be QNAME");
+                assert_eq!(host, "proxy.home");
+            }
+            other => panic!("expected CNAME, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn wildcard_nodata_when_qtype_absent() {
         let map = build_zone_map(&[zone("*.foo", "A", "10.0.0.1")]).unwrap();
         let result = map.lookup("x.foo", QueryType::AAAA);
@@ -1623,9 +1646,19 @@ impl ZoneMap {
 
     /// `None` = no zone owns this name (fall through to next stage).
     /// `Some(rrs)` = zone owns name; empty vec is NODATA (RFC 4592 §2.2.1).
+    /// RFC 1034 §3.6.2: if the qtype is absent but a CNAME exists at the
+    /// same name, return the CNAME so the chase layer can follow it.
     pub fn lookup(&self, qname: &str, qtype: QueryType) -> Option<Vec<DnsRecord>> {
         if let Some(records) = self.exact.get(qname) {
-            return Some(records.get(&qtype).cloned().unwrap_or_default());
+            if let Some(rrs) = records.get(&qtype) {
+                return Some(rrs.clone());
+            }
+            if qtype != QueryType::CNAME {
+                if let Some(cnames) = records.get(&QueryType::CNAME) {
+                    return Some(cnames.clone());
+                }
+            }
+            return Some(Vec::new());
         }
         let mut rest = qname;
         while let Some(dot) = rest.find('.') {
@@ -1634,20 +1667,24 @@ impl ZoneMap {
                 break;
             }
             if let Some(records) = self.wildcard.get(parent) {
-                return Some(
-                    records
-                        .get(&qtype)
-                        .map(|rrs| {
-                            rrs.iter()
-                                .cloned()
-                                .map(|mut r| {
-                                    r.set_domain(qname.to_string());
-                                    r
-                                })
-                                .collect()
+                let rebind = |rrs: &Vec<DnsRecord>| -> Vec<DnsRecord> {
+                    rrs.iter()
+                        .cloned()
+                        .map(|mut r| {
+                            r.set_domain(qname.to_string());
+                            r
                         })
-                        .unwrap_or_default(),
-                );
+                        .collect()
+                };
+                if let Some(rrs) = records.get(&qtype) {
+                    return Some(rebind(rrs));
+                }
+                if qtype != QueryType::CNAME {
+                    if let Some(cnames) = records.get(&QueryType::CNAME) {
+                        return Some(rebind(cnames));
+                    }
+                }
+                return Some(Vec::new());
             }
             rest = parent;
         }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -108,21 +108,10 @@ pub async fn resolve_query(
     // Pipeline: overrides -> .localhost -> local zones -> special-use (unless forwarded)
     //        -> .tld proxy -> blocklist -> cache -> forwarding -> recursive/upstream
     // Each lock is scoped to avoid holding MutexGuard across await points.
-    let mut upstream_transport: Option<crate::stats::UpstreamTransport> = None;
-    let (response, path, dnssec) = match resolve_local(&query, src_addr, &qname, qtype, ctx) {
-        Some(result) => result,
-        None => {
-            let (resp, path, dnssec, ut) =
-                resolve_remote(&query, raw_wire, src_addr, &qname, qtype, ctx).await;
-            upstream_transport = ut;
-            (resp, path, dnssec)
-        }
-    };
-
-    let mut response = response;
+    let (mut response, path, mut dnssec, upstream_transport) =
+        resolve_with_cname_chase(&query, raw_wire, src_addr, &qname, qtype, ctx).await;
 
     // DNSSEC validation (recursive/forwarded responses only)
-    let mut dnssec = dnssec;
     if ctx.dnssec_enabled && path == QueryPath::Recursive {
         let (status, vstats) =
             crate::dnssec::validate_response(&response, &ctx.cache, &ctx.root_hints, &ctx.srtt)
@@ -233,6 +222,71 @@ fn serialize_with_fallback(
             servfail.write(&mut out)?;
             Ok(out)
         }
+    }
+}
+
+/// RFC 1034 §3.6.2 CNAME chase across the local-or-remote pipeline. Bad
+/// chains (loop, over `MAX_CNAME_DEPTH`) return SERVFAIL, never bare CNAME.
+async fn resolve_with_cname_chase(
+    query: &DnsPacket,
+    raw_wire: &[u8],
+    src_addr: SocketAddr,
+    qname: &str,
+    qtype: QueryType,
+    ctx: &Arc<ServerCtx>,
+) -> (
+    DnsPacket,
+    QueryPath,
+    DnssecStatus,
+    Option<crate::stats::UpstreamTransport>,
+) {
+    let mut visited = HashSet::new();
+    visited.insert(qname.to_ascii_lowercase());
+
+    let (mut resp, path, dnssec, mut ut) = match resolve_local(query, src_addr, qname, qtype, ctx) {
+        Some((r, p, d)) => (r, p, d, None),
+        None => resolve_remote(query, raw_wire, src_addr, qname, qtype, ctx).await,
+    };
+    let mut current_qname = qname.to_string();
+
+    loop {
+        if resp.answers.iter().any(|r| r.query_type() == qtype)
+            || resp.header.rescode != ResultCode::NOERROR
+        {
+            return (resp, path, dnssec, ut);
+        }
+        let Some(target) = crate::recursive::extract_cname_target(&resp, &current_qname) else {
+            return (resp, path, dnssec, ut);
+        };
+        if visited.len() > crate::recursive::MAX_CNAME_DEPTH as usize
+            || !visited.insert(target.to_ascii_lowercase())
+        {
+            return (
+                DnsPacket::response_from(query, ResultCode::SERVFAIL),
+                path,
+                dnssec,
+                ut,
+            );
+        }
+
+        let sub_query = DnsPacket::query(query.header.id, &target, qtype);
+        let mut sub_buf = BytePacketBuffer::new();
+        sub_query
+            .write(&mut sub_buf)
+            .expect("sub-query serialization");
+        let (sub_resp, _, _, sub_ut) =
+            match resolve_local(&sub_query, src_addr, &target, qtype, ctx) {
+                Some((r, p, d)) => (r, p, d, None),
+                None => {
+                    resolve_remote(&sub_query, sub_buf.filled(), src_addr, &target, qtype, ctx)
+                        .await
+                }
+            };
+
+        resp.answers.extend(sub_resp.answers);
+        resp.header.rescode = sub_resp.header.rescode;
+        ut = ut.or(sub_ut);
+        current_qname = target;
     }
 }
 
@@ -2201,5 +2255,110 @@ mod tests {
             .unwrap();
             assert_eq!(src, addr, "reply must come from the receiving socket");
         }
+    }
+
+    // ---- CNAME chase (issue #237) ----
+
+    async fn ctx_with_zone(records: Vec<DnsRecord>) -> ServerCtx {
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.zone_map = crate::config::ZoneMap::from_exact(records);
+        ctx
+    }
+
+    #[tokio::test]
+    async fn cname_chase_local_to_local_returns_combined_answer() {
+        let ctx = Arc::new(
+            ctx_with_zone(vec![
+                crate::testutil::cname_record("app.example.com", "nas.lan", 60),
+                crate::testutil::a_record("nas.lan", Ipv4Addr::new(192, 168, 1, 42), 60),
+            ])
+            .await,
+        );
+
+        let (resp, path) = resolve_in_test(&ctx, "app.example.com", QueryType::A).await;
+        assert_eq!(path, QueryPath::Local);
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert_eq!(resp.answers.len(), 2);
+        assert!(matches!(&resp.answers[0], DnsRecord::CNAME { host, .. } if host == "nas.lan"));
+        assert!(
+            matches!(&resp.answers[1], DnsRecord::A { addr, .. } if *addr == Ipv4Addr::new(192, 168, 1, 42))
+        );
+    }
+
+    #[tokio::test]
+    async fn cname_chase_direct_cname_query_does_not_chase() {
+        let ctx = Arc::new(
+            ctx_with_zone(vec![
+                crate::testutil::cname_record("app.example.com", "nas.lan", 60),
+                crate::testutil::a_record("nas.lan", Ipv4Addr::new(192, 168, 1, 42), 60),
+            ])
+            .await,
+        );
+
+        let (resp, path) = resolve_in_test(&ctx, "app.example.com", QueryType::CNAME).await;
+        assert_eq!(path, QueryPath::Local);
+        assert_eq!(resp.answers.len(), 1);
+        assert!(matches!(&resp.answers[0], DnsRecord::CNAME { .. }));
+    }
+
+    #[tokio::test]
+    async fn cname_chase_loop_returns_servfail() {
+        let ctx = Arc::new(
+            ctx_with_zone(vec![
+                crate::testutil::cname_record("a.test", "b.test", 60),
+                crate::testutil::cname_record("b.test", "a.test", 60),
+            ])
+            .await,
+        );
+        let (resp, _) = resolve_in_test(&ctx, "a.test", QueryType::A).await;
+        assert_eq!(resp.header.rescode, ResultCode::SERVFAIL);
+    }
+
+    #[tokio::test]
+    async fn cname_chase_depth_cap_returns_servfail() {
+        let chain: Vec<DnsRecord> = (0..10)
+            .map(|i| {
+                crate::testutil::cname_record(
+                    &format!("n{}.test", i),
+                    &format!("n{}.test", i + 1),
+                    60,
+                )
+            })
+            .collect();
+        let ctx = Arc::new(ctx_with_zone(chain).await);
+        let (resp, _) = resolve_in_test(&ctx, "n0.test", QueryType::A).await;
+        assert_eq!(resp.header.rescode, ResultCode::SERVFAIL);
+    }
+
+    #[tokio::test]
+    async fn cname_chase_local_to_upstream_returns_combined() {
+        let upstream = crate::testutil::mock_upstream(crate::testutil::a_record_response(
+            "public.example.org",
+            Ipv4Addr::new(93, 184, 216, 34),
+            300,
+        ))
+        .await;
+
+        let mut ctx = ctx_with_zone(vec![crate::testutil::cname_record(
+            "alias.test",
+            "public.example.org",
+            60,
+        )])
+        .await;
+        ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
+            vec![crate::forward::Upstream::Udp(upstream)],
+            vec![],
+        ));
+        let ctx = Arc::new(ctx);
+
+        let (resp, _) = resolve_in_test(&ctx, "alias.test", QueryType::A).await;
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert_eq!(resp.answers.len(), 2);
+        assert!(
+            matches!(&resp.answers[0], DnsRecord::CNAME { host, .. } if host == "public.example.org")
+        );
+        assert!(
+            matches!(&resp.answers[1], DnsRecord::A { addr, .. } if *addr == Ipv4Addr::new(93, 184, 216, 34))
+        );
     }
 }

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -15,7 +15,7 @@ use crate::srtt::SrttCache;
 use crate::stats::UpstreamTransport;
 
 const MAX_REFERRAL_DEPTH: u8 = 10;
-const MAX_CNAME_DEPTH: u8 = 8;
+pub(crate) const MAX_CNAME_DEPTH: u8 = 8;
 const NS_QUERY_TIMEOUT: Duration = Duration::from_millis(400);
 const TCP_TIMEOUT: Duration = Duration::from_millis(400);
 const UDP_FAIL_THRESHOLD: u8 = 3;
@@ -790,7 +790,7 @@ async fn send_query(
     }
 }
 
-fn extract_cname_target(response: &DnsPacket, qname: &str) -> Option<String> {
+pub(crate) fn extract_cname_target(response: &DnsPacket, qname: &str) -> Option<String> {
     response.answers.iter().find_map(|r| match r {
         DnsRecord::CNAME { domain, host, .. } if domain.eq_ignore_ascii_case(qname) => {
             Some(host.clone())

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -69,6 +69,24 @@ pub async fn test_ctx() -> ServerCtx {
     }
 }
 
+/// Build a `DnsRecord::A` — concise fixture for zone-map and pipeline tests.
+pub fn a_record(domain: &str, addr: Ipv4Addr, ttl: u32) -> DnsRecord {
+    DnsRecord::A {
+        domain: domain.to_string(),
+        addr,
+        ttl,
+    }
+}
+
+/// Build a `DnsRecord::CNAME` — concise fixture for zone-map and pipeline tests.
+pub fn cname_record(domain: &str, host: &str, ttl: u32) -> DnsRecord {
+    DnsRecord::CNAME {
+        domain: domain.to_string(),
+        host: host.to_string(),
+        ttl,
+    }
+}
+
 /// Build a NOERROR response containing a single A record — the shape used
 /// repeatedly by pipeline/forwarding tests to seed `mock_upstream`.
 pub fn a_record_response(domain: &str, addr: Ipv4Addr, ttl: u32) -> DnsPacket {

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -380,6 +380,20 @@ domain = "*.foo.test"
 record_type = "A"
 value = "10.0.0.2"
 ttl = 60
+
+# CNAME chase (issue #237) — interop check that dig parses our
+# combined CNAME+A answer. Logic itself is covered by unit tests.
+[[zones]]
+domain = "alias.local"
+record_type = "CNAME"
+value = "target.local"
+ttl = 60
+
+[[zones]]
+domain = "target.local"
+record_type = "A"
+value = "10.0.0.3"
+ttl = 60
 CONF
 
 RUST_LOG=info "$BINARY" "$CONFIG" > "$LOG" 2>&1 &
@@ -407,6 +421,10 @@ check "Local PTR record (192.168.0.1 → router.lan)" \
 check "Non-local domain still resolves" \
     "." \
     "$($DIG example.com A +short)"
+
+check "CNAME chase: alias.local A → target.local A → 10.0.0.3 (#237)" \
+    "10.0.0.3" \
+    "$($DIG alias.local A +short)"
 
 echo ""
 echo "=== Wildcard zones (RFC 4592) ==="


### PR DESCRIPTION
## Summary

- `ZoneMap::lookup` falls back to CNAME when the qtype is absent, per RFC 1034 §3.6.2 (both exact and wildcard branches).
- New `resolve_with_cname_chase` helper drives the local-or-remote pipeline once, then re-enters for any CNAME target — same merge pattern as `resolve_iterative`'s in-protocol chase, but at the top of the pipeline so chases flow through cache / forwarder / recursive cleanly.
- Loop guard via visited-set; depth cap at `MAX_CNAME_DEPTH` (8), shared with the recursive resolver. On loop or over-depth: SERVFAIL, never bare-CNAME NOERROR (per the dnsmasq man page footgun — many stubs misread bare CNAME as NXDOMAIN).

Closes #237.

## Test plan

- [x] `cargo test --lib` (459 pass, including 6 new chase tests)
- [x] `cargo test` (full suite: 462 pass)
- [x] `cargo clippy -- -D warnings` clean on touched files
- [x] `cargo fmt --check` clean

New test cases cover:
- local CNAME → local A: combined answer
- direct CNAME query: returns just the CNAME, no chase
- loop `a→b→a`: SERVFAIL via visited-set
- 10-deep chain: SERVFAIL via depth cap
- local CNAME → upstream (mocked): combined answer through full pipeline
- wildcard CNAME: chased with QNAME owner rebinding

## Known follow-ups (separate PRs)

- Propagate `query.edns` to sub-queries so the DO bit and UDP payload size survive the chase hop.
- Lowercase CNAME `host` in `build_zone_map` (zone config currently stores target case verbatim, which breaks chase into local zones for mixed-case targets).
- Cache the merged chain under `(alias, qtype)` — needs a pipeline reorder to be useful, deferred.