### PR TITLE
fix(nix): vendor crates via cargoHash to fix nix-build 403

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779877693,
+        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   description = "Portable DNS resolver in Rust";
 
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = {

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
                 pname = "numa";
                 version = (lib.importTOML ./Cargo.toml).package.version;
                 src = ./.;
-                cargoLock = {lockFile = ./Cargo.lock;};
+                cargoHash = "sha256-yJdSDSi7qSdJG1f74/DCoEUV8TyaRJQ2hwT5wWSkPtg=";
                 meta = {
                   description = "Portable DNS resolver in Rust";
                   homepage = "https://numa.rs";


### PR DESCRIPTION
## Summary
- The `nix-build` CI job died fetching crate sources with `curl: (22) ... 403 → cannot download from any mirror` (first `psl 2.1.206`, then `proxy-header 0.1.2`).
- Root cause: with `cargoLock = { lockFile = ./Cargo.lock; }`, nixpkgs' `importCargoLock` fetches each crate via `fetchurl` from `https://crates.io/api/v1/crates/{name}/{version}/download`. crates.io now **403s that endpoint for non-cargo User-Agents** (reproduced: `curl`-UA → 403, `cargo`-UA → 302; even `serde 1.0.0` 403s). It only worked while every crate was mirrored on `cache.nixos.org`; recently-added crates (`psl`, `proxy-header`) weren't mirrored yet, so Nix fetched them live and got blocked. Any future uncached crate would fail identically.
- nixpkgs has fixed this on **master** (`f830e611`, switch to `static.crates.io`), but it is not in the `nixpkgs-unstable` channel yet, and pinning bleeding-edge master risks cache-miss rebuilds of the toolchain.
- Fix: switch from `cargoLock.lockFile` to `cargoHash`, so vendoring runs through **cargo itself** (sparse index + `static.crates.io`, cargo's own User-Agent) instead of per-crate `fetchurl` against the 403-ing api endpoint. Version-independent — works on the pinned, well-cached nixpkgs.
- Also declares `inputs.nixpkgs.url` explicitly (deterministic; clears the "registry in flake inputs is deprecated" warning; prevents local Determinate Nix from relocking to FlakeHub).

## Test plan
- [x] `nix build .#numa` succeeds locally — vendor FOD downloads via cargo with no 403; release build + bundled tests green (488 + 2 + 1 passed)
- [x] `make all` (fmt + clippy -D warnings + cargo audit + cargo test) passes
- [ ] CI `nix-build` job goes green