### PR TITLE
fix(acl): canonicalize peer IP for dual-stack allow_from matching

### DIFF
--- a/src/acl.rs
+++ b/src/acl.rs
@@ -38,6 +38,9 @@ impl AllowFromAcl {
     }
 
     pub fn allows(&self, peer: IpAddr) -> bool {
+        // Dual-stack `[::]` binds deliver IPv4 clients as `::ffff:a.b.c.d`;
+        // canonicalize so IPv4 CIDR rules and the loopback check still match.
+        let peer = peer.to_canonical();
         if self.nets.is_empty() || peer.is_loopback() {
             return true;
         }
@@ -101,6 +104,22 @@ mod tests {
     fn invalid_entry_rejects() {
         assert!(AllowFromAcl::from_entries(&["not-a-cidr".to_string()]).is_err());
         assert!(AllowFromAcl::from_entries(&["192.168.1.0/40".to_string()]).is_err());
+    }
+
+    #[test]
+    fn ipv4_mapped_client_matches_v4_rule() {
+        // Dual-stack `[::]` binds deliver IPv4 peers as `::ffff:a.b.c.d`;
+        // an IPv4 CIDR allowlist must still match (and still reject out-of-range).
+        let a = acl(&["192.168.1.0/24"]);
+        assert!(a.allows("::ffff:192.168.1.50".parse().unwrap()));
+        assert!(!a.allows("::ffff:10.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn ipv4_mapped_loopback_always_allowed() {
+        // IPv4-mapped loopback on a dual-stack bind must pass through too.
+        let a = acl(&["192.168.1.0/24"]);
+        assert!(a.allows("::ffff:127.0.0.1".parse().unwrap()));
     }
 
     #[test]


### PR DESCRIPTION
## What

`AllowFromAcl::allows()` (`src/acl.rs`, shipped in #232) compares the peer against IPv4 CIDRs with `IpNet::contains()` and short-circuits on `is_loopback()` — but does **not** canonicalize the peer first.

On a dual-stack `[::]` bind, IPv4 clients arrive as IPv4-mapped IPv6 (`::ffff:a.b.c.d`). Against an IPv4 CIDR that silently **fails to match**, so legitimate v4 clients get **denied**; the `is_loopback()` guarantee also breaks for `::ffff:127.0.0.1`.

This is the same class of bug fixed for `client_policy` in #239 — porting the identical one-liner to the other client-IP ACL.

## Fix

```rust
let peer = peer.to_canonical();
```
at the top of `allows()`, plus regression tests:
- `ipv4_mapped_client_matches_v4_rule` — `::ffff:192.168.1.50` matches `192.168.1.0/24`, `::ffff:10.0.0.1` still rejected
- `ipv4_mapped_loopback_always_allowed` — `::ffff:127.0.0.1` passes through

Verified the test fails without the fix (peer denied) and passes with it.

## Impact

Dormant on any bind that keeps a dedicated v4 socket (or `net.ipv6.bindv6only=1`, where `[::]` is v6-only) — v4 clients arrive native. Bites a `[::]`-only bind. Low-risk, additive.