### PR TITLE
fix(windows): static CRT so numa.exe runs without VC++ Redistributable (#236)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
## Summary
- Add `.cargo/config.toml` enabling `+crt-static` for the `x86_64-pc-windows-msvc` target only — leaves Linux/macOS builds untouched.
- Fixes #236: the released `numa.exe` dynamically links the MSVC CRT and imports `VCRUNTIME140.dll`, which is **not** present on a clean Windows install (it ships with the VC++ Redistributable). The loader fails to resolve imports before `main()`, so every invocation exits silently with `0xC0000135` (STATUS_DLL_NOT_FOUND) — `numa install` appears to succeed but registers nothing.
- Static linking removes the runtime dependency at the cost of ~200 KB. Appropriate for a single-exe distribution.

## Root cause (verified)
`strings numa.exe` on the shipped v0.20.0 release shows the offending import:
```
VCRUNTIME140.dll          <- not inbox; from VC++ Redistributable
api-ms-win-crt-*.dll      <- UCRT, inbox on Win10/11, resolves fine
```
Only `VCRUNTIME140.dll` is the blocker. `+crt-static` statically links both the VC runtime and UCRT, eliminating the import.

## Test plan
- CI `check-windows` builds `numa.exe` on `windows-latest` and uploads it as an artifact.
- Verify the artifact no longer imports the CRT: `strings numa.exe | grep -i vcruntime140` must return **nothing** (current release returns `VCRUNTIME140.dll`).
- Runtime sanity on a real Windows 11 box: `.\numa.exe --version` prints a version instead of exiting `0xC0000135`.
- Cannot be validated on macOS/Linux locally (target-scoped); relies on the Windows CI job + manual artifact inspection.