### PR TITLE
fix(dnssec): authenticate DS RRsets and root self-signature

### DIFF
--- a/src/dnssec.rs
+++ b/src/dnssec.rs
@@ -1825,4 +1825,243 @@ mod tests {
         // invalid char
         assert!(base32hex_decode("!!").is_none());
     }
+
+    // --- Chain-of-trust authentication (issue #235 follow-up) ---
+    // An attacker who can tamper with a delegation's DS response must not be
+    // able to forge a Secure verdict. These tests mint throwaway ECDSA P-256
+    // (algo 13) keys so a self-consistent chain can be built end to end, with a
+    // test KSK standing in for the root trust anchor (the real root's private
+    // key is, by design, unforgeable).
+    use ring::rand::SystemRandom;
+    use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
+
+    struct TestSigner {
+        key: EcdsaKeyPair,
+        pubkey: Vec<u8>, // DNSSEC form: raw x||y, no 0x04 prefix
+        flags: u16,
+    }
+
+    fn mk_signer(flags: u16) -> TestSigner {
+        let rng = SystemRandom::new();
+        let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng).unwrap();
+        let key = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8.as_ref(), &rng)
+            .unwrap();
+        let pubkey = key.public_key().as_ref()[1..].to_vec();
+        TestSigner { key, pubkey, flags }
+    }
+
+    fn mk_dnskey(owner: &str, s: &TestSigner) -> DnsRecord {
+        DnsRecord::DNSKEY {
+            domain: owner.into(),
+            flags: s.flags,
+            protocol: 3,
+            algorithm: 13,
+            public_key: s.pubkey.clone(),
+            ttl: 3600,
+        }
+    }
+
+    /// RRSIG made by `signer` over `rrset`, signing the exact bytes the
+    /// validator reconstructs via `build_signed_data`.
+    fn mk_rrsig(
+        signer: &TestSigner,
+        signer_name: &str,
+        type_covered: QueryType,
+        rrset: &[&DnsRecord],
+    ) -> DnsRecord {
+        let mut rrsig = DnsRecord::RRSIG {
+            domain: rrset[0].domain().to_string(),
+            type_covered: type_covered.to_num(),
+            algorithm: 13,
+            labels: rrset[0]
+                .domain()
+                .split('.')
+                .filter(|l| !l.is_empty())
+                .count() as u8,
+            original_ttl: 3600,
+            expiration: 2_147_483_647,
+            inception: 1,
+            key_tag: compute_key_tag(signer.flags, 3, 13, &signer.pubkey),
+            signer_name: signer_name.to_string(),
+            signature: Vec::new(),
+            ttl: 3600,
+        };
+        let signed_data = build_signed_data(&rrsig, rrset);
+        let sig = signer.key.sign(&SystemRandom::new(), &signed_data).unwrap();
+        if let DnsRecord::RRSIG { signature, .. } = &mut rrsig {
+            *signature = sig.as_ref().to_vec();
+        }
+        rrsig
+    }
+
+    fn mk_ds(child_owner: &str, child_ksk: &DnsRecord) -> DnsRecord {
+        let DnsRecord::DNSKEY {
+            flags,
+            protocol,
+            algorithm,
+            public_key,
+            ..
+        } = child_ksk
+        else {
+            unreachable!()
+        };
+        let mut input = name_to_wire(child_owner);
+        input.extend(&flags.to_be_bytes());
+        input.push(*protocol);
+        input.push(*algorithm);
+        input.extend(public_key);
+        DnsRecord::DS {
+            domain: child_owner.into(),
+            key_tag: compute_key_tag(*flags, *protocol, *algorithm, public_key),
+            algorithm: *algorithm,
+            digest_type: 2,
+            digest: digest::digest(&digest::SHA256, &input).as_ref().to_vec(),
+            ttl: 3600,
+        }
+    }
+
+    fn mk_pkt(answers: Vec<DnsRecord>) -> DnsPacket {
+        let mut p = DnsPacket::new();
+        p.answers = answers;
+        p
+    }
+
+    fn empty_ctx() -> (RwLock<DnsCache>, RwLock<SrttCache>, Mutex<ValidationStats>) {
+        (
+            RwLock::new(DnsCache::new(1000, 0, 100_000)),
+            RwLock::new(SrttCache::new(false)),
+            Mutex::new(ValidationStats::default()),
+        )
+    }
+
+    /// A fully-signed delegation must validate — guards the fix against being
+    /// too strict and confirms the harness produces verifiable signatures.
+    #[tokio::test]
+    async fn properly_signed_delegation_validates() {
+        let (cache, srtt, stats) = empty_ctx();
+
+        let root_ksk = mk_signer(257);
+        let root_zsk = mk_signer(256);
+        let root_ksk_dk = mk_dnskey(".", &root_ksk);
+        let root_zsk_dk = mk_dnskey(".", &root_zsk);
+        let trust_anchors = vec![root_ksk_dk.clone()];
+
+        let root_set = vec![root_ksk_dk.clone(), root_zsk_dk.clone()];
+        let root_refs: Vec<&DnsRecord> = root_set.iter().collect();
+        let root_selfsig = mk_rrsig(&root_ksk, ".", QueryType::DNSKEY, &root_refs);
+        let mut root_answers = root_set.clone();
+        root_answers.push(root_selfsig);
+        cache
+            .write()
+            .unwrap()
+            .insert(".", QueryType::DNSKEY, &mk_pkt(root_answers));
+
+        let test_ksk = mk_signer(257);
+        let test_dk = mk_dnskey("test", &test_ksk);
+        let test_set = vec![test_dk.clone()];
+        let test_refs: Vec<&DnsRecord> = test_set.iter().collect();
+        let test_selfsig = mk_rrsig(&test_ksk, "test", QueryType::DNSKEY, &test_refs);
+        let test_records = vec![test_dk.clone(), test_selfsig];
+
+        // DS for "test", signed by the root ZSK — a legitimate delegation.
+        let ds = mk_ds("test", &test_dk);
+        let ds_set = vec![ds.clone()];
+        let ds_refs: Vec<&DnsRecord> = ds_set.iter().collect();
+        let ds_sig = mk_rrsig(&root_zsk, ".", QueryType::DS, &ds_refs);
+        cache
+            .write()
+            .unwrap()
+            .insert("test", QueryType::DS, &mk_pkt(vec![ds, ds_sig]));
+
+        let status = validate_chain(
+            "test",
+            &test_records,
+            &cache,
+            &[],
+            &srtt,
+            &trust_anchors,
+            0,
+            &stats,
+        )
+        .await;
+        assert_eq!(status, DnssecStatus::Secure);
+    }
+
+    /// A DS whose digest matches the child KSK but carries NO parent signature
+    /// must NOT validate — otherwise an on-path attacker forges any delegation.
+    #[tokio::test]
+    async fn unsigned_ds_must_not_validate() {
+        let (cache, srtt, stats) = empty_ctx();
+
+        let root_ksk = mk_signer(257);
+        let root_ksk_dk = mk_dnskey(".", &root_ksk);
+        let trust_anchors = vec![root_ksk_dk.clone()];
+        let root_set = vec![root_ksk_dk.clone()];
+        let root_refs: Vec<&DnsRecord> = root_set.iter().collect();
+        let root_selfsig = mk_rrsig(&root_ksk, ".", QueryType::DNSKEY, &root_refs);
+        cache.write().unwrap().insert(
+            ".",
+            QueryType::DNSKEY,
+            &mk_pkt(vec![root_ksk_dk.clone(), root_selfsig]),
+        );
+
+        // Attacker zone "test": own KSK, self-signed DNSKEY set.
+        let test_ksk = mk_signer(257);
+        let test_dk = mk_dnskey("test", &test_ksk);
+        let test_set = vec![test_dk.clone()];
+        let test_refs: Vec<&DnsRecord> = test_set.iter().collect();
+        let test_selfsig = mk_rrsig(&test_ksk, "test", QueryType::DNSKEY, &test_refs);
+        let test_records = vec![test_dk.clone(), test_selfsig];
+
+        // Forged DS — digest matches the attacker KSK, but UNSIGNED by root.
+        let forged_ds = mk_ds("test", &test_dk);
+        cache
+            .write()
+            .unwrap()
+            .insert("test", QueryType::DS, &mk_pkt(vec![forged_ds]));
+
+        let status = validate_chain(
+            "test",
+            &test_records,
+            &cache,
+            &[],
+            &srtt,
+            &trust_anchors,
+            0,
+            &stats,
+        )
+        .await;
+        assert_ne!(
+            status,
+            DnssecStatus::Secure,
+            "unsigned DS must not yield Secure — the parent must sign the DS RRset"
+        );
+    }
+
+    /// Mere presence of the trust-anchor KSK in the root DNSKEY set must not
+    /// yield Secure without a valid self-signature proving the KSK signed it.
+    #[tokio::test]
+    async fn root_anchor_without_self_signature_must_not_validate() {
+        let (cache, srtt, stats) = empty_ctx();
+        let root_ksk = mk_signer(257);
+        let root_ksk_dk = mk_dnskey(".", &root_ksk);
+        let trust_anchors = vec![root_ksk_dk.clone()];
+        let root_records = vec![root_ksk_dk.clone()]; // no RRSIG
+        let status = validate_chain(
+            ".",
+            &root_records,
+            &cache,
+            &[],
+            &srtt,
+            &trust_anchors,
+            0,
+            &stats,
+        )
+        .await;
+        assert_ne!(
+            status,
+            DnssecStatus::Secure,
+            "trust-anchor presence alone must not yield Secure"
+        );
+    }
 }

