### PR TITLE
fix(doh): log rejected peer on allow_from denial

### DIFF
--- a/src/doh.rs
+++ b/src/doh.rs
@@ -5,7 +5,7 @@ use axum::body::Bytes;
 use axum::extract::{Request, State};
 use axum::response::{IntoResponse, Response};
 use hyper::StatusCode;
-use log::warn;
+use log::{debug, warn};
 
 use crate::buffer::BytePacketBuffer;
 use crate::ctx::{resolve_query, ServerCtx};
@@ -92,6 +92,10 @@ fn doh_validate(
             .remote_addr
             .is_some_and(|a| state.ctx.allow_from.allows(a.ip()));
         if !allowed {
+            match state.remote_addr {
+                Some(a) => debug!("DoH: dropping {a} — not in allow_from"),
+                None => debug!("DoH: dropping unknown peer — not in allow_from"),
+            }
             return Err(StatusCode::FORBIDDEN);
         }
     }


### PR DESCRIPTION
## Summary
- DoH was the only query surface that dropped an `allow_from`-denied client **silently** — it returned `403 FORBIDDEN` with no log line.
- UDP, TCP, DoT, and both PROXY-protocol paths already `debug!`-log the rejected peer; DoH now matches.
- Net effect: `RUST_LOG=debug` explains ACL denials uniformly across every transport, closing the one blind spot where a misconfigured `allow_from` (e.g. behind a load balancer that rewrites the source IP) produced vanishing queries with nothing in the logs.
- No new state, no behavior change beyond the added log line.

Prompted by a [Technitium clustering post-mortem](https://www.virtualizationhowto.com/2026/05/i-thought-my-technitium-dns-cluster-was-fixed-these-settings-were-the-real-problem/) whose multi-hour debugging spiral was exactly this failure mode: an ACL silently rejecting traffic whose observed source IP didn't match expectations.

## Test plan
- `make all` (fmt --check + clippy -D warnings + cargo audit + full test suite) — green, 500+ tests pass.
- Logging-only change on the denial branch; existing DoH ACL tests (`doh::tests`) unaffected.