### PR TITLE
fix(nix): refresh v0.20.0 vendor hash + automate it in release.sh

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
                 pname = "numa";
                 version = (lib.importTOML ./Cargo.toml).package.version;
                 src = ./.;
-                cargoHash = "sha256-yJdSDSi7qSdJG1f74/DCoEUV8TyaRJQ2hwT5wWSkPtg=";
+                cargoHash = "sha256-svTcUocOSHNmXcPQaBusOSh3oVb2kRbPS9Hy4XdVpv4=";
                 meta = {
                   description = "Portable DNS resolver in Rust";
                   homepage = "https://numa.rs";

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -33,8 +33,30 @@ sed -i.bak "s/^version = \"$CURRENT\"/version = \"$VERSION\"/" Cargo.toml
 rm -f Cargo.toml.bak
 cargo update --workspace
 
+# Refresh the Nix vendor hash. cargo update shifts the vendored crate set, so a
+# stale flake.nix cargoHash fails the nix-build CI job (deps are fetched via
+# cargoHash, not the lockfile — see #252). Recompute via the fake-hash dance.
+if command -v nix >/dev/null 2>&1; then
+  echo "Refreshing flake.nix cargoHash"
+  FAKE="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  sed -i.bak "s|cargoHash = \"sha256-[^\"]*\";|cargoHash = \"$FAKE\";|" flake.nix
+  rm -f flake.nix.bak
+  NEW_HASH=$(nix build .#numa --no-link 2>&1 \
+    | sed -n 's/.*got:[[:space:]]*\(sha256-[A-Za-z0-9+/=]*\).*/\1/p' | tail -1 || true)
+  if [ -z "$NEW_HASH" ]; then
+    echo "ERROR: could not compute cargoHash from nix build" >&2
+    git checkout -- flake.nix
+    exit 1
+  fi
+  sed -i.bak "s|cargoHash = \"$FAKE\";|cargoHash = \"$NEW_HASH\";|" flake.nix
+  rm -f flake.nix.bak
+  echo "  cargoHash -> $NEW_HASH"
+else
+  echo "WARNING: nix not found — flake.nix cargoHash NOT refreshed; nix-build CI will fail until it is updated by hand." >&2
+fi
+
 # Commit, tag, push
-git add Cargo.toml Cargo.lock
+git add Cargo.toml Cargo.lock flake.nix
 git commit -m "chore: bump version to $VERSION"
 git tag "$TAG"
 git push origin main "$TAG"


### PR DESCRIPTION
## Summary

The v0.20.0 bump (#258) shifted the vendored crate set, so `flake.nix` was left pinning a stale `cargoHash`. The `nix-build` CI job failed on the fixed-output-derivation hash mismatch — **the only red**; all other platforms (macOS/Windows/FreeBSD/Linux), both integration suites, and the **Release** workflow (binaries + crates.io) were green.

- **flake.nix** — `cargoHash → sha256-svTcUocOSHNmXcPQaBusOSh3oVb2kRbPS9Hy4XdVpv4=`. Verified by a full `nix build .` on macOS (exit 0, produced `numa-0.20.0`).
- **scripts/release.sh** — recompute the hash automatically after `cargo update` via the fake-hash dance, so this stops recurring on every bump. Gated on `nix` being present; absent → loud warning, release still proceeds.

Reverting to `cargoLock.lockFile` is **not** an option — it 403s on the crates.io download endpoint for non-cargo User-Agents (the reason #252 moved to `cargoHash`).

## Note on the v0.20.0 tag

The `v0.20.0` tag itself stays as-is (immutable; crates.io/binaries already published). This fixes `main` and every release from v0.20.1 onward. `nix build github:razvandimescu/numa/v0.20.0` remains broken; flake users tracking `main` are fine.

## Test plan

- [x] `nix build .` full compile succeeds (exit 0)
- [x] release.sh refresh pipeline validated end-to-end on BSD sed — recovers the correct hash
- [x] `make all` (fmt + clippy -D warnings + audit + 502 tests) green