--- a/src/dnssec.rs
+++ b/src/dnssec.rs
@@ -423,15 +423,17 @@ fn validate_chain<'a>(
                     {
                         let ta_tag = compute_key_tag(*ta_flags, *ta_proto, *ta_algo, ta_key);
                         if tag == ta_tag && algorithm == ta_algo && public_key == ta_key {
-                            // Presence of the (public) anchor key is not enough:
-                            // require the DNSKEY RRset to be self-signed by it,
-                            // else a spoofed set carrying the anchor validates.
-                            if verify_dnskey_self_signed(zone_records) {
-                                debug!("dnssec: trust anchor match (self-signed) for '{}'", zone);
+                            // Signed by the anchor itself, not merely present.
+                            if verify_rrset_signed(
+                                zone_records,
+                                QueryType::DNSKEY,
+                                std::slice::from_ref(ta),
+                            ) {
+                                debug!("dnssec: root DNSKEY signed by trust anchor for '{}'", zone);
                                 return DnssecStatus::Secure;
                             }
                             debug!(
-                                "dnssec: trust anchor present but RRset not self-signed for '{}'",
+                                "dnssec: anchor present but RRset not signed by it: '{}'",
                                 zone
                             );
                             return DnssecStatus::Bogus;
@@ -461,28 +463,23 @@ fn validate_chain<'a>(
             return DnssecStatus::Insecure;
         }
 
-        // Verify DS matches a zone DNSKEY
-        let mut ds_matched = false;
-        for ds in &ds_records {
-            for dk in &zone_dnskeys {
-                if verify_ds(ds, dk, zone) {
-                    ds_matched = true;
-                    break;
-                }
-            }
-            if ds_matched {
-                break;
-            }
-        }
-
-        if !ds_matched {
+        // RFC 4035 §5.2: the RRset must be signed by the *same* KSK the DS
+        // commits to, so verify only against DS-matched keys (not any KSK).
+        let ds_authenticated_ksks: Vec<DnsRecord> = zone_dnskeys
+            .iter()
+            .copied()
+            .filter(|dk| ds_records.iter().any(|ds| verify_ds(ds, dk, zone)))
+            .cloned()
+            .collect();
+        if ds_authenticated_ksks.is_empty() {
             debug!("dnssec: DS digest mismatch for zone '{}'", zone);
             return DnssecStatus::Bogus;
         }
-
-        // Verify the DNSKEY RRset is self-signed by a KSK
-        if !verify_dnskey_self_signed(zone_records) {
-            debug!("dnssec: DNSKEY RRset not self-signed for zone '{}'", zone);
+        if !verify_rrset_signed(zone_records, QueryType::DNSKEY, &ds_authenticated_ksks) {
+            debug!(
+                "dnssec: DNSKEY RRset not signed by a DS-matched KSK: '{}'",
+                zone
+            );
             return DnssecStatus::Bogus;
         }
 
@@ -520,22 +517,11 @@ fn validate_chain<'a>(
     })
 }
 
-/// Verify the apex DNSKEY RRset is self-signed by a KSK (SEP, flags bit 0x0001)
-/// it contains — the key the parent's DS commits to.
-fn verify_dnskey_self_signed(records: &[DnsRecord]) -> bool {
-    let ksks: Vec<DnsRecord> = records
-        .iter()
-        .filter(|r| matches!(r, DnsRecord::DNSKEY { flags, .. } if *flags & 0x0101 == 0x0101))
-        .cloned()
-        .collect();
-    verify_rrset_signed(records, QueryType::DNSKEY, &ksks)
-}
-
 /// The signature-checking primitive: does the `rrset_type` RRset in `records`
 /// carry a time-valid RRSIG made by one of `signing_keys` (which the caller must
-/// already trust)? Signers may be ZSKs (e.g. a parent signing a child's DS),
-/// not only KSKs — `verify_dnskey_self_signed` is this restricted to the set's
-/// own KSKs.
+/// already trust)? Callers pass the specific authenticated key(s) — the trust
+/// anchor for the root DNSKEY, or the DS-matched KSKs for a child — so a signer
+/// the chain never committed to cannot satisfy the check.
 fn verify_rrset_signed(
     records: &[DnsRecord],
     rrset_type: QueryType,
@@ -1862,12 +1848,9 @@ mod tests {
         assert!(base32hex_decode("!!").is_none());
     }
 
-    // --- Chain-of-trust authentication (issue #235 follow-up) ---
-    // An attacker who can tamper with a delegation's DS response must not be
-    // able to forge a Secure verdict. These tests mint throwaway ECDSA P-256
-    // (algo 13) keys so a self-consistent chain can be built end to end, with a
-    // test KSK standing in for the root trust anchor (the real root's private
-    // key is, by design, unforgeable).
+    // Chain-of-trust authentication (issue #235). These tests mint throwaway
+    // ECDSA P-256 (algo 13) keys and use a test KSK as the root trust anchor —
+    // the real root's private key is, by design, unforgeable.
     use ring::rand::SystemRandom;
     use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 
@@ -1970,8 +1953,7 @@ mod tests {
         )
     }
 
-    /// A fully-signed delegation must validate — guards the fix against being
-    /// too strict and confirms the harness produces verifiable signatures.
+    // Positive control: a fully-signed delegation must stay Secure.
     #[tokio::test]
     async fn properly_signed_delegation_validates() {
         let (cache, srtt, stats) = empty_ctx();
@@ -2023,8 +2005,6 @@ mod tests {
         assert_eq!(status, DnssecStatus::Secure);
     }
 
-    /// A DS whose digest matches the child KSK but carries NO parent signature
-    /// must NOT validate — otherwise an on-path attacker forges any delegation.
     #[tokio::test]
     async fn unsigned_ds_must_not_validate() {
         let (cache, srtt, stats) = empty_ctx();
@@ -2074,8 +2054,6 @@ mod tests {
         );
     }
 
-    /// Mere presence of the trust-anchor KSK in the root DNSKEY set must not
-    /// yield Secure without a valid self-signature proving the KSK signed it.
     #[tokio::test]
     async fn root_anchor_without_self_signature_must_not_validate() {
         let (cache, srtt, stats) = empty_ctx();
@@ -2098,6 +2076,99 @@ mod tests {
             status,
             DnssecStatus::Secure,
             "trust-anchor presence alone must not yield Secure"
+        );
+    }
+
+    #[tokio::test]
+    async fn root_with_forged_ksk_must_not_validate() {
+        let (cache, srtt, stats) = empty_ctx();
+        let anchor = mk_signer(257);
+        let anchor_dk = mk_dnskey(".", &anchor);
+        let trust_anchors = [anchor_dk.clone()];
+
+        // Set carries the (public) anchor key + an attacker KSK; signed by the
+        // attacker KSK, which the attacker controls — never by the anchor.
+        let attacker = mk_signer(257);
+        let attacker_dk = mk_dnskey(".", &attacker);
+        let root_set = vec![anchor_dk.clone(), attacker_dk.clone()];
+        let root_refs: Vec<&DnsRecord> = root_set.iter().collect();
+        let forged = mk_rrsig(&attacker, ".", QueryType::DNSKEY, &root_refs);
+        let mut root_records = root_set.clone();
+        root_records.push(forged);
+
+        let status = validate_chain(
+            ".",
+            &root_records,
+            &cache,
+            &[],
+            &srtt,
+            &trust_anchors,
+            0,
+            &stats,
+        )
+        .await;
+        assert_ne!(
+            status,
+            DnssecStatus::Secure,
+            "root set signed by a non-anchor KSK must not validate"
+        );
+    }
+
+    #[tokio::test]
+    async fn child_with_forged_ksk_must_not_validate() {
+        let (cache, srtt, stats) = empty_ctx();
+
+        let root_ksk = mk_signer(257);
+        let root_dk = mk_dnskey(".", &root_ksk);
+        let trust_anchors = [root_dk.clone()];
+        let root_set = [root_dk.clone()];
+        let root_refs: Vec<&DnsRecord> = root_set.iter().collect();
+        let root_selfsig = mk_rrsig(&root_ksk, ".", QueryType::DNSKEY, &root_refs);
+        cache.write().unwrap().insert(
+            ".",
+            QueryType::DNSKEY,
+            &mk_pkt(vec![root_dk.clone(), root_selfsig]),
+        );
+
+        // Real child KSK — the genuine DS commits to it.
+        let real_ksk = mk_signer(257);
+        let real_dk = mk_dnskey("test", &real_ksk);
+
+        // Attacker's child set: real (public) KSK to satisfy the DS digest, plus
+        // an attacker KSK that actually signs the set.
+        let attacker = mk_signer(257);
+        let attacker_dk = mk_dnskey("test", &attacker);
+        let child_set = vec![real_dk.clone(), attacker_dk.clone()];
+        let child_refs: Vec<&DnsRecord> = child_set.iter().collect();
+        let forged = mk_rrsig(&attacker, "test", QueryType::DNSKEY, &child_refs);
+        let mut child_records = child_set.clone();
+        child_records.push(forged);
+
+        // Genuine DS (digest of the REAL KSK), signed by the root.
+        let ds = mk_ds("test", &real_dk);
+        let ds_set = [ds.clone()];
+        let ds_refs: Vec<&DnsRecord> = ds_set.iter().collect();
+        let ds_sig = mk_rrsig(&root_ksk, ".", QueryType::DS, &ds_refs);
+        cache
+            .write()
+            .unwrap()
+            .insert("test", QueryType::DS, &mk_pkt(vec![ds, ds_sig]));
+
+        let status = validate_chain(
+            "test",
+            &child_records,
+            &cache,
+            &[],
+            &srtt,
+            &trust_anchors,
+            0,
+            &stats,
+        )
+        .await;
+        assert_ne!(
+            status,
+            DnssecStatus::Secure,
+            "child set signed by a KSK the DS does not commit to must not validate"
         );
     }
 }

--- a/src/dnssec.rs
+++ b/src/dnssec.rs
@@ -423,8 +423,18 @@ fn validate_chain<'a>(
                     {
                         let ta_tag = compute_key_tag(*ta_flags, *ta_proto, *ta_algo, ta_key);
                         if tag == ta_tag && algorithm == ta_algo && public_key == ta_key {
-                            debug!("dnssec: trust anchor match for zone '{}'", zone);
-                            return DnssecStatus::Secure;
+                            // Presence of the (public) anchor key is not enough:
+                            // require the DNSKEY RRset to be self-signed by it,
+                            // else a spoofed set carrying the anchor validates.
+                            if verify_dnskey_self_signed(zone_records) {
+                                debug!("dnssec: trust anchor match (self-signed) for '{}'", zone);
+                                return DnssecStatus::Secure;
+                            }
+                            debug!(
+                                "dnssec: trust anchor present but RRset not self-signed for '{}'",
+                                zone
+                            );
+                            return DnssecStatus::Bogus;
                         }
                     }
                 }
