### PR TITLE
build(deps): use ring as the sole rustls crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,28 +207,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,8 +304,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -440,15 +416,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -704,12 +671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,12 +757,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1480,16 +1435,6 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
 ]
 
 [[package]]
@@ -2253,7 +2198,6 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2288,7 +2232,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3"
 socket2 = { version = "0.6", features = ["all"] }
 rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
 time = "0.3"
-rustls = "0.23"
-tokio-rustls = "0.26"
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12", "logging"] }
 arc-swap = "1"
 ring = "0.17"
 odoh-rs = "1"

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
                 pname = "numa";
                 version = (lib.importTOML ./Cargo.toml).package.version;
                 src = ./.;
-                cargoHash = "sha256-svTcUocOSHNmXcPQaBusOSh3oVb2kRbPS9Hy4XdVpv4=";
+                cargoHash = "sha256-DU+pAgIy76FcKFs1p25o8S1MxcT5hdGphVqpi60pIus=";
                 meta = {
                   description = "Portable DNS resolver in Rust";
                   homepage = "https://numa.rs";


### PR DESCRIPTION
## Summary

Pin `rustls` / `tokio-rustls` to `default-features = false` with the `ring` backend, dropping the default `aws-lc-rs` provider. This removes **`aws-lc-sys` and its `cmake` / C / `bindgen` build dependencies from the tree entirely** (−57 lines of `Cargo.lock`), leaving **ring as the single crypto provider** across `rustls`, `reqwest`, and `odoh`.

## Why — build & cross-compilation, not size

I verified this is **not** a binary-size win, despite the earlier hypothesis:

| | aws-lc-rs (baseline) | ring (this PR) |
|---|---|---|
| clean release binary | 8.14 MiB | 8.14 MiB |

There was only ever one crypto provider linked (`aws-lc-rs`, shared by rustls + reqwest); this swaps it for another of comparable size. The real wins are:

- **No C toolchain to build.** `aws-lc-sys` requires `cmake` + a C compiler + `bindgen`. Gone.
- **Cross-compilation.** `aws-lc-sys` is the exact reason cross-building to armv6 (Pi Zero) currently needs a `rust-musl-cross` Docker image. `ring` ships pre-generated asm and is far more cross-friendly.
- **One crypto audit surface** instead of provider ambiguity.

## Trade-off

`ring` is no longer rustls's *recommended-default* provider and lacks FIPS certification — neither is relevant for Numa (no FIPS requirement; the recursive/DoT/DoH/ODoH paths don't need aws-lc's perf edge at our scale).

## Test plan

- [x] `cargo build` clean; `aws-lc*` absent from `cargo tree` and `Cargo.lock`.
- [x] `cargo clippy -- -D warnings` clean (CI's exact command).
- [x] `cargo test` — **503 pass** (500 lib + 2 bin + 1 integration).
- [x] DoT / DoH / ODoH TLS tests pass on ring (TLS handshake + cert paths exercised).
- [x] Clean release build measured at 8.14 MiB.