### PR TITLE
build: shrink release binary  via fat LTO + strip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,5 +73,10 @@ harness = false
 name = "recursive_compare"
 harness = false
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = true
+
 [lints.clippy]
 cognitive_complexity = "warn"


### PR DESCRIPTION
## What

Adds a `[profile.release]` with `lto = "fat"`, `codegen-units = 1`, `strip = true`.

## Why

The **raw, uncompressed** release binary (`cargo build --release`) was 14.11 MiB with no release profile set. These three knobs are a free size win — measured locally on the x86_64 macOS build:

| Build (raw, uncompressed) | Size |
|---|--:|
| default `release` | 14.11 MiB |
| `lto="fat"` + `codegen-units=1` + `strip=true` | **8.14 MiB** (−42%) |

Split: `strip` removes the ~2.75 MB symbol table; fat LTO trims ~3.5 MB via cross-crate inlining, dead-code elimination and monomorphization dedup.

### Who sees what

- **`cargo install` / source builders** get the full raw −42%.
- **Release-download users** already get ~6 MiB artifacts — the release pipeline ships musl binaries inside `tar.gz`/`zip`, and gzip was already compressing much of what `strip` now removes. So the *compressed download* shrinks too, but by **less than 42%** (exact delta TBD on the first tagged build off `main`). The −42% headline is the raw-binary figure, not the download.

## No runtime cost

`opt-level` stays at `3`, so the cached-hit and cold-recursive latency benchmarks are unchanged. The only tradeoff is a slower single-threaded final LTO link at release time, which the release cadence absorbs (release builds aren't per-commit).

Deliberately **excluded** `panic = "abort"` (would save ~0.9 MB more) — it sacrifices per-query fault isolation, and a system resolver shouldn't abort the whole process on a single panicking task. Further levers (single crypto provider, `opt-level="s"`) are tracked separately for measured follow-up.