@@ -440,7 +450,11 @@ fn validate_chain<'a>(
             return DnssecStatus::Indeterminate;
         }
         let parent = parent_zone(zone);
-        let ds_records = fetch_ds(zone, cache, root_hints, srtt, stats).await;
+        let ds_response = fetch_ds(zone, cache, root_hints, srtt, stats).await;
+        let ds_records: Vec<&DnsRecord> = ds_response
+            .iter()
+            .filter(|r| matches!(r, DnsRecord::DS { .. }))
+            .collect();
 
         if ds_records.is_empty() {
             debug!("dnssec: no DS for zone '{}' at parent '{}'", zone, parent);
@@ -480,7 +494,7 @@ fn validate_chain<'a>(
             return DnssecStatus::Indeterminate;
         }
 
-        validate_chain(
+        let parent_status = validate_chain(
             &parent,
             &parent_records,
             cache,
@@ -490,33 +504,69 @@ fn validate_chain<'a>(
             depth + 1,
             stats,
         )
-        .await
+        .await;
+        if parent_status != DnssecStatus::Secure {
+            return parent_status;
+        }
+
+        // The DS RRset must itself be signed by the (now-validated) parent.
+        // A digest match alone lets a forged DS endorse an attacker's KSK.
+        if !verify_rrset_signed(&ds_response, QueryType::DS, &parent_records) {
+            debug!("dnssec: DS RRset for '{}' not signed by parent", zone);
+            return DnssecStatus::Bogus;
+        }
+
+        DnssecStatus::Secure
     })
 }
 
