### PR TITLE
feat(proxy): resolve .numa services to the per-client egress IP

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -376,7 +376,8 @@ fn resolve_local(
 }
 
 /// Resolve `.numa` queries:
-///   - locally-registered service → loopback (local client) or LAN IP (remote)
+///   - locally-registered service → loopback locally, else the egress IP toward
+///     the client (so LAN and tailnet peers each get a reachable proxy address)
 ///   - LAN peer learned via discovery → that peer's actual IP (v4 or v6 native)
 ///   - unknown name → NXDOMAIN (never silently sinkhole to loopback)
 fn resolve_proxy_tld(
@@ -391,7 +392,8 @@ fn resolve_proxy_tld(
 
     if ctx.services.lock().unwrap().lookup(service_name).is_some() {
         let v4 = if is_remote {
-            *ctx.lan_ip.lock().unwrap()
+            crate::lan::local_ip_toward(src_addr.ip())
+                .unwrap_or_else(|| *ctx.lan_ip.lock().unwrap())
         } else {
             std::net::Ipv4Addr::LOCALHOST
         };

--- a/src/lan.rs
+++ b/src/lan.rs
@@ -101,13 +101,19 @@ impl PeerStore {
 
 // --- mDNS Discovery ---
 
-pub fn detect_lan_ip() -> Option<Ipv4Addr> {
+/// Source IPv4 the kernel would route from to reach `dest`. The UDP `connect`
+/// sends no packet — it only consults the routing table.
+pub fn local_ip_toward(dest: IpAddr) -> Option<Ipv4Addr> {
     let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
-    socket.connect("8.8.8.8:80").ok()?;
+    socket.connect((dest, 53)).ok()?;
     match socket.local_addr().ok()? {
         SocketAddr::V4(addr) => Some(*addr.ip()),
         _ => None,
     }
+}
+
+pub fn detect_lan_ip() -> Option<Ipv4Addr> {
+    local_ip_toward(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)))
 }
 
 /// Short hostname for mDNS instance names (`<short>._numa._tcp.local`).
@@ -511,4 +517,17 @@ fn create_mdns_socket() -> std::io::Result<std::net::UdpSocket> {
     socket.bind(&socket2::SockAddr::from(addr))?;
     socket.join_multicast_v4(&MDNS_ADDR, &Ipv4Addr::UNSPECIFIED)?;
     Ok(socket.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_ip_toward_loopback_dest_is_loopback() {
+        assert_eq!(
+            local_ip_toward(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            Some(Ipv4Addr::LOCALHOST)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- A registered `.numa` service resolved to the node's detected **LAN IP** for every remote client (`resolve_proxy_tld`). A client reaching the resolver over a *different* network — notably a **Tailscale tailnet** — was handed a LAN address it can't route to, so the `.numa` reverse proxy was unreachable from e.g. a phone on the tailnet.
- Generalize `detect_lan_ip` into `local_ip_toward(dest)`: a UDP `connect` sends no packet, it just consults the kernel routing table, which yields the source IP toward a given destination.
- `resolve_proxy_tld` now answers a remote query with the **egress IP toward that client** — so LAN peers still get the LAN address and tailnet peers get the tailnet address. Falls back to the cached `lan_ip` if the route probe fails (behaviour-preserving on error).
- Local clients are unchanged (still loopback).

This is the Numa half of making `peekmtail.numa`-style services reachable from a phone over a tailnet; it pairs with binding the proxy off-loopback (`[proxy] bind_addr`) in config.

## Test plan

- [x] `make all` green — fmt, `clippy -D warnings`, `cargo audit`, build, 503 tests.
- [x] New unit test `local_ip_toward_loopback_dest_is_loopback` — routing toward a loopback destination yields a loopback source (the property the tailnet case relies on), deterministic across hosts.
- [x] Existing `.numa` proxy-TLD tests still pass (local client → loopback, unknown name → NXDOMAIN, LAN-peer paths).
- [x] Manual end-to-end (post-merge, needs the config + peekm sides): iPhone on tailnet resolves `*.numa` to the node's tailnet IP and the proxy serves it.