### PR TITLE
feat(proxy): enforce allow_from on the .numa proxy listeners

### DIFF
--- a/src/acl.rs
+++ b/src/acl.rs
@@ -84,6 +84,14 @@ impl AllowFromAcl {
         self.matcher.matches(peer)
     }
 
+    /// Whether to admit a connection given its PROXY-v2 command kind. A LOCAL
+    /// command is the front-end/LB probing for itself (already vetted by
+    /// `proxy_protocol.from`) — it carries no client, so it bypasses this
+    /// client allowlist. Everything else is gated on `allows`.
+    pub fn admits(&self, peer: IpAddr, local_command: bool) -> bool {
+        local_command || self.allows(peer)
+    }
+
     pub fn is_enabled(&self) -> bool {
         !self.matcher.is_empty()
     }
@@ -124,6 +132,25 @@ mod tests {
         let a = AllowFromAcl::default();
         assert!(!a.is_enabled());
         check_allows(&a, &[("1.2.3.4", true), ("2001:db8::1", true)]);
+    }
+
+    /// A PROXY-v2 LOCAL command (health probe, no client) bypasses the ACL even
+    /// when the resolved address is outside the allowlist; a real client at the
+    /// same address is still gated. (Untestable through a listener: the test
+    /// peer is always loopback, which `allows` exempts regardless.)
+    #[test]
+    fn local_command_bypasses_allow_from() {
+        let a = AllowFromAcl {
+            matcher: matcher(&["10.0.0.0/8"], &[]),
+        };
+        let outside: IpAddr = "192.0.2.1".parse().unwrap();
+        let inside: IpAddr = "10.1.2.3".parse().unwrap();
+        assert!(
+            a.admits(outside, true),
+            "LOCAL command bypasses the allowlist"
+        );
+        assert!(!a.admits(outside, false), "real client outside is gated");
+        assert!(a.admits(inside, false), "real client inside is admitted");
     }
 
     #[test]

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -86,8 +86,8 @@ impl AllowFromAcl {
 
     /// Whether to admit a connection given its PROXY-v2 command kind. A LOCAL
     /// command is the front-end/LB probing for itself (already vetted by
-    /// `proxy_protocol.from`) — it carries no client, so it bypasses this
-    /// client allowlist. Everything else is gated on `allows`.
+    /// `proxy_protocol.from`) — it carries no client, so it bypasses the
+    /// client allowlist.
     pub fn admits(&self, peer: IpAddr, local_command: bool) -> bool {
         local_command || self.allows(peer)
     }
@@ -134,10 +134,8 @@ mod tests {
         check_allows(&a, &[("1.2.3.4", true), ("2001:db8::1", true)]);
     }
 
-    /// A PROXY-v2 LOCAL command (health probe, no client) bypasses the ACL even
-    /// when the resolved address is outside the allowlist; a real client at the
-    /// same address is still gated. (Untestable through a listener: the test
-    /// peer is always loopback, which `allows` exempts regardless.)
+    /// Pure test: the LOCAL exemption can't be hit through a listener — the test
+    /// peer is always loopback, which `allows` exempts regardless.
     #[test]
     fn local_command_bypasses_allow_from() {
         let a = AllowFromAcl {

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -117,13 +117,13 @@ async fn accept_loop(
         tokio::spawn(async move {
             let _permit = permit; // held until task exits
 
-            let Some((stream, remote_addr)) =
+            let Some((stream, remote_addr, local_command)) =
                 pp2::handshake(tcp_stream, tcp_peer, pp.as_deref(), &ctx).await
             else {
                 return;
             };
 
-            if !ctx.allow_from.allows(remote_addr.ip()) {
+            if !ctx.allow_from.admits(remote_addr.ip(), local_command) {
                 // Close before TLS handshake — no fingerprint, no cert exposure.
                 debug!("DoT: dropping {} — not in allow_from", remote_addr);
                 return;

--- a/src/pp2.rs
+++ b/src/pp2.rs
@@ -84,16 +84,20 @@ pub fn init(listener: &str, cfg: &ProxyProtocolConfig) -> Result<Option<Arc<PpCo
 /// Returns `None` when the connection should be dropped — either because
 /// the peer is not on the allowlist, or because the header failed to parse
 /// or arrive before the timeout. Stats are recorded as a side effect.
+/// Returns `(stream, remote_addr, local_command)`. `local_command` is true for
+/// a PROXY-v2 LOCAL header (the front-end probing for itself, no client) so the
+/// caller can exempt it from the client `allow_from`; false for a real proxied
+/// client or a direct (no-PROXY) connection.
 pub async fn handshake(
     tcp_stream: TcpStream,
     tcp_peer: SocketAddr,
     pp: Option<&PpConfig>,
     ctx: &Arc<ServerCtx>,
-) -> Option<(Stream, SocketAddr)> {
+) -> Option<(Stream, SocketAddr, bool)> {
     let pp = match pp {
         Some(p) => p,
-        // Feature disabled on this listener; passthrough.
-        None => return Some((Stream::Bare(tcp_stream), tcp_peer)),
+        // Feature disabled on this listener; passthrough (direct client).
+        None => return Some((Stream::Bare(tcp_stream), tcp_peer, false)),
     };
 
     if !pp.allows(tcp_peer.ip()) {
@@ -126,20 +130,20 @@ pub async fn handshake(
     };
 
     let header = proxied.proxy_header();
-    let real_addr = match header.proxied_address() {
+    let (real_addr, local_command) = match header.proxied_address() {
         Some(addr) => {
             ctx.stats.lock().unwrap().proxy_v2_accepted += 1;
-            addr.source
+            (addr.source, false)
         }
         None => {
             // LOCAL command (proxy health check) or an address-less header.
             // Use the TCP peer as the connection's remote_addr.
             ctx.stats.lock().unwrap().proxy_v2_local_command += 1;
-            tcp_peer
+            (tcp_peer, true)
         }
     };
 
-    Some((Stream::Proxied(Box::new(proxied)), real_addr))
+    Some((Stream::Proxied(Box::new(proxied)), real_addr, local_command))
 }
 
 /// `Either`-style enum covering the two states the listener may produce:

--- a/src/pp2_udp.rs
+++ b/src/pp2_udp.rs
@@ -14,7 +14,13 @@ use crate::pp2::{PpConfig, PARSE_CFG};
 #[derive(Debug, PartialEq, Eq)]
 pub enum UdpPp {
     Bare,
-    Proxied { src: SocketAddr, hdr_len: usize },
+    Proxied {
+        src: SocketAddr,
+        hdr_len: usize,
+        /// LOCAL command (sender health probe): `src` is the front-end itself,
+        /// not a client, so it bypasses the client `allow_from`.
+        local_command: bool,
+    },
     Drop,
 }
 
@@ -27,12 +33,16 @@ impl UdpPp {
         buf: &mut [u8],
         len: usize,
         peer: SocketAddr,
-    ) -> Option<(SocketAddr, usize)> {
+    ) -> Option<(SocketAddr, usize, bool)> {
         match self {
-            UdpPp::Bare => Some((peer, len)),
-            UdpPp::Proxied { src, hdr_len } => {
+            UdpPp::Bare => Some((peer, len, false)),
+            UdpPp::Proxied {
+                src,
+                hdr_len,
+                local_command,
+            } => {
                 buf.copy_within(hdr_len..len, 0);
-                Some((src, len - hdr_len))
+                Some((src, len - hdr_len, local_command))
             }
             UdpPp::Drop => None,
         }
@@ -71,13 +81,18 @@ pub fn parse_if_trusted(
             UdpPp::Proxied {
                 src: addr.source,
                 hdr_len,
+                local_command: false,
             }
         }
         None => {
             // LOCAL command (sender health probe): use peer as the real
             // client and treat the rest of the datagram as DNS.
             ctx.stats.lock().unwrap().proxy_v2_local_command += 1;
-            UdpPp::Proxied { src: peer, hdr_len }
+            UdpPp::Proxied {
+                src: peer,
+                hdr_len,
+                local_command: true,
+            }
         }
     }
 }
@@ -141,8 +156,13 @@ mod tests {
         let peer: SocketAddr = "172.29.0.20:44444".parse().unwrap();
 
         match parse_if_trusted(&datagram, peer, Some(&pp), &ctx) {
-            UdpPp::Proxied { src, hdr_len } => {
+            UdpPp::Proxied {
+                src,
+                hdr_len,
+                local_command,
+            } => {
                 assert_eq!(src.to_string(), "203.0.113.5:55000");
+                assert!(!local_command, "PROXY command is not a LOCAL probe");
                 assert_eq!(&datagram[hdr_len..], dns);
             }
             other => panic!("expected Proxied, got {other:?}"),
@@ -185,7 +205,10 @@ mod tests {
     async fn apply_bare_passes_through() {
         let mut buf = *b"hello-world";
         let peer: SocketAddr = "1.2.3.4:53".parse().unwrap();
-        assert_eq!(UdpPp::Bare.apply(&mut buf, 11, peer), Some((peer, 11)));
+        assert_eq!(
+            UdpPp::Bare.apply(&mut buf, 11, peer),
+            Some((peer, 11, false))
+        );
         assert_eq!(&buf, b"hello-world");
     }
 
@@ -197,9 +220,10 @@ mod tests {
         let r = UdpPp::Proxied {
             src: real,
             hdr_len: 9,
+            local_command: false,
         }
         .apply(&mut buf, 20, peer);
-        assert_eq!(r, Some((real, 11)));
+        assert_eq!(r, Some((real, 11, false)));
         assert_eq!(&buf[..11], b"dns-payload");
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -2,7 +2,8 @@ use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use axum::body::Body;
-use axum::extract::{Request, State};
+use axum::extract::{ConnectInfo, Request, State};
+use axum::middleware::Next;
 use axum::response::IntoResponse;
 use axum::routing::{any, get};
 use axum::Router;
@@ -34,6 +35,23 @@ struct ProxyState {
     client: HttpClient,
 }
 
+/// Reject proxy clients outside `[server].allow_from`, mirroring the DNS
+/// listeners. Loopback and an empty allowlist are always permitted (see
+/// `AllowFromAcl::allows`), so the default open behaviour is unchanged.
+async fn allow_from_guard(
+    State(ctx): State<Arc<ServerCtx>>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    req: Request,
+    next: Next,
+) -> axum::response::Response {
+    if ctx.allow_from.allows(peer.ip()) {
+        next.run(req).await
+    } else {
+        debug!("proxy: dropping {} — not in allow_from", peer.ip());
+        StatusCode::FORBIDDEN.into_response()
+    }
+}
+
 pub async fn start_proxy(ctx: Arc<ServerCtx>, port: u16, bind_addr: Ipv4Addr) {
     let addr: SocketAddr = (bind_addr, port).into();
     let listener = match tokio::net::TcpListener::bind(addr).await {
@@ -52,11 +70,22 @@ pub async fn start_proxy(ctx: Arc<ServerCtx>, port: u16, bind_addr: Ipv4Addr) {
         .http1_preserve_header_case(true)
         .build_http();
 
-    let state = ProxyState { ctx, client };
+    let state = ProxyState {
+        ctx: Arc::clone(&ctx),
+        client,
+    };
 
-    let app = Router::new().fallback(any(proxy_handler)).with_state(state);
+    let app = Router::new()
+        .fallback(any(proxy_handler))
+        .with_state(state)
+        .layer(axum::middleware::from_fn_with_state(ctx, allow_from_guard));
 
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
+    .unwrap();
 }
 
 pub async fn start_proxy_tls(
@@ -135,6 +164,14 @@ async fn accept_loop_tls(
             else {
                 return;
             };
+
+            if !ctx_for_pp2.allow_from.allows(remote_addr.ip()) {
+                debug!(
+                    "proxy(tls): dropping {} — not in allow_from",
+                    remote_addr.ip()
+                );
+                return;
+            }
 
             let mut conn_doh_state = doh_state;
             conn_doh_state.remote_addr = Some(remote_addr);
@@ -632,5 +669,36 @@ mod tests {
         let resp = DnsPacket::from_buffer(&mut r_buf).unwrap();
         assert_eq!(resp.header.rescode, ResultCode::NOERROR);
         assert_eq!(resp.answers.len(), 1);
+    }
+
+    /// The proxy honours `allow_from` like the DNS listeners: peers outside the
+    /// set get 403, peers inside pass, loopback is always exempt.
+    #[tokio::test]
+    async fn proxy_allow_from_guard_gates_by_peer_ip() {
+        use tower::ServiceExt;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.allow_from =
+            crate::acl::AllowFromAcl::from_entries(&["10.0.0.0/8".to_string()]).unwrap();
+        let ctx = Arc::new(ctx);
+
+        let app = Router::new()
+            .route("/", get(|| async { StatusCode::OK }))
+            .layer(axum::middleware::from_fn_with_state(
+                Arc::clone(&ctx),
+                allow_from_guard,
+            ));
+
+        for (peer, want) in [
+            ("10.1.2.3:5000", StatusCode::OK),
+            ("192.0.2.1:5000", StatusCode::FORBIDDEN),
+            ("127.0.0.1:5000", StatusCode::OK),
+        ] {
+            let peer: SocketAddr = peer.parse().unwrap();
+            let mut req = Request::builder().uri("/").body(Body::empty()).unwrap();
+            req.extensions_mut().insert(ConnectInfo(peer));
+            let status = app.clone().oneshot(req).await.unwrap().status();
+            assert_eq!(status, want, "peer {peer}");
+        }
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -35,9 +35,10 @@ struct ProxyState {
     client: HttpClient,
 }
 
-/// Reject proxy clients outside `[server].allow_from`, mirroring the DNS
-/// listeners. Loopback and an empty allowlist are always permitted (see
-/// `AllowFromAcl::allows`), so the default open behaviour is unchanged.
+/// Gate the plain HTTP proxy on `[server].allow_from`, checking the direct TCP
+/// peer — this listener has no PROXY-protocol support, so behind a load balancer
+/// the peer is the balancer, not the client. Loopback and an empty allowlist are
+/// always permitted, so the default open behaviour is unchanged.
 async fn allow_from_guard(
     State(ctx): State<Arc<ServerCtx>>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
@@ -159,13 +160,16 @@ async fn accept_loop_tls(
         let pp = pp.clone();
 
         tokio::spawn(async move {
-            let Some((stream, remote_addr)) =
+            let Some((stream, remote_addr, local_command)) =
                 pp2::handshake(tcp_stream, tcp_peer, pp.as_deref(), &ctx_for_pp2).await
             else {
                 return;
             };
 
-            if !ctx_for_pp2.allow_from.allows(remote_addr.ip()) {
+            if !ctx_for_pp2
+                .allow_from
+                .admits(remote_addr.ip(), local_command)
+            {
                 debug!(
                     "proxy(tls): dropping {} — not in allow_from",
                     remote_addr.ip()
@@ -563,12 +567,20 @@ mod tests {
         h
     }
 
-    /// Spin up a DoH-capable TLS listener with a PROXY v2 allowlist.
-    async fn spawn_doh_server_with_pp(pp_from: &[&str]) -> (SocketAddr, CertificateDer<'static>) {
+    /// Spin up a DoH-capable TLS listener with a PROXY v2 allowlist and an
+    /// optional `[server].allow_from` (empty = allow-all).
+    async fn spawn_doh_server_with_pp(
+        pp_from: &[&str],
+        allow_from: &[&str],
+    ) -> (SocketAddr, CertificateDer<'static>) {
         let (server_tls, cert_der) = test_tls_configs();
         let upstream_addr = crate::testutil::blackhole_upstream();
 
         let mut ctx = crate::testutil::test_ctx().await;
+        ctx.allow_from = crate::acl::AllowFromAcl::from_entries(
+            &allow_from.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        )
+        .unwrap();
         ctx.zone_map = crate::config::ZoneMap::from_exact(vec![DnsRecord::A {
             domain: "doh-test.example".to_string(),
             addr: std::net::Ipv4Addr::new(10, 0, 0, 2),
@@ -635,7 +647,7 @@ mod tests {
         // Trusted client (127.0.0.1) sends a v4 PROXY header before the TLS
         // ClientHello; server completes TLS, parses the wire DNS message,
         // and returns NOERROR with the local-zone A record.
-        let (addr, cert_der) = spawn_doh_server_with_pp(&["127.0.0.1"]).await;
+        let (addr, cert_der) = spawn_doh_server_with_pp(&["127.0.0.1"], &[]).await;
 
         let mut root_store = rustls::RootCertStore::empty();
         root_store.add(cert_der).unwrap();
@@ -700,5 +712,50 @@ mod tests {
             let status = app.clone().oneshot(req).await.unwrap().status();
             assert_eq!(status, want, "peer {peer}");
         }
+    }
+
+    /// On 443 the proxy gates the PROXY-v2-resolved client against allow_from:
+    /// an in-range proxied source completes TLS, an out-of-range one is dropped
+    /// before the handshake. (The test client is loopback, but the gated address
+    /// is the proxied source in the PROXY header, so the check is exercised.)
+    #[tokio::test]
+    async fn proxy_tls_allow_from_gates_proxied_client() {
+        let (addr, cert_der) = spawn_doh_server_with_pp(&["127.0.0.1"], &["203.0.113.0/24"]).await;
+
+        let mut root_store = rustls::RootCertStore::empty();
+        root_store.add(cert_der).unwrap();
+        let client_config = Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(root_store)
+                .with_no_client_auth(),
+        );
+
+        async fn tls_connects(
+            addr: SocketAddr,
+            client_config: Arc<rustls::ClientConfig>,
+            src: &str,
+        ) -> bool {
+            let mut tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+            let pp = pp2_v4_proxy(
+                src.parse().unwrap(),
+                "10.0.0.5".parse().unwrap(),
+                54321,
+                443,
+            );
+            tcp.write_all(&pp).await.unwrap();
+            tokio_rustls::TlsConnector::from(client_config)
+                .connect(ServerName::try_from("numa.numa").unwrap(), tcp)
+                .await
+                .is_ok()
+        }
+
+        assert!(
+            tls_connects(addr, client_config.clone(), "203.0.113.42").await,
+            "in-range proxied client should be served"
+        );
+        assert!(
+            !tls_connects(addr, client_config, "198.51.100.7").await,
+            "out-of-range proxied client should be dropped before TLS"
+        );
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -683,8 +683,7 @@ mod tests {
         assert_eq!(resp.answers.len(), 1);
     }
 
-    /// The proxy honours `allow_from` like the DNS listeners: peers outside the
-    /// set get 403, peers inside pass, loopback is always exempt.
+    /// Port-80 guard: outside `allow_from` → 403, inside → pass, loopback exempt.
     #[tokio::test]
     async fn proxy_allow_from_guard_gates_by_peer_ip() {
         use tower::ServiceExt;
@@ -714,10 +713,8 @@ mod tests {
         }
     }
 
-    /// On 443 the proxy gates the PROXY-v2-resolved client against allow_from:
-    /// an in-range proxied source completes TLS, an out-of-range one is dropped
-    /// before the handshake. (The test client is loopback, but the gated address
-    /// is the proxied source in the PROXY header, so the check is exercised.)
+    /// The gated address is the proxied source in the PROXY header (not the
+    /// loopback test peer), so the 443 ACL is genuinely exercised.
     #[tokio::test]
     async fn proxy_tls_allow_from_gates_proxied_client() {
         let (addr, cert_der) = spawn_doh_server_with_pp(&["127.0.0.1"], &["203.0.113.0/24"]).await;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -405,10 +405,10 @@ async fn udp_serve_loop(
             Err(e) => return Err(e.into()),
         };
         let pp = crate::pp2_udp::parse_if_trusted(&buffer.buf[..len], peer, udp_pp, ctx);
-        let Some((src_addr, dns_len)) = pp.apply(&mut buffer.buf, len, peer) else {
+        let Some((src_addr, dns_len, local_command)) = pp.apply(&mut buffer.buf, len, peer) else {
             continue;
         };
-        if !ctx.allow_from.allows(src_addr.ip()) {
+        if !ctx.allow_from.admits(src_addr.ip(), local_command) {
             // Silent drop: no reply means no amplification, no fingerprint.
             debug!("UDP: dropping {} — not in allow_from", src_addr);
             continue;

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -81,13 +81,13 @@ async fn accept_loop(listener: TcpListener, pp: Option<Arc<PpConfig>>, ctx: Arc<
         tokio::spawn(async move {
             let _permit = permit;
 
-            let Some((stream, remote_addr)) =
+            let Some((stream, remote_addr, local_command)) =
                 pp2::handshake(tcp_stream, tcp_peer, pp.as_deref(), &ctx).await
             else {
                 return;
             };
 
-            if !ctx.allow_from.allows(remote_addr.ip()) {
+            if !ctx.allow_from.admits(remote_addr.ip(), local_command) {
                 debug!("TCP: dropping {} — not in allow_from", remote_addr);
                 return;
             }


### PR DESCRIPTION
## Summary

- The `.numa` reverse proxy (HTTP/80 and HTTPS/443) answered **every** client, unlike the DNS listeners (UDP/TCP/DoT/DoH) which already gate on `[server].allow_from`. With the proxy bound off-loopback (e.g. `bind_addr = "0.0.0.0"` to serve a tailnet), that left it reachable by any host that could route to the node — no ACL.
- Apply the same `allow_from` check to both proxy listeners:
  - **Plain (80):** a `ConnectInfo` guard layer (`allow_from_guard`) → 403 for disallowed peers.
  - **TLS (443):** a pre-TLS check in the accept loop, using the **PROXY-v2-resolved** client address, so the connection is dropped before the handshake.
- Reuses the existing `AllowFromAcl::allows()`, so **loopback and an empty allowlist stay permitted** → default behaviour is unchanged. Operators who set `allow_from` now have it cover the proxy as well as DNS.

### Why
This makes binding the proxy to `0.0.0.0` safe-by-policy: it answers exactly the clients in `allow_from` (e.g. LAN + tailnet CGNAT) and drops the rest, instead of being exposed on every interface. Pairs with the per-client egress-IP fix (#263) to make `.numa` services reachable over a tailnet without an open proxy.

## Test plan

- [x] `make all` green — fmt, `clippy -D warnings`, `cargo audit`, build, 503 tests.
- [x] New unit test `proxy_allow_from_guard_gates_by_peer_ip`: peer in allowlist → 200, peer outside → 403, loopback → 200 (always exempt).
- [x] Existing PROXY-v2 + DoH-over-TLS tests still pass (the 443 accept-loop change sits after the PP2 handshake).

## Scope / deliberately excluded
- **ODoH target** — not gated: its trust model is anonymity, and the peer is the *relay*, not the client, so `allow_from` would be semantically wrong there.
- **Mobile API** — not gated: separate onboarding trust model.
- **Dashboard/REST API (5380)** — loopback-bound by default (no live exposure); same guard could extend there later, kept out to keep this focused.