-/// Verify that the DNSKEY RRset is signed by a KSK within the set.
+/// Verify the apex DNSKEY RRset is self-signed by a KSK (SEP, flags bit 0x0001)
+/// it contains — the key the parent's DS commits to.
 fn verify_dnskey_self_signed(records: &[DnsRecord]) -> bool {
-    let dnskeys: Vec<&DnsRecord> = records
+    let ksks: Vec<DnsRecord> = records
         .iter()
-        .filter(|r| matches!(r, DnsRecord::DNSKEY { .. }))
+        .filter(|r| matches!(r, DnsRecord::DNSKEY { flags, .. } if *flags & 0x0101 == 0x0101))
+        .cloned()
         .collect();
+    verify_rrset_signed(records, QueryType::DNSKEY, &ksks)
+}
 
-    // Find RRSIG covering DNSKEY type
+/// The signature-checking primitive: does the `rrset_type` RRset in `records`
+/// carry a time-valid RRSIG made by one of `signing_keys` (which the caller must
+/// already trust)? Signers may be ZSKs (e.g. a parent signing a child's DS),
+/// not only KSKs — `verify_dnskey_self_signed` is this restricted to the set's
+/// own KSKs.
+fn verify_rrset_signed(
+    records: &[DnsRecord],
+    rrset_type: QueryType,
+    signing_keys: &[DnsRecord],
+) -> bool {
+    let rrset: Vec<&DnsRecord> = records
+        .iter()
+        .filter(|r| r.query_type() == rrset_type)
+        .collect();
+    if rrset.is_empty() {
+        return false;
+    }
+
     for r in records {
         if let DnsRecord::RRSIG {
             type_covered,
             algorithm,
             key_tag,
+            expiration,
+            inception,
             signature,
             ..
         } = r
         {
-            if QueryType::from_num(*type_covered) != QueryType::DNSKEY {
+            if QueryType::from_num(*type_covered) != rrset_type {
                 continue;
             }
-
-            // Find the KSK that made this signature
-            for dk in &dnskeys {
+            if !is_rrsig_time_valid(*expiration, *inception) {
+                continue;
+            }
+            for dk in signing_keys {
                 if let DnsRecord::DNSKEY {
                     flags,
                     protocol,
@@ -525,28 +575,20 @@ fn verify_dnskey_self_signed(records: &[DnsRecord]) -> bool {
                     ..
                 } = dk
                 {
-                    if *flags & 0x0101 != 0x0101 {
-                        continue; // Not a KSK
-                    }
                     if dk_algo != algorithm {
                         continue;
                     }
-                    let tag = compute_key_tag(*flags, *protocol, *dk_algo, public_key);
-                    if tag != *key_tag {
+                    if compute_key_tag(*flags, *protocol, *dk_algo, public_key) != *key_tag {
                         continue;
                     }
-
-                    // Verify: RRSIG(DNSKEY) signed by this KSK
-                    let signed_data = build_signed_data(r, &dnskeys);
+                    let signed_data = build_signed_data(r, &rrset);
                     if verify_signature(*algorithm, public_key, &signed_data, signature) {
-                        trace!("dnssec: DNSKEY RRset self-signed by KSK tag={}", tag);
                         return true;
                     }
                 }
             }
         }
     }
-
     false
 }
 
@@ -591,13 +633,11 @@ async fn fetch_ds(
     srtt: &RwLock<SrttCache>,
     stats: &Mutex<ValidationStats>,
 ) -> Vec<DnsRecord> {
+    // Returns the full answer set (DS records *and* their RRSIGs); the caller
+    // both digest-matches the DS and verifies the parent's signature over it.
     if let Some(pkt) = cache.read().unwrap().lookup(child, QueryType::DS) {
         stats.lock().unwrap().ds_cache_hits += 1;
-        return pkt
-            .answers
-            .into_iter()
-            .filter(|r| matches!(r, DnsRecord::DS { .. }))
-            .collect();
+        return pkt.answers;
     }
 
     stats.lock().unwrap().ds_fetches += 1;
@@ -606,11 +646,7 @@ async fn fetch_ds(
             .await
     {
         cache.write().unwrap().insert(child, QueryType::DS, &pkt);
-        return pkt
-            .answers
-            .into_iter()
-            .filter(|r| matches!(r, DnsRecord::DS { .. }))
-            .collect();
+        return pkt.answers;
     }
 
     Vec::new()
@@ -1958,14 +1994,14 @@ mod tests {
 
         let test_ksk = mk_signer(257);
         let test_dk = mk_dnskey("test", &test_ksk);
-        let test_set = vec![test_dk.clone()];
+        let test_set = [test_dk.clone()];
         let test_refs: Vec<&DnsRecord> = test_set.iter().collect();
         let test_selfsig = mk_rrsig(&test_ksk, "test", QueryType::DNSKEY, &test_refs);
         let test_records = vec![test_dk.clone(), test_selfsig];
 
         // DS for "test", signed by the root ZSK — a legitimate delegation.
         let ds = mk_ds("test", &test_dk);
-        let ds_set = vec![ds.clone()];
+        let ds_set = [ds.clone()];
         let ds_refs: Vec<&DnsRecord> = ds_set.iter().collect();
         let ds_sig = mk_rrsig(&root_zsk, ".", QueryType::DS, &ds_refs);
         cache
@@ -1996,7 +2032,7 @@ mod tests {
         let root_ksk = mk_signer(257);
         let root_ksk_dk = mk_dnskey(".", &root_ksk);
         let trust_anchors = vec![root_ksk_dk.clone()];
-        let root_set = vec![root_ksk_dk.clone()];
+        let root_set = [root_ksk_dk.clone()];
         let root_refs: Vec<&DnsRecord> = root_set.iter().collect();
         let root_selfsig = mk_rrsig(&root_ksk, ".", QueryType::DNSKEY, &root_refs);
         cache.write().unwrap().insert(
@@ -2008,7 +2044,7 @@ mod tests {
         // Attacker zone "test": own KSK, self-signed DNSKEY set.
         let test_ksk = mk_signer(257);
         let test_dk = mk_dnskey("test", &test_ksk);
-        let test_set = vec![test_dk.clone()];
+        let test_set = [test_dk.clone()];
         let test_refs: Vec<&DnsRecord> = test_set.iter().collect();
         let test_selfsig = mk_rrsig(&test_ksk, "test", QueryType::DNSKEY, &test_refs);
         let test_records = vec![test_dk.clone(), test_selfsig];

--- a/src/dnssec.rs
+++ b/src/dnssec.rs
@@ -278,71 +278,7 @@ async fn try_verify_with_key(
     dnskey_response: &[DnsRecord],
     ctx: &ValidationCtx<'_>,
 ) -> KeyOutcome {
-    let DnsRecord::DNSKEY {
-        flags,
-        protocol,
-        algorithm: dk_algo,
-        public_key,
-        ..
-    } = dk
-    else {
-        return KeyOutcome::Skip;
-    };
-    let DnsRecord::RRSIG {
-        algorithm,
-        key_tag,
-        expiration,
-        inception,
-        signature,
-        ..
-    } = rrsig
-    else {
-        return KeyOutcome::Skip;
-    };
-
-    let tag = compute_key_tag(*flags, *protocol, *dk_algo, public_key);
-    if *dk_algo != *algorithm {
-        trace!(
-            "dnssec:   DNSKEY tag={} algo={} — algo mismatch (want {})",
-            tag,
-            dk_algo,
-            algorithm
-        );
-        return KeyOutcome::Skip;
-    }
-    if tag != *key_tag {
-        trace!(
-            "dnssec:   DNSKEY tag={} — tag mismatch (want {})",
-            tag,
-            key_tag
-        );
-        return KeyOutcome::Skip;
-    }
-    if !is_rrsig_time_valid(*expiration, *inception) {
-        trace!(
-            "dnssec:   RRSIG expired or not yet valid (inception={} expiration={})",
-            inception,
-            expiration
-        );
-        return KeyOutcome::Skip;
-    }
-
-    trace!(
-        "dnssec:   DNSKEY tag={} algo={} flags={} — matched, verifying signature ({} bytes)",
-        tag,
-        dk_algo,
-        flags,
-        public_key.len()
-    );
-    let signed_data = build_signed_data(rrsig, rrset);
-    let ok = verify_signature(*algorithm, public_key, &signed_data, signature);
-    trace!(
-        "dnssec:   verify result: {} (signed_data={} bytes, sig={} bytes)",
-        ok,
-        signed_data.len(),
-        signature.len()
-    );
-    if !ok {
+    if !rrsig_verified_by(rrsig, dk, rrset) {
         return KeyOutcome::Skip;
     }
 
@@ -398,49 +334,23 @@ fn validate_chain<'a>(
             return DnssecStatus::Indeterminate;
         }
 
-        // Check if any zone DNSKEY matches a trust anchor
-        for dk in &zone_dnskeys {
-            if let DnsRecord::DNSKEY {
-                flags,
-                protocol,
-                algorithm,
-                public_key,
-                ..
-            } = dk
-            {
-                if *flags & 0x0101 != 0x0101 {
-                    continue;
-                }
-                let tag = compute_key_tag(*flags, *protocol, *algorithm, public_key);
-                for ta in trust_anchors {
-                    if let DnsRecord::DNSKEY {
-                        algorithm: ta_algo,
-                        public_key: ta_key,
-                        flags: ta_flags,
-                        protocol: ta_proto,
-                        ..
-                    } = ta
-                    {
-                        let ta_tag = compute_key_tag(*ta_flags, *ta_proto, *ta_algo, ta_key);
-                        if tag == ta_tag && algorithm == ta_algo && public_key == ta_key {
-                            // Signed by the anchor itself, not merely present.
-                            if verify_rrset_signed(
-                                zone_records,
-                                QueryType::DNSKEY,
-                                std::slice::from_ref(ta),
-                            ) {
-                                debug!("dnssec: root DNSKEY signed by trust anchor for '{}'", zone);
-                                return DnssecStatus::Secure;
-                            }
-                            debug!(
-                                "dnssec: anchor present but RRset not signed by it: '{}'",
-                                zone
-                            );
-                            return DnssecStatus::Bogus;
-                        }
-                    }
-                }
-            }
+        // Root base case: a trust anchor must be present *and* have signed the
+        // DNSKEY RRset. Present-but-unsigned is an attack signal → Bogus (fail
+        // closed), not a fall-through to the Indeterminate KSK-rollover path.
+        let anchor_present = zone_dnskeys
+            .iter()
+            .any(|dk| trust_anchors.iter().any(|ta| same_dnskey(dk, ta)));
+        if anchor_present {
+            return if verify_rrset_signed(zone_records, QueryType::DNSKEY, trust_anchors) {
+                debug!("dnssec: root DNSKEY signed by trust anchor for '{}'", zone);
+                DnssecStatus::Secure
+            } else {
+                debug!(
+                    "dnssec: anchor present but RRset not signed by it: '{}'",
+                    zone
+                );
+                DnssecStatus::Bogus
+            };
         }
 
         // Not a trust anchor — need to verify via parent DS
@@ -517,11 +427,58 @@ fn validate_chain<'a>(
     })
 }
 
-/// The signature-checking primitive: does the `rrset_type` RRset in `records`
-/// carry a time-valid RRSIG made by one of `signing_keys` (which the caller must
-/// already trust)? Callers pass the specific authenticated key(s) — the trust
-/// anchor for the root DNSKEY, or the DS-matched KSKs for a child — so a signer
-/// the chain never committed to cannot satisfy the check.
+/// Same DNSKEY identity (algorithm + public key); flags/protocol are not part
+/// of key identity, so a tag comparison would be redundant.
+fn same_dnskey(a: &DnsRecord, b: &DnsRecord) -> bool {
+    matches!(
+        (a, b),
+        (
+            DnsRecord::DNSKEY { algorithm: aa, public_key: ak, .. },
+            DnsRecord::DNSKEY { algorithm: ba, public_key: bk, .. },
+        ) if aa == ba && ak == bk
+    )
+}
+
+/// The chain's single signature gate: does `dk` make a time-valid RRSIG `rrsig`
+/// over `rrset`? Matches algorithm + key tag, checks validity window, then
+/// verifies the signature over the canonical RRset bytes.
+fn rrsig_verified_by(rrsig: &DnsRecord, dk: &DnsRecord, rrset: &[&DnsRecord]) -> bool {
+    let (
+        DnsRecord::RRSIG {
+            algorithm,
+            key_tag,
+            expiration,
+            inception,
+            signature,
+            ..
+        },
+        DnsRecord::DNSKEY {
+            flags,
+            protocol,
+            algorithm: dk_algo,
+            public_key,
+            ..
+        },
+    ) = (rrsig, dk)
+    else {
+        return false;
+    };
+    dk_algo == algorithm
+        && compute_key_tag(*flags, *protocol, *dk_algo, public_key) == *key_tag
+        && is_rrsig_time_valid(*expiration, *inception)
+        && verify_signature(
+            *algorithm,
+            public_key,
+            &build_signed_data(rrsig, rrset),
+            signature,
+        )
+}
+
+/// Does the `rrset_type` RRset in `records` carry an RRSIG made by one of
+/// `signing_keys` (which the caller must already trust)? Callers pass the
+/// specific authenticated key(s) — the trust anchor for the root DNSKEY, or the
+/// DS-matched KSKs for a child — so a signer the chain never committed to cannot
+/// satisfy the check.
 fn verify_rrset_signed(
     records: &[DnsRecord],
     rrset_type: QueryType,
@@ -534,48 +491,13 @@ fn verify_rrset_signed(
     if rrset.is_empty() {
         return false;
     }
-
-    for r in records {
-        if let DnsRecord::RRSIG {
-            type_covered,
-            algorithm,
-            key_tag,
-            expiration,
-            inception,
-            signature,
-            ..
-        } = r
-        {
-            if QueryType::from_num(*type_covered) != rrset_type {
-                continue;
-            }
-            if !is_rrsig_time_valid(*expiration, *inception) {
-                continue;
-            }
-            for dk in signing_keys {
-                if let DnsRecord::DNSKEY {
-                    flags,
-                    protocol,
-                    algorithm: dk_algo,
-                    public_key,
-                    ..
-                } = dk
-                {
-                    if dk_algo != algorithm {
-                        continue;
-                    }
-                    if compute_key_tag(*flags, *protocol, *dk_algo, public_key) != *key_tag {
-                        continue;
-                    }
-                    let signed_data = build_signed_data(r, &rrset);
-                    if verify_signature(*algorithm, public_key, &signed_data, signature) {
-                        return true;
-                    }
-                }
-            }
-        }
-    }
-    false
+    records.iter().any(|r| {
+        matches!(r, DnsRecord::RRSIG { type_covered, .. }
+            if QueryType::from_num(*type_covered) == rrset_type)
+            && signing_keys
+                .iter()
+                .any(|dk| rrsig_verified_by(r, dk, &rrset))
+    })
 }
 
 // -- Fetching helpers --


### PR DESCRIPTION
## Summary

While addressing the hardcoded root KSK (#235), a deeper validation gap surfaced: `validate_chain` could return **Secure** for a chain that was never actually authenticated.

Two missing checks:

1. **DS RRsets were trusted on a digest match alone.** `fetch_ds` returned only DS records (RRSIGs filtered out) and `validate_chain` only ran `verify_ds` (digest matches the child KSK) — it never verified the **parent's signature over the DS RRset**.
2. **The root base case returned Secure on mere presence** of the trust-anchor KSK in the fetched DNSKEY set, without verifying that set was self-signed by it.

### Impact

An attacker able to tamper with a delegation's DS response — on-path to the authoritatives, or by poisoning Numa's cache — could mint their own KSK/ZSK for a target zone, self-sign its DNSKEY RRset, and inject a forged DS whose digest matches their key. With neither the DS RRSIG nor the root self-signature checked, the forged chain validated as `Secure`. That defeats DNSSEC for precisely the spoofing case it exists to prevent. (Resolution itself still worked; this is a silent loss of the integrity guarantee, not an outage.)

This is **pre-existing** behaviour, independent of the KSK rollover work.

## Fix

- **DS authentication:** after the parent chain validates to `Secure`, require the DS RRset to carry a time-valid RRSIG made by a parent DNSKEY (new `verify_rrset_signed` helper, generalising `verify_dnskey_self_signed` to non-KSK signers). `fetch_ds` now returns RRSIGs alongside DS records.
- **Root self-signature:** require the root DNSKEY RRset to be self-signed by the matched trust anchor, not just present.

## How it's verified

The first commit adds regression tests that **fail against the current validator** (exposing the bug); the fix commit flips them green:

- `unsigned_ds_must_not_validate` — forged unsigned DS → must not be `Secure`
- `root_anchor_without_self_signature_must_not_validate` — anchor presence alone → must not be `Secure`
- `properly_signed_delegation_validates` — fully-signed root→TLD delegation (throwaway ECDSA P-256 keys) → still `Secure` (positive control, guards against over-strictness)

Full lib suite (488 tests) + `cargo clippy -- -D warnings` + `cargo fmt --check` all pass.

The two commits are kept separate (red → green) to document the finding; squash-merge if preferred.

Refs #235.