### PR TITLE
fix(install): write annotated numa.toml on install so config is discoverable (#244)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Set as system DNS:
 | Linux | `sudo numa install` | `sudo numa uninstall` |
 | Windows | `numa install` (admin) + reboot | `numa uninstall` (admin) + reboot |
 
-On macOS and Linux, numa runs as a system service (launchd/systemd). On Windows, numa auto-starts on login via registry.
+On macOS and Linux, numa runs as a system service (launchd/systemd). On Windows, numa auto-starts on login via registry. Windows also binds `127.0.0.2:53` (the built-in Dnscache owns `127.0.0.1:53`) and installs an NRPT rule to route queries to it — so edit `bind_addr`/`api_bind_addr` against `127.0.0.2`, not `127.0.0.1`.
 
 ## Local Services
 

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -6,6 +6,24 @@ use log::info;
 use crate::forward::Upstream;
 use crate::forward::UpstreamPool;
 
+// Unix only: the reference config binds `0.0.0.0:53`, wrong for Windows
+// where numa lives on the `127.0.0.2:53` loopback behind an NRPT rule.
+#[cfg(not(windows))]
+const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("../numa.toml");
+
+/// `Ok(true)` if written, `Ok(false)` if a config was already there.
+#[cfg(not(windows))]
+fn write_default_config(path: &std::path::Path) -> std::io::Result<bool> {
+    if path.exists() {
+        return Ok(false);
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, DEFAULT_CONFIG_TEMPLATE)?;
+    Ok(true)
+}
+
 fn print_recursive_hint() {
     let is_recursive = crate::config::load_config("numa.toml")
         .map(|c| c.config.upstream.mode == crate::config::UpstreamMode::Recursive)
@@ -1140,6 +1158,21 @@ pub fn install_service(skip_system_dns: bool) -> Result<(), String> {
     };
 
     if result.is_ok() {
+        #[cfg(not(windows))]
+        {
+            // data_dir(), not config_dir(): under sudo the latter resolves to
+            // the calling user's home, but the daemon reads the system path.
+            let config_path = crate::data_dir().join("numa.toml");
+            match write_default_config(&config_path) {
+                Ok(true) => eprintln!("  Wrote default config: {}", config_path.display()),
+                Ok(false) => {}
+                Err(e) => eprintln!(
+                    "  warning: could not write {}: {}",
+                    config_path.display(),
+                    e
+                ),
+            }
+        }
         if let Err(e) = trust_ca() {
             eprintln!("  warning: could not trust CA: {}", e);
             eprintln!("  HTTPS proxy will work but browsers will show certificate warnings.\n");
@@ -2110,6 +2143,43 @@ mod tests {
     fn try_port53_advisory_skips_malformed_bind_addr() {
         let err = std::io::Error::from(std::io::ErrorKind::AddrInUse);
         assert!(try_port53_advisory("not-an-address", &err).is_none());
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn config_template_parses_as_config() {
+        let _: crate::config::Config = toml::from_str(DEFAULT_CONFIG_TEMPLATE)
+            .expect("embedded numa.toml template must parse as a valid Config");
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn write_default_config_creates_when_absent() {
+        let dir = std::env::temp_dir().join(format!("numa-tmpl-new-{}", std::process::id()));
+        let path = dir.join("numa.toml");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(write_default_config(&path).unwrap());
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            DEFAULT_CONFIG_TEMPLATE
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn write_default_config_never_clobbers() {
+        let dir = std::env::temp_dir().join(format!("numa-tmpl-keep-{}", std::process::id()));
+        let path = dir.join("numa.toml");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(&path, "# user config\n").unwrap();
+
+        assert!(!write_default_config(&path).unwrap());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "# user config\n");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Reported in #244: a fresh `sudo numa install` leaves **no config file on disk** — the daemon runs purely on `Config::default()`. When a user wants to change a setting (e.g. open the dashboard to the LAN via `api_bind_addr = "0.0.0.0"`), there is:

- no file to edit,
- no discoverable list of available knobs,
- nothing at `/var/lib/numa/numa.toml` — the very path our own troubleshooting advice points at.

The reporter confirmed *"No such file exists in that location"* and only resolved it by hand-authoring `numa.toml` from scratch.

## Fix

On `install`, write the project's annotated reference `numa.toml` (the one README links to as the configuration reference) to the **daemon-read path** — `data_dir()/numa.toml` (`/var/lib/numa` on Linux, `/usr/local/var/numa` on macOS) — **if and only if** no config already exists. Never clobbers user config.

- Zero duplication: embeds the existing maintained `numa.toml` via `include_str!`, so the shipped template can't drift from the documented reference.
- The template is all-defaults-commented, so behaviour on first run is unchanged — it just gives users a documented file to edit, with `api_bind_addr` (the exact knob this issue needed) explained inline.
- **Scoped to Unix.** The template's `bind_addr = "0.0.0.0:53"` is the Unix default but wrong for Windows, where numa binds `127.0.0.2:53` behind an NRPT rule — so Windows is excluded.