### PR TITLE
feat(rebind): DNS rebinding protection (static filter, off by default)

### DIFF
--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -128,7 +128,6 @@ impl BlocklistStore {
         BlockCheckResult::not_blocked()
     }
 
-
     /// Atomically swap in a new domain set. Build the set outside the lock,
     /// then call this to swap — keeps lock hold time sub-microsecond.
     pub fn swap_domains(&mut self, domains: HashSet<String>, sources: Vec<String>) {

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -88,10 +88,10 @@ impl BlocklistStore {
             }
         }
         let domain = normalize(domain);
-        if Self::find_in_set(&domain, &self.allowlist).is_some() {
+        if find_in_set(&domain, &self.allowlist).is_some() {
             return false;
         }
-        Self::find_in_set(&domain, &self.domains).is_some()
+        find_in_set(&domain, &self.domains).is_some()
     }
 
     pub fn check(&self, domain: &str) -> BlockCheckResult {
@@ -107,7 +107,7 @@ impl BlocklistStore {
 
         let domain = normalize(domain);
 
-        if let Some(matched) = Self::find_in_set(&domain, &self.allowlist) {
+        if let Some(matched) = find_in_set(&domain, &self.allowlist) {
             let reason = if matched == domain {
                 "exact match in allowlist"
             } else {
@@ -116,7 +116,7 @@ impl BlocklistStore {
             return BlockCheckResult::allowed(matched, reason);
         }
 
-        if let Some(matched) = Self::find_in_set(&domain, &self.domains) {
+        if let Some(matched) = find_in_set(&domain, &self.domains) {
             let reason = if matched == domain {
                 "exact match in blocklist"
             } else {
@@ -128,19 +128,6 @@ impl BlocklistStore {
         BlockCheckResult::not_blocked()
     }
 
-    fn find_in_set<'a>(domain: &'a str, set: &HashSet<String>) -> Option<&'a str> {
-        if set.contains(domain) {
-            return Some(domain);
-        }
-        let mut d = domain;
-        while let Some(dot) = d.find('.') {
-            d = &d[dot + 1..];
-            if set.contains(d) {
-                return Some(d);
-            }
-        }
-        None
-    }
 
     /// Atomically swap in a new domain set. Build the set outside the lock,
     /// then call this to swap — keeps lock hold time sub-microsecond.
@@ -235,8 +222,25 @@ pub fn parse_blocklist(text: &str) -> HashSet<String> {
     domains
 }
 
-fn normalize(domain: &str) -> String {
+pub(crate) fn normalize(domain: &str) -> String {
     domain.to_lowercase().trim_end_matches('.').to_string()
+}
+
+/// Exact-or-parent suffix match: `example.com` matches `nas.example.com` but
+/// never `evilexample.com`. `domain` must already be normalized. Shared by the
+/// blocklist and rebind allowlist.
+pub(crate) fn find_in_set<'a>(domain: &'a str, set: &HashSet<String>) -> Option<&'a str> {
+    if set.contains(domain) {
+        return Some(domain);
+    }
+    let mut d = domain;
+    while let Some(dot) = d.find('.') {
+        d = &d[dot + 1..];
+        if set.contains(d) {
+            return Some(d);
+        }
+    }
+    None
 }
 
 fn insert_if_valid(set: &mut HashSet<String>, raw: &str) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,7 +116,6 @@ pub struct ServerConfig {
     /// hostname can't be rebound to an address inside the perimeter. Local
     /// data (zones, overrides, `.numa`, blocklist sinkhole) is never affected.
     /// DNSBL/RBL users should add their lookup zones to `rebind_allowlist`.
-    /// Default false.
     #[serde(default)]
     pub rebind_protect: bool,
     /// Domains exempt from rebind protection (split-horizon home services).

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,6 +110,21 @@ pub struct ServerConfig {
     /// CIDR allowlist applied at every DNS surface. Empty = disabled.
     #[serde(default)]
     pub allow_from: Vec<String>,
+    /// DNS rebinding protection (#240). When true, strip private/special-use
+    /// addresses (RFC 1918, link-local, ULA, `0.0.0.0/8`; not loopback) from
+    /// answers resolved via the upstream/recursive/cache paths, so a public
+    /// hostname can't be rebound to an address inside the perimeter. Local
+    /// data (zones, overrides, `.numa`, blocklist sinkhole) is never affected.
+    /// Default false.
+    #[serde(default)]
+    pub rebind_protect: bool,
+    /// Domains exempt from rebind protection (split-horizon home services).
+    /// Suffix match: `example.com` covers `nas.example.com`, not `evilexample.com`.
+    #[serde(default)]
+    pub rebind_allowlist: Vec<String>,
+    /// Override the built-in private-range set. Empty = built-in defaults.
+    #[serde(default)]
+    pub rebind_private_ranges: Vec<String>,
 }
 
 impl Default for ServerConfig {
@@ -122,6 +137,9 @@ impl Default for ServerConfig {
             filter_aaaa: false,
             proxy_protocol: ProxyProtocolConfig::default(),
             allow_from: Vec::new(),
+            rebind_protect: false,
+            rebind_allowlist: Vec::new(),
+            rebind_private_ranges: Vec::new(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,10 +111,11 @@ pub struct ServerConfig {
     #[serde(default)]
     pub allow_from: Vec<String>,
     /// DNS rebinding protection (#240). When true, strip private/special-use
-    /// addresses (RFC 1918, link-local, ULA, `0.0.0.0/8`; not loopback) from
+    /// addresses (loopback, RFC 1918, link-local, ULA, `0.0.0.0/8`) from
     /// answers resolved via the upstream/recursive/cache paths, so a public
     /// hostname can't be rebound to an address inside the perimeter. Local
     /// data (zones, overrides, `.numa`, blocklist sinkhole) is never affected.
+    /// DNSBL/RBL users should add their lookup zones to `rebind_allowlist`.
     /// Default false.
     #[serde(default)]
     pub rebind_protect: bool,

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -147,16 +147,12 @@ pub async fn resolve_query(
     }
 
     // Rebind protection, after DNSSEC validation + the unfiltered cache insert
-    // above, before shaping. Gated by *exclusion*, not inclusion: only the
-    // trusted-local paths (zones/special-use, ephemeral overrides, blocklist
-    // sinkhole) legitimately return private IPs and are exempt. Everything else
-    // — recursive/forward/upstream/cache, and any future untrusted source such
-    // as pkarr (#225) — is filtered by default, so a new path can't silently
-    // ship unprotected. UpstreamError carries no answers, so it's a no-op.
-    if !matches!(
-        path,
-        QueryPath::Local | QueryPath::Overridden | QueryPath::Blocked
-    ) {
+    // above, before shaping. Gated by *exclusion* (see
+    // `QueryPath::returns_trusted_local_data`): only trusted-local paths are
+    // exempt, so any future untrusted source — recursive/forward/upstream/cache
+    // or pkarr (#225) — is filtered by default and can't silently ship
+    // unprotected. UpstreamError carries no answers, so it's a no-op.
+    if !path.returns_trusted_local_data() {
         let stripped = ctx.rebind.apply(&qname, &mut response);
         if stripped > 0 {
             // A stripped Secure answer is no longer the validated one; don't

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -85,6 +85,7 @@ pub struct ServerCtx {
     pub filter_aaaa: bool,
     pub allow_from: crate::acl::AllowFromAcl,
     pub client_policy: crate::client_policy::ClientPolicySet,
+    pub rebind: crate::rebind::RebindFilter,
 }
 
 /// Transport-agnostic DNS resolution. Runs the full pipeline (overrides, blocklist,
@@ -143,6 +144,32 @@ pub async fn resolve_query(
             .write()
             .unwrap()
             .insert_with_status(&qname, qtype, &response, status);
+    }
+
+    // Rebind protection: runs only on untrusted (remote/cache) paths, after
+    // DNSSEC validation + the unfiltered cache insert above, before shaping.
+    // Local paths (overrides, zones, `.numa`, blocklist sinkhole) legitimately
+    // return private IPs and are exempt by construction.
+    if matches!(
+        path,
+        QueryPath::Recursive
+            | QueryPath::Forwarded
+            | QueryPath::Upstream
+            | QueryPath::Cached
+            | QueryPath::Coalesced
+    ) {
+        let stripped = ctx.rebind.apply(&qname, &mut response);
+        if stripped > 0 {
+            // A stripped Secure answer is no longer the validated one; don't
+            // claim AD over a NODATA the validator never proved.
+            response.header.authed_data = false;
+            info!(
+                "REBIND | {} | stripped {} private RR(s) | {}",
+                qname,
+                stripped,
+                path.as_str()
+            );
+        }
     }
 
     shape_response_for_client(&mut response, &query, ctx.filter_aaaa);
@@ -1357,6 +1384,60 @@ mod tests {
             "forwarding rule must take precedence over special-use NXDOMAIN"
         );
         assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+    }
+
+    #[tokio::test]
+    async fn pipeline_rebind_strips_private_from_forwarded() {
+        let mut resp = DnsPacket::new();
+        resp.header.response = true;
+        resp.header.rescode = ResultCode::NOERROR;
+        resp.answers.push(DnsRecord::A {
+            domain: "intranet.evil.test".to_string(),
+            addr: "192.168.1.1".parse().unwrap(),
+            ttl: 60,
+        });
+        let upstream_addr = crate::testutil::mock_upstream(resp).await;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.rebind = crate::rebind::RebindFilter::new(true, &[], &[]).unwrap();
+        ctx.forwarding_rules = vec![ForwardingRule::new(
+            "evil.test".to_string(),
+            UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]),
+        )];
+        let ctx = Arc::new(ctx);
+
+        let (resp, path) = resolve_in_test(&ctx, "intranet.evil.test", QueryType::A).await;
+        assert_eq!(path, QueryPath::Forwarded);
+        assert_eq!(
+            resp.header.rescode,
+            ResultCode::NOERROR,
+            "all-stripped is NODATA, not NXDOMAIN"
+        );
+        assert!(resp.answers.is_empty(), "private answer must be stripped");
+    }
+
+    #[tokio::test]
+    async fn pipeline_rebind_leaves_local_override_untouched() {
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.rebind = crate::rebind::RebindFilter::new(true, &[], &[]).unwrap();
+        ctx.overrides
+            .write()
+            .unwrap()
+            .insert("nas.local", "192.168.1.50", 60, None)
+            .unwrap();
+        let ctx = Arc::new(ctx);
+
+        let (resp, path) = resolve_in_test(&ctx, "nas.local", QueryType::A).await;
+        assert_eq!(
+            path,
+            QueryPath::Overridden,
+            "local path is exempt by gating"
+        );
+        assert_eq!(
+            resp.answers.len(),
+            1,
+            "override's private IP must not be stripped"
+        );
     }
 
     #[tokio::test]

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -146,12 +146,9 @@ pub async fn resolve_query(
             .insert_with_status(&qname, qtype, &response, status);
     }
 
-    // Rebind protection, after DNSSEC validation + the unfiltered cache insert
-    // above, before shaping. Gated by *exclusion* (see
-    // `QueryPath::returns_trusted_local_data`): only trusted-local paths are
-    // exempt, so any future untrusted source — recursive/forward/upstream/cache
-    // or pkarr (#225) — is filtered by default and can't silently ship
-    // unprotected. UpstreamError carries no answers, so it's a no-op.
+    // Runs after DNSSEC validation + the unfiltered cache insert above (so the
+    // cache keeps the true record), before shaping. UpstreamError carries no
+    // answers, so it's a no-op.
     if !path.returns_trusted_local_data() {
         let stripped = ctx.rebind.apply(&qname, &mut response);
         if stripped > 0 {

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -146,17 +146,16 @@ pub async fn resolve_query(
             .insert_with_status(&qname, qtype, &response, status);
     }
 
-    // Rebind protection: runs only on untrusted (remote/cache) paths, after
-    // DNSSEC validation + the unfiltered cache insert above, before shaping.
-    // Local paths (overrides, zones, `.numa`, blocklist sinkhole) legitimately
-    // return private IPs and are exempt by construction.
-    if matches!(
+    // Rebind protection, after DNSSEC validation + the unfiltered cache insert
+    // above, before shaping. Gated by *exclusion*, not inclusion: only the
+    // trusted-local paths (zones/special-use, ephemeral overrides, blocklist
+    // sinkhole) legitimately return private IPs and are exempt. Everything else
+    // — recursive/forward/upstream/cache, and any future untrusted source such
+    // as pkarr (#225) — is filtered by default, so a new path can't silently
+    // ship unprotected. UpstreamError carries no answers, so it's a no-op.
+    if !matches!(
         path,
-        QueryPath::Recursive
-            | QueryPath::Forwarded
-            | QueryPath::Upstream
-            | QueryPath::Cached
-            | QueryPath::Coalesced
+        QueryPath::Local | QueryPath::Overridden | QueryPath::Blocked
     ) {
         let stripped = ctx.rebind.apply(&qname, &mut response);
         if stripped > 0 {
@@ -1438,6 +1437,27 @@ mod tests {
             1,
             "override's private IP must not be stripped"
         );
+    }
+
+    #[tokio::test]
+    async fn pipeline_rebind_leaves_blocklist_sinkhole_untouched() {
+        // The Blocked path returns 0.0.0.0, which IS in the default rebind
+        // ranges — so the exclusion gate must exempt it, or rebind protection
+        // would silently eat ad-blocking.
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.rebind = crate::rebind::RebindFilter::new(true, &[], &[]).unwrap();
+        let mut domains = std::collections::HashSet::new();
+        domains.insert("ads.tracker.test".to_string());
+        ctx.blocklist.write().unwrap().swap_domains(domains, vec![]);
+        let ctx = Arc::new(ctx);
+
+        let (resp, path) = resolve_in_test(&ctx, "ads.tracker.test", QueryType::A).await;
+        assert_eq!(path, QueryPath::Blocked);
+        assert_eq!(resp.answers.len(), 1, "sinkhole answer must survive rebind");
+        match &resp.answers[0] {
+            DnsRecord::A { addr, .. } => assert_eq!(*addr, Ipv4Addr::UNSPECIFIED),
+            other => panic!("expected sinkhole A record, got {:?}", other),
+        }
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod pp2_udp;
 pub mod proxy;
 pub mod query_log;
 pub mod question;
+pub mod rebind;
 pub mod record;
 pub mod recursive;
 pub mod relay;

--- a/src/rebind.rs
+++ b/src/rebind.rs
@@ -1,0 +1,231 @@
+//! DNS rebinding protection (#240). Strips private/special-use addresses from
+//! answers that came from an untrusted upstream path, so a public hostname
+//! can't be rebound to an address inside the client's perimeter. Off by
+//! default; opt-in via `[server] rebind_protect`. Local data (zones,
+//! overrides, `.numa`, blocklist sinkhole) resolves on a different
+//! `QueryPath` and never reaches this filter — see `resolve_query`.
+
+use std::net::IpAddr;
+
+use crate::acl::CidrMatcher;
+use crate::packet::DnsPacket;
+use crate::question::QueryType;
+use crate::record::DnsRecord;
+
+/// Built-in private/special-use ranges, used when `rebind_private_ranges` is
+/// empty. Loopback (`127.0.0.0/8`, `::1`) is deliberately omitted: it collides
+/// with the blocklist's `0.0.0.0` sinkhole and with DNSBLs that return
+/// `127.0.0.x` as a positive signal. IPv4-mapped IPv6 (`::ffff:a.b.c.d`) needs
+/// no entry — `CidrMatcher` canonicalizes before matching, so a mapped private
+/// address already matches the v4 ranges.
+const DEFAULT_RANGES: &[&str] = &[
+    "10.0.0.0/8",     // RFC 1918
+    "172.16.0.0/12",  // RFC 1918
+    "192.168.0.0/16", // RFC 1918
+    "169.254.0.0/16", // RFC 3927 link-local
+    "0.0.0.0/8",      // RFC 1122 "this host" — localhost-mapped on Linux/macOS
+    "fc00::/7",       // RFC 4193 ULA
+    "fe80::/10",      // RFC 4291 link-local
+    "::/128",         // unspecified
+];
+
+#[derive(Clone, Debug, Default)]
+pub struct RebindFilter {
+    enabled: bool,
+    ranges: CidrMatcher,
+    allowlist: Vec<String>, // normalized: lowercase, no trailing dot
+}
+
+impl RebindFilter {
+    pub fn new(
+        enabled: bool,
+        allowlist: &[String],
+        custom_ranges: &[String],
+    ) -> Result<Self, String> {
+        let ranges = if custom_ranges.is_empty() {
+            let defaults: Vec<String> = DEFAULT_RANGES.iter().map(|s| s.to_string()).collect();
+            CidrMatcher::from_entries(&defaults, &[], "rebind_private_ranges")?
+        } else {
+            CidrMatcher::from_entries(custom_ranges, &[], "rebind_private_ranges")?
+        };
+        Ok(RebindFilter {
+            enabled,
+            ranges,
+            allowlist: allowlist.iter().map(|d| normalize(d)).collect(),
+        })
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Strip private A/AAAA answers (and private SVCB/HTTPS address hints) from
+    /// `response`. Returns the count of records removed or hint-scrubbed — 0 if
+    /// disabled, allowlisted, or nothing private. The caller logs and clears
+    /// `authed_data` when the count is > 0.
+    pub fn apply(&self, qname: &str, response: &mut DnsPacket) -> usize {
+        if !self.enabled || self.is_allowed(qname) {
+            return 0;
+        }
+        let is_private = |ip: IpAddr| self.ranges.matches(ip);
+
+        let before = response.answers.len();
+        response.answers.retain(|r| match r {
+            DnsRecord::A { addr, .. } => !is_private(IpAddr::V4(*addr)),
+            DnsRecord::AAAA { addr, .. } => !is_private(IpAddr::V6(*addr)),
+            _ => true,
+        });
+        let mut acted = before - response.answers.len();
+
+        let https = QueryType::HTTPS.to_num();
+        let svcb = QueryType::SVCB.to_num();
+        for rec in &mut response.answers {
+            if let DnsRecord::UNKNOWN { qtype, data, .. } = rec {
+                if *qtype == https || *qtype == svcb {
+                    if let Some(scrubbed) = crate::svcb::strip_private_hints(data, is_private) {
+                        *data = scrubbed;
+                        acted += 1;
+                    }
+                }
+            }
+        }
+        acted
+    }
+
+    /// Exact-or-parent suffix match, mirroring `BlocklistStore` semantics:
+    /// `example.com` covers `nas.example.com` but never `evilexample.com`.
+    fn is_allowed(&self, qname: &str) -> bool {
+        if self.allowlist.is_empty() {
+            return false;
+        }
+        let q = normalize(qname);
+        let mut d = q.as_str();
+        loop {
+            if self.allowlist.iter().any(|e| e == d) {
+                return true;
+            }
+            match d.find('.') {
+                Some(dot) => d = &d[dot + 1..],
+                None => return false,
+            }
+        }
+    }
+}
+
+fn normalize(domain: &str) -> String {
+    domain.to_lowercase().trim_end_matches('.').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn filter(allowlist: &[&str]) -> RebindFilter {
+        RebindFilter::new(
+            true,
+            &allowlist.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            &[],
+        )
+        .unwrap()
+    }
+
+    fn a(addr: &str) -> DnsRecord {
+        DnsRecord::A {
+            domain: "host.example.".into(),
+            addr: addr.parse::<Ipv4Addr>().unwrap(),
+            ttl: 60,
+        }
+    }
+
+    fn aaaa(addr: &str) -> DnsRecord {
+        DnsRecord::AAAA {
+            domain: "host.example.".into(),
+            addr: addr.parse::<Ipv6Addr>().unwrap(),
+            ttl: 60,
+        }
+    }
+
+    fn packet(answers: Vec<DnsRecord>) -> DnsPacket {
+        let mut p = DnsPacket::new();
+        p.answers = answers;
+        p
+    }
+
+    #[test]
+    fn strips_rfc1918_v4() {
+        let f = filter(&[]);
+        let mut p = packet(vec![a("8.8.8.8"), a("192.168.1.1"), a("10.0.0.5")]);
+        assert_eq!(f.apply("evil.com", &mut p), 2);
+        assert_eq!(p.answers, vec![a("8.8.8.8")]);
+    }
+
+    #[test]
+    fn strips_link_local_and_this_host() {
+        let f = filter(&[]);
+        let mut p = packet(vec![a("169.254.1.1"), a("0.0.0.0"), a("1.1.1.1")]);
+        assert_eq!(f.apply("evil.com", &mut p), 2);
+        assert_eq!(p.answers, vec![a("1.1.1.1")]);
+    }
+
+    #[test]
+    fn strips_ula_and_link_local_v6() {
+        let f = filter(&[]);
+        let mut p = packet(vec![aaaa("2606:4700::1"), aaaa("fd00::1"), aaaa("fe80::1")]);
+        assert_eq!(f.apply("evil.com", &mut p), 2);
+        assert_eq!(p.answers, vec![aaaa("2606:4700::1")]);
+    }
+
+    #[test]
+    fn strips_v4_mapped_private_v6() {
+        // ::ffff:192.168.1.1 canonicalizes to the v4 range — no explicit
+        // ::ffff:0:0/96 entry needed.
+        let f = filter(&[]);
+        let mut p = packet(vec![aaaa("::ffff:192.168.1.1"), aaaa("::ffff:8.8.8.8")]);
+        assert_eq!(f.apply("evil.com", &mut p), 1);
+        assert_eq!(p.answers, vec![aaaa("::ffff:8.8.8.8")]);
+    }
+
+    #[test]
+    fn loopback_not_stripped_by_default() {
+        let f = filter(&[]);
+        let mut p = packet(vec![a("127.0.0.1")]);
+        assert_eq!(f.apply("evil.com", &mut p), 0);
+    }
+
+    #[test]
+    fn allowlist_suffix_exempts_subdomain_not_lookalike() {
+        let f = filter(&["example.com"]);
+        let mut nas = packet(vec![a("192.168.1.50")]);
+        assert_eq!(f.apply("nas.example.com", &mut nas), 0, "subdomain exempt");
+
+        let mut evil = packet(vec![a("192.168.1.50")]);
+        assert_eq!(
+            f.apply("evilexample.com", &mut evil),
+            1,
+            "lookalike not exempt"
+        );
+    }
+
+    #[test]
+    fn disabled_passes_through() {
+        let f = RebindFilter::new(false, &[], &[]).unwrap();
+        let mut p = packet(vec![a("192.168.1.1")]);
+        assert_eq!(f.apply("evil.com", &mut p), 0);
+        assert_eq!(p.answers.len(), 1);
+    }
+
+    #[test]
+    fn custom_ranges_override_defaults() {
+        // Only block ULA; RFC1918 v4 now passes.
+        let f = RebindFilter::new(true, &[], &["fc00::/7".to_string()]).unwrap();
+        let mut p = packet(vec![a("192.168.1.1"), aaaa("fd00::1")]);
+        assert_eq!(f.apply("evil.com", &mut p), 1);
+        assert_eq!(p.answers, vec![a("192.168.1.1")]);
+    }
+
+    #[test]
+    fn invalid_custom_range_errors() {
+        assert!(RebindFilter::new(true, &[], &["not-a-cidr".to_string()]).is_err());
+    }
+}

--- a/src/rebind.rs
+++ b/src/rebind.rs
@@ -100,21 +100,16 @@ impl RebindFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::{Ipv4Addr, Ipv6Addr};
 
     fn filter(allowlist: &[&str]) -> RebindFilter {
-        RebindFilter::new(
-            true,
-            &allowlist.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
-            &[],
-        )
-        .unwrap()
+        let allow: Vec<String> = allowlist.iter().map(|s| s.to_string()).collect();
+        RebindFilter::new(true, &allow, &[]).unwrap()
     }
 
     fn a(addr: &str) -> DnsRecord {
         DnsRecord::A {
             domain: "host.example.".into(),
-            addr: addr.parse::<Ipv4Addr>().unwrap(),
+            addr: addr.parse().unwrap(),
             ttl: 60,
         }
     }
@@ -122,57 +117,53 @@ mod tests {
     fn aaaa(addr: &str) -> DnsRecord {
         DnsRecord::AAAA {
             domain: "host.example.".into(),
-            addr: addr.parse::<Ipv6Addr>().unwrap(),
+            addr: addr.parse().unwrap(),
             ttl: 60,
         }
     }
 
-    fn packet(answers: Vec<DnsRecord>) -> DnsPacket {
+    /// Apply `f` to `answers` for `qname`; return (count stripped, survivors).
+    fn run(f: &RebindFilter, qname: &str, answers: Vec<DnsRecord>) -> (usize, Vec<DnsRecord>) {
         let mut p = DnsPacket::new();
         p.answers = answers;
-        p
+        let n = f.apply(qname, &mut p);
+        (n, p.answers)
+    }
+
+    /// The common case: default ranges, no allowlist, throwaway public qname.
+    fn strip(answers: Vec<DnsRecord>) -> (usize, Vec<DnsRecord>) {
+        run(&filter(&[]), "evil.com", answers)
     }
 
     #[test]
     fn strips_rfc1918_v4() {
-        let f = filter(&[]);
-        let mut p = packet(vec![a("8.8.8.8"), a("192.168.1.1"), a("10.0.0.5")]);
-        assert_eq!(f.apply("evil.com", &mut p), 2);
-        assert_eq!(p.answers, vec![a("8.8.8.8")]);
+        let r = strip(vec![a("8.8.8.8"), a("192.168.1.1"), a("10.0.0.5")]);
+        assert_eq!(r, (2, vec![a("8.8.8.8")]));
     }
 
     #[test]
     fn strips_link_local_and_this_host() {
-        let f = filter(&[]);
-        let mut p = packet(vec![a("169.254.1.1"), a("0.0.0.0"), a("1.1.1.1")]);
-        assert_eq!(f.apply("evil.com", &mut p), 2);
-        assert_eq!(p.answers, vec![a("1.1.1.1")]);
+        let r = strip(vec![a("169.254.1.1"), a("0.0.0.0"), a("1.1.1.1")]);
+        assert_eq!(r, (2, vec![a("1.1.1.1")]));
     }
 
     #[test]
     fn strips_ula_and_link_local_v6() {
-        let f = filter(&[]);
-        let mut p = packet(vec![aaaa("2606:4700::1"), aaaa("fd00::1"), aaaa("fe80::1")]);
-        assert_eq!(f.apply("evil.com", &mut p), 2);
-        assert_eq!(p.answers, vec![aaaa("2606:4700::1")]);
+        let r = strip(vec![aaaa("2606:4700::1"), aaaa("fd00::1"), aaaa("fe80::1")]);
+        assert_eq!(r, (2, vec![aaaa("2606:4700::1")]));
     }
 
     #[test]
     fn strips_v4_mapped_private_v6() {
         // ::ffff:192.168.1.1 canonicalizes to the v4 range — no explicit
         // ::ffff:0:0/96 entry needed.
-        let f = filter(&[]);
-        let mut p = packet(vec![aaaa("::ffff:192.168.1.1"), aaaa("::ffff:8.8.8.8")]);
-        assert_eq!(f.apply("evil.com", &mut p), 1);
-        assert_eq!(p.answers, vec![aaaa("::ffff:8.8.8.8")]);
+        let r = strip(vec![aaaa("::ffff:192.168.1.1"), aaaa("::ffff:8.8.8.8")]);
+        assert_eq!(r, (1, vec![aaaa("::ffff:8.8.8.8")]));
     }
 
     #[test]
     fn loopback_stripped_by_default() {
-        let f = filter(&[]);
-        let mut p = packet(vec![a("127.0.0.1"), aaaa("::1")]);
-        assert_eq!(f.apply("evil.com", &mut p), 2);
-        assert!(p.answers.is_empty());
+        assert_eq!(strip(vec![a("127.0.0.1"), aaaa("::1")]), (2, vec![]));
     }
 
     #[test]
@@ -180,19 +171,23 @@ mod tests {
         // RBL lookups legitimately resolve to 127.0.0.x; allowlisting the zone
         // exempts them from the loopback strip.
         let f = filter(&["spamhaus.org"]);
-        let mut p = packet(vec![a("127.0.0.2")]);
-        assert_eq!(f.apply("2.0.0.127.zen.spamhaus.org", &mut p), 0);
+        assert_eq!(
+            run(&f, "2.0.0.127.zen.spamhaus.org", vec![a("127.0.0.2")]).0,
+            0
+        );
     }
 
     #[test]
     fn allowlist_suffix_exempts_subdomain_not_lookalike() {
         let f = filter(&["example.com"]);
-        let mut nas = packet(vec![a("192.168.1.50")]);
-        assert_eq!(f.apply("nas.example.com", &mut nas), 0, "subdomain exempt");
-
-        let mut evil = packet(vec![a("192.168.1.50")]);
+        let priv_a = vec![a("192.168.1.50")];
         assert_eq!(
-            f.apply("evilexample.com", &mut evil),
+            run(&f, "nas.example.com", priv_a.clone()).0,
+            0,
+            "subdomain exempt"
+        );
+        assert_eq!(
+            run(&f, "evilexample.com", priv_a).0,
             1,
             "lookalike not exempt"
         );
@@ -201,18 +196,18 @@ mod tests {
     #[test]
     fn disabled_passes_through() {
         let f = RebindFilter::new(false, &[], &[]).unwrap();
-        let mut p = packet(vec![a("192.168.1.1")]);
-        assert_eq!(f.apply("evil.com", &mut p), 0);
-        assert_eq!(p.answers.len(), 1);
+        assert_eq!(
+            run(&f, "evil.com", vec![a("192.168.1.1")]),
+            (0, vec![a("192.168.1.1")])
+        );
     }
 
     #[test]
     fn custom_ranges_override_defaults() {
         // Only block ULA; RFC1918 v4 now passes.
         let f = RebindFilter::new(true, &[], &["fc00::/7".to_string()]).unwrap();
-        let mut p = packet(vec![a("192.168.1.1"), aaaa("fd00::1")]);
-        assert_eq!(f.apply("evil.com", &mut p), 1);
-        assert_eq!(p.answers, vec![a("192.168.1.1")]);
+        let r = run(&f, "evil.com", vec![a("192.168.1.1"), aaaa("fd00::1")]);
+        assert_eq!(r, (1, vec![a("192.168.1.1")]));
     }
 
     #[test]

--- a/src/rebind.rs
+++ b/src/rebind.rs
@@ -13,12 +13,9 @@ use crate::question::QueryType;
 use crate::record::DnsRecord;
 
 /// Built-in private/special-use ranges, used when `rebind_private_ranges` is
-/// empty. Loopback is included — it's the canonical rebind target (localhost
-/// dev servers, Docker/Electron dashboards). DNSBL/RBL users (mail servers
-/// resolving `127.0.0.x` from zones like `zen.spamhaus.org`) and upstreams
-/// that sinkhole ads to `127.0.0.1` should allowlist those names. IPv4-mapped
-/// IPv6 (`::ffff:a.b.c.d`) needs no entry — `CidrMatcher` canonicalizes before
-/// matching, so a mapped private address already matches the v4 ranges.
+/// empty. Loopback is included — it's a prime rebind target (localhost dev
+/// servers, Docker/Electron dashboards); DNSBL/RBL users that resolve
+/// `127.0.0.x` should allowlist those zones.
 const DEFAULT_RANGES: &[&str] = &[
     "127.0.0.0/8",    // RFC 1122 loopback — the canonical rebind target
     "10.0.0.0/8",     // RFC 1918
@@ -95,8 +92,6 @@ impl RebindFilter {
         acted
     }
 
-    /// Exact-or-parent suffix match (shared with `BlocklistStore`):
-    /// `example.com` covers `nas.example.com` but never `evilexample.com`.
     fn is_allowed(&self, qname: &str) -> bool {
         !self.allowlist.is_empty() && find_in_set(&normalize(qname), &self.allowlist).is_some()
     }

--- a/src/rebind.rs
+++ b/src/rebind.rs
@@ -3,9 +3,11 @@
 //! client's perimeter. Off by default. Runs only on remote/cache paths; local
 //! data (zones, overrides, `.numa`, sinkhole) is exempt by gating in `ctx.rs`.
 
+use std::collections::HashSet;
 use std::net::IpAddr;
 
 use crate::acl::CidrMatcher;
+use crate::blocklist::{find_in_set, normalize};
 use crate::packet::DnsPacket;
 use crate::question::QueryType;
 use crate::record::DnsRecord;
@@ -34,7 +36,7 @@ const DEFAULT_RANGES: &[&str] = &[
 pub struct RebindFilter {
     enabled: bool,
     ranges: CidrMatcher,
-    allowlist: Vec<String>, // normalized: lowercase, no trailing dot
+    allowlist: HashSet<String>, // normalized: lowercase, no trailing dot
 }
 
 impl RebindFilter {
@@ -93,28 +95,11 @@ impl RebindFilter {
         acted
     }
 
-    /// Exact-or-parent suffix match, mirroring `BlocklistStore` semantics:
+    /// Exact-or-parent suffix match (shared with `BlocklistStore`):
     /// `example.com` covers `nas.example.com` but never `evilexample.com`.
     fn is_allowed(&self, qname: &str) -> bool {
-        if self.allowlist.is_empty() {
-            return false;
-        }
-        let q = normalize(qname);
-        let mut d = q.as_str();
-        loop {
-            if self.allowlist.iter().any(|e| e == d) {
-                return true;
-            }
-            match d.find('.') {
-                Some(dot) => d = &d[dot + 1..],
-                None => return false,
-            }
-        }
+        !self.allowlist.is_empty() && find_in_set(&normalize(qname), &self.allowlist).is_some()
     }
-}
-
-fn normalize(domain: &str) -> String {
-    domain.to_lowercase().trim_end_matches('.').to_string()
 }
 
 #[cfg(test)]

--- a/src/rebind.rs
+++ b/src/rebind.rs
@@ -1,9 +1,7 @@
-//! DNS rebinding protection (#240). Strips private/special-use addresses from
-//! answers that came from an untrusted upstream path, so a public hostname
-//! can't be rebound to an address inside the client's perimeter. Off by
-//! default; opt-in via `[server] rebind_protect`. Local data (zones,
-//! overrides, `.numa`, blocklist sinkhole) resolves on a different
-//! `QueryPath` and never reaches this filter — see `resolve_query`.
+//! DNS rebinding protection (#240): strip private/special-use addresses from
+//! upstream answers so a public name can't resolve to an address inside the
+//! client's perimeter. Off by default. Runs only on remote/cache paths; local
+//! data (zones, overrides, `.numa`, sinkhole) is exempt by gating in `ctx.rs`.
 
 use std::net::IpAddr;
 
@@ -13,19 +11,22 @@ use crate::question::QueryType;
 use crate::record::DnsRecord;
 
 /// Built-in private/special-use ranges, used when `rebind_private_ranges` is
-/// empty. Loopback (`127.0.0.0/8`, `::1`) is deliberately omitted: it collides
-/// with the blocklist's `0.0.0.0` sinkhole and with DNSBLs that return
-/// `127.0.0.x` as a positive signal. IPv4-mapped IPv6 (`::ffff:a.b.c.d`) needs
-/// no entry — `CidrMatcher` canonicalizes before matching, so a mapped private
-/// address already matches the v4 ranges.
+/// empty. Loopback is included — it's the canonical rebind target (localhost
+/// dev servers, Docker/Electron dashboards). DNSBL/RBL users (mail servers
+/// resolving `127.0.0.x` from zones like `zen.spamhaus.org`) and upstreams
+/// that sinkhole ads to `127.0.0.1` should allowlist those names. IPv4-mapped
+/// IPv6 (`::ffff:a.b.c.d`) needs no entry — `CidrMatcher` canonicalizes before
+/// matching, so a mapped private address already matches the v4 ranges.
 const DEFAULT_RANGES: &[&str] = &[
+    "127.0.0.0/8",    // RFC 1122 loopback — the canonical rebind target
     "10.0.0.0/8",     // RFC 1918
     "172.16.0.0/12",  // RFC 1918
     "192.168.0.0/16", // RFC 1918
     "169.254.0.0/16", // RFC 3927 link-local
-    "0.0.0.0/8",      // RFC 1122 "this host" — localhost-mapped on Linux/macOS
+    "0.0.0.0/8",      // RFC 1122 "this host" — 0.0.0.0 routes to localhost on connect
     "fc00::/7",       // RFC 4193 ULA
     "fe80::/10",      // RFC 4291 link-local
+    "::1/128",        // loopback
     "::/128",         // unspecified
 ];
 
@@ -187,10 +188,20 @@ mod tests {
     }
 
     #[test]
-    fn loopback_not_stripped_by_default() {
+    fn loopback_stripped_by_default() {
         let f = filter(&[]);
-        let mut p = packet(vec![a("127.0.0.1")]);
-        assert_eq!(f.apply("evil.com", &mut p), 0);
+        let mut p = packet(vec![a("127.0.0.1"), aaaa("::1")]);
+        assert_eq!(f.apply("evil.com", &mut p), 2);
+        assert!(p.answers.is_empty());
+    }
+
+    #[test]
+    fn allowlisted_dnsbl_zone_keeps_127_response() {
+        // RBL lookups legitimately resolve to 127.0.0.x; allowlisting the zone
+        // exempts them from the loopback strip.
+        let f = filter(&["spamhaus.org"]);
+        let mut p = packet(vec![a("127.0.0.2")]);
+        assert_eq!(f.apply("2.0.0.127.zen.spamhaus.org", &mut p), 0);
     }
 
     #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -140,6 +140,24 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         );
     }
 
+    let rebind = crate::rebind::RebindFilter::new(
+        config.server.rebind_protect,
+        &config.server.rebind_allowlist,
+        &config.server.rebind_private_ranges,
+    )
+    .map_err(|e| format!("invalid [server] rebind config: {e}"))?;
+    if rebind.is_enabled() {
+        info!(
+            "DNS rebinding protection enabled ({} allowlist entr{})",
+            config.server.rebind_allowlist.len(),
+            if config.server.rebind_allowlist.len() == 1 {
+                "y"
+            } else {
+                "ies"
+            }
+        );
+    }
+
     let sockets = bind_udp_listeners(&config.server.bind_addr).await?;
 
     let ctx = Arc::new(ServerCtx {
@@ -189,6 +207,7 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         filter_aaaa: config.server.filter_aaaa,
         allow_from,
         client_policy,
+        rebind,
     });
 
     let zone_count: usize = ctx.zone_map.len();

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -148,13 +148,8 @@ pub async fn run(config_path: String) -> crate::Result<()> {
     .map_err(|e| format!("invalid [server] rebind config: {e}"))?;
     if rebind.is_enabled() {
         info!(
-            "DNS rebinding protection enabled ({} allowlist entr{})",
-            config.server.rebind_allowlist.len(),
-            if config.server.rebind_allowlist.len() == 1 {
-                "y"
-            } else {
-                "ies"
-            }
+            "DNS rebinding protection enabled ({} allowlist entries)",
+            config.server.rebind_allowlist.len()
         );
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -213,10 +213,9 @@ impl QueryPath {
         }
     }
 
-    /// True for paths that return trusted local data (zones/special-use,
-    /// ephemeral overrides, blocklist sinkhole) and are therefore exempt from
-    /// rebind protection. Exhaustive on purpose: adding a `QueryPath` variant
-    /// forces a trust decision here, so a new (untrusted) source fails closed.
+    /// Paths returning trusted local data (zones, overrides, sinkhole) — exempt
+    /// from rebind protection. Exhaustive on purpose: a new `QueryPath` variant
+    /// must choose a side here, so an untrusted source fails closed.
     pub fn returns_trusted_local_data(&self) -> bool {
         match self {
             QueryPath::Local | QueryPath::Overridden | QueryPath::Blocked => true,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -213,6 +213,22 @@ impl QueryPath {
         }
     }
 
+    /// True for paths that return trusted local data (zones/special-use,
+    /// ephemeral overrides, blocklist sinkhole) and are therefore exempt from
+    /// rebind protection. Exhaustive on purpose: adding a `QueryPath` variant
+    /// forces a trust decision here, so a new (untrusted) source fails closed.
+    pub fn returns_trusted_local_data(&self) -> bool {
+        match self {
+            QueryPath::Local | QueryPath::Overridden | QueryPath::Blocked => true,
+            QueryPath::Cached
+            | QueryPath::Forwarded
+            | QueryPath::Upstream
+            | QueryPath::Recursive
+            | QueryPath::Coalesced
+            | QueryPath::UpstreamError => false,
+        }
+    }
+
     pub fn parse_str(s: &str) -> Option<QueryPath> {
         if s.eq_ignore_ascii_case("LOCAL") {
             Some(QueryPath::Local)

--- a/src/svcb.rs
+++ b/src/svcb.rs
@@ -30,7 +30,6 @@ fn skip_target_name(rdata: &[u8], mut pos: usize) -> Option<usize> {
     }
 }
 
-/// Address stride for a hint key: 4 bytes per `ipv4hint`, 16 per `ipv6hint`.
 fn hint_stride(key: u16) -> Option<usize> {
     match key {
         IPV4_HINT_KEY => Some(4),

--- a/src/svcb.rs
+++ b/src/svcb.rs
@@ -1,10 +1,131 @@
-//! Minimal SVCB/HTTPS (RFC 9460) RDATA parser — just enough to strip
-//! the `ipv6hint` SvcParam. Used by the `filter_aaaa` feature so
-//! HTTPS-record-aware clients (Chrome ≥103, Firefox, Safari) don't
-//! receive v6 address hints on IPv4-only networks.
+//! Minimal SVCB/HTTPS (RFC 9460) RDATA parser. Two consumers:
+//! `filter_aaaa` strips the whole `ipv6hint` SvcParam (so IPv4-only clients
+//! see no v6 hints); rebind protection drops only the *private* addresses
+//! from `ipv4hint`/`ipv6hint` (so a public name can't smuggle a private
+//! address through a hint).
 
-/// SvcParamKey = 6 (RFC 9460 §14.3.2).
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// SvcParamKey = 4 / 6 (RFC 9460 §14.3.2): `ipv4hint` / `ipv6hint`.
+const IPV4_HINT_KEY: u16 = 4;
 const IPV6_HINT_KEY: u16 = 6;
+
+/// Skip the SVCB TargetName beginning at `pos`, returning the offset of the
+/// first SvcParam. `None` if the name is truncated or uses a compression
+/// pointer (forbidden in SVCB RDATA).
+fn skip_target_name(rdata: &[u8], mut pos: usize) -> Option<usize> {
+    loop {
+        let len = *rdata.get(pos)? as usize;
+        pos += 1;
+        if len == 0 {
+            return Some(pos);
+        }
+        if len & 0xC0 != 0 {
+            return None;
+        }
+        pos = pos.checked_add(len)?;
+        if pos > rdata.len() {
+            return None;
+        }
+    }
+}
+
+/// Address stride for a hint key: 4 bytes per `ipv4hint`, 16 per `ipv6hint`.
+fn hint_stride(key: u16) -> Option<usize> {
+    match key {
+        IPV4_HINT_KEY => Some(4),
+        IPV6_HINT_KEY => Some(16),
+        _ => None,
+    }
+}
+
+fn hint_addr(chunk: &[u8]) -> IpAddr {
+    match chunk.len() {
+        4 => IpAddr::V4(Ipv4Addr::new(chunk[0], chunk[1], chunk[2], chunk[3])),
+        _ => {
+            let mut b = [0u8; 16];
+            b.copy_from_slice(chunk);
+            IpAddr::V6(Ipv6Addr::from(b))
+        }
+    }
+}
+
+/// Concatenated `stride`-byte addresses, keeping only those `is_private`
+/// rejects. Order is preserved.
+fn filter_hint(value: &[u8], stride: usize, is_private: &impl Fn(IpAddr) -> bool) -> Vec<u8> {
+    let mut out = Vec::with_capacity(value.len());
+    for chunk in value.chunks_exact(stride) {
+        if !is_private(hint_addr(chunk)) {
+            out.extend_from_slice(chunk);
+        }
+    }
+    out
+}
+
+/// Strip private address values from `ipv4hint`/`ipv6hint` SvcParams, keeping
+/// public ones. A hint left empty is dropped entirely; all other SvcParams
+/// (alpn, port, ech, …) are preserved untouched. `is_private` receives the
+/// address as-is — callers that canonicalize v4-mapped IPv6 (e.g.
+/// `CidrMatcher`) catch `::ffff:10.0.0.1` via their v4 ranges.
+///
+/// Returns `Some(new_rdata)` if any private value was removed, `None` if
+/// nothing changed or the RDATA couldn't be parsed (caller keeps the
+/// original bytes).
+pub fn strip_private_hints(rdata: &[u8], is_private: impl Fn(IpAddr) -> bool) -> Option<Vec<u8>> {
+    if rdata.len() < 2 {
+        return None;
+    }
+    let params_start = skip_target_name(rdata, 2)?;
+
+    // Validate framing and decide whether a rebuild is needed.
+    let mut scan = params_start;
+    let mut changed = false;
+    while scan < rdata.len() {
+        if scan + 4 > rdata.len() {
+            return None;
+        }
+        let key = u16::from_be_bytes([rdata[scan], rdata[scan + 1]]);
+        let vlen = u16::from_be_bytes([rdata[scan + 2], rdata[scan + 3]]) as usize;
+        let end = scan.checked_add(4)?.checked_add(vlen)?;
+        if end > rdata.len() {
+            return None;
+        }
+        if let Some(stride) = hint_stride(key) {
+            if !vlen.is_multiple_of(stride) {
+                return None;
+            }
+            if filter_hint(&rdata[scan + 4..end], stride, &is_private).len() != vlen {
+                changed = true;
+            }
+        }
+        scan = end;
+    }
+    if scan != rdata.len() || !changed {
+        return None;
+    }
+
+    let mut out = Vec::with_capacity(rdata.len());
+    out.extend_from_slice(&rdata[..params_start]);
+    let mut pos = params_start;
+    while pos < rdata.len() {
+        let key = u16::from_be_bytes([rdata[pos], rdata[pos + 1]]);
+        let vlen = u16::from_be_bytes([rdata[pos + 2], rdata[pos + 3]]) as usize;
+        let end = pos + 4 + vlen;
+        match hint_stride(key) {
+            Some(stride) => {
+                let kept = filter_hint(&rdata[pos + 4..end], stride, &is_private);
+                if !kept.is_empty() {
+                    out.extend_from_slice(&key.to_be_bytes());
+                    out.extend_from_slice(&(kept.len() as u16).to_be_bytes());
+                    out.extend_from_slice(&kept);
+                }
+            }
+            None => out.extend_from_slice(&rdata[pos..end]),
+        }
+        pos = end;
+    }
+    Some(out)
+}
 
 /// Strip the `ipv6hint` SvcParam from an HTTPS/SVCB RDATA blob.
 ///
@@ -21,28 +142,10 @@ pub fn strip_ipv6hint(rdata: &[u8]) -> Option<Vec<u8>> {
     if rdata.len() < 2 {
         return None;
     }
-    let mut pos = 2;
-
-    // TargetName — uncompressed per RFC 9460 §2.2
-    loop {
-        let len = *rdata.get(pos)? as usize;
-        pos += 1;
-        if len == 0 {
-            break;
-        }
-        if len & 0xC0 != 0 {
-            // Pointer: forbidden in SVCB but defend against a broken upstream.
-            return None;
-        }
-        pos = pos.checked_add(len)?;
-        if pos > rdata.len() {
-            return None;
-        }
-    }
+    let params_start = skip_target_name(rdata, 2)?;
 
     // Scan params once to decide whether we need to rebuild.
-    let params_start = pos;
-    let mut scan = pos;
+    let mut scan = params_start;
     let mut has_ipv6hint = false;
     while scan < rdata.len() {
         if scan + 4 > rdata.len() {
@@ -175,5 +278,65 @@ mod tests {
         // key=6, length=0xFFFF but value is short — malformed.
         let rdata = vec![0, 1, 0, 0, 6, 0xFF, 0xFF, 0, 1, 2];
         assert!(strip_ipv6hint(&rdata).is_none());
+    }
+
+    fn is_priv(ip: std::net::IpAddr) -> bool {
+        match ip.to_canonical() {
+            std::net::IpAddr::V4(v4) => {
+                let o = v4.octets();
+                o[0] == 10 || (o[0] == 192 && o[1] == 168)
+            }
+            std::net::IpAddr::V6(v6) => v6.segments()[0] & 0xfe00 == 0xfc00, // fc00::/7
+        }
+    }
+
+    fn ipv4hint(addrs: &[[u8; 4]]) -> (u16, Vec<u8>) {
+        (4, addrs.concat())
+    }
+
+    fn ipv6hint(addrs: &[[u8; 16]]) -> (u16, Vec<u8>) {
+        (6, addrs.concat())
+    }
+
+    const PUB4: [u8; 4] = [93, 184, 216, 34];
+    const PRIV4: [u8; 4] = [192, 168, 1, 1];
+    const PUB6: [u8; 16] = [0x26, 0x06, 0x47, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]; // 2606:4700::1
+    const ULA6: [u8; 16] = [0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]; // fd00::1
+
+    #[test]
+    fn private_hints_keeps_public_drops_private() {
+        let rdata = build_rdata(1, &[], &[alpn_h3(), ipv4hint(&[PUB4, PRIV4])]);
+        let out = strip_private_hints(&rdata, is_priv).expect("private hint → rewritten");
+        let expected = build_rdata(1, &[], &[alpn_h3(), ipv4hint(&[PUB4])]);
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn private_hints_drops_emptied_param_but_keeps_alpn() {
+        let rdata = build_rdata(1, &[], &[alpn_h3(), ipv4hint(&[PRIV4])]);
+        let out = strip_private_hints(&rdata, is_priv).expect("all-private hint → param dropped");
+        let expected = build_rdata(1, &[], &[alpn_h3()]);
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn private_hints_filters_ipv6() {
+        let rdata = build_rdata(1, &[], &[ipv6hint(&[PUB6, ULA6])]);
+        let out = strip_private_hints(&rdata, is_priv).expect("ULA hint → rewritten");
+        let expected = build_rdata(1, &[], &[ipv6hint(&[PUB6])]);
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn private_hints_all_public_returns_none() {
+        let rdata = build_rdata(1, &[], &[alpn_h3(), ipv4hint(&[PUB4]), ipv6hint(&[PUB6])]);
+        assert!(strip_private_hints(&rdata, is_priv).is_none());
+    }
+
+    #[test]
+    fn private_hints_malformed_ipv4hint_returns_none() {
+        // ipv4hint value length 5 is not a multiple of 4.
+        let rdata = build_rdata(1, &[], &[(4, vec![1, 2, 3, 4, 5])]);
+        assert!(strip_private_hints(&rdata, is_priv).is_none());
     }
 }

--- a/src/svcb.rs
+++ b/src/svcb.rs
@@ -61,6 +61,70 @@ fn filter_hint(value: &[u8], stride: usize, is_private: &impl Fn(IpAddr) -> bool
     out
 }
 
+/// One SvcParam at `pos`: `(key, value, end)`, or `None` if its
+/// {u16 key, u16 len, opaque[len]} framing runs past the RDATA.
+fn read_param(rdata: &[u8], pos: usize) -> Option<(u16, &[u8], usize)> {
+    if pos + 4 > rdata.len() {
+        return None;
+    }
+    let key = u16::from_be_bytes([rdata[pos], rdata[pos + 1]]);
+    let vlen = u16::from_be_bytes([rdata[pos + 2], rdata[pos + 3]]) as usize;
+    let end = pos.checked_add(4)?.checked_add(vlen)?;
+    if end > rdata.len() {
+        return None;
+    }
+    Some((key, &rdata[pos + 4..end], end))
+}
+
+enum Edit {
+    Keep,
+    /// Replace the value; an empty `Vec` drops the param entirely.
+    Rewrite(Vec<u8>),
+}
+
+/// Apply `edit` to each SvcParam of an HTTPS/SVCB RDATA blob (RFC 9460 §2.2:
+/// priority, uncompressed target name, then key-sorted params). `None` when
+/// nothing changed, the RDATA is unparseable, or `edit` rejects a malformed
+/// param — so the caller keeps the original bytes. The first pass validates
+/// framing and skips the allocation entirely when no param is rewritten.
+fn edit_svcparams(rdata: &[u8], edit: impl Fn(u16, &[u8]) -> Option<Edit>) -> Option<Vec<u8>> {
+    if rdata.len() < 2 {
+        return None;
+    }
+    let params_start = skip_target_name(rdata, 2)?;
+
+    let mut pos = params_start;
+    let mut changed = false;
+    while pos < rdata.len() {
+        let (key, value, end) = read_param(rdata, pos)?;
+        if !matches!(edit(key, value)?, Edit::Keep) {
+            changed = true;
+        }
+        pos = end;
+    }
+    if !changed {
+        return None;
+    }
+
+    let mut out = Vec::with_capacity(rdata.len());
+    out.extend_from_slice(&rdata[..params_start]);
+    let mut pos = params_start;
+    while pos < rdata.len() {
+        let (key, value, end) = read_param(rdata, pos)?;
+        match edit(key, value)? {
+            Edit::Keep => out.extend_from_slice(&rdata[pos..end]),
+            Edit::Rewrite(v) if !v.is_empty() => {
+                out.extend_from_slice(&key.to_be_bytes());
+                out.extend_from_slice(&(v.len() as u16).to_be_bytes());
+                out.extend_from_slice(&v);
+            }
+            Edit::Rewrite(_) => {}
+        }
+        pos = end;
+    }
+    Some(out)
+}
+
 /// Strip private address values from `ipv4hint`/`ipv6hint` SvcParams, keeping
 /// public ones. A hint left empty is dropped entirely; all other SvcParams
 /// (alpn, port, ech, …) are preserved untouched. `is_private` receives the
@@ -71,115 +135,35 @@ fn filter_hint(value: &[u8], stride: usize, is_private: &impl Fn(IpAddr) -> bool
 /// nothing changed or the RDATA couldn't be parsed (caller keeps the
 /// original bytes).
 pub fn strip_private_hints(rdata: &[u8], is_private: impl Fn(IpAddr) -> bool) -> Option<Vec<u8>> {
-    if rdata.len() < 2 {
-        return None;
-    }
-    let params_start = skip_target_name(rdata, 2)?;
-
-    // Validate framing and decide whether a rebuild is needed.
-    let mut scan = params_start;
-    let mut changed = false;
-    while scan < rdata.len() {
-        if scan + 4 > rdata.len() {
-            return None;
-        }
-        let key = u16::from_be_bytes([rdata[scan], rdata[scan + 1]]);
-        let vlen = u16::from_be_bytes([rdata[scan + 2], rdata[scan + 3]]) as usize;
-        let end = scan.checked_add(4)?.checked_add(vlen)?;
-        if end > rdata.len() {
-            return None;
-        }
-        if let Some(stride) = hint_stride(key) {
-            if !vlen.is_multiple_of(stride) {
+    edit_svcparams(rdata, |key, value| match hint_stride(key) {
+        Some(stride) => {
+            if !value.len().is_multiple_of(stride) {
                 return None;
             }
-            if filter_hint(&rdata[scan + 4..end], stride, &is_private).len() != vlen {
-                changed = true;
-            }
+            let kept = filter_hint(value, stride, &is_private);
+            Some(if kept.len() == value.len() {
+                Edit::Keep
+            } else {
+                Edit::Rewrite(kept)
+            })
         }
-        scan = end;
-    }
-    if scan != rdata.len() || !changed {
-        return None;
-    }
-
-    let mut out = Vec::with_capacity(rdata.len());
-    out.extend_from_slice(&rdata[..params_start]);
-    let mut pos = params_start;
-    while pos < rdata.len() {
-        let key = u16::from_be_bytes([rdata[pos], rdata[pos + 1]]);
-        let vlen = u16::from_be_bytes([rdata[pos + 2], rdata[pos + 3]]) as usize;
-        let end = pos + 4 + vlen;
-        match hint_stride(key) {
-            Some(stride) => {
-                let kept = filter_hint(&rdata[pos + 4..end], stride, &is_private);
-                if !kept.is_empty() {
-                    out.extend_from_slice(&key.to_be_bytes());
-                    out.extend_from_slice(&(kept.len() as u16).to_be_bytes());
-                    out.extend_from_slice(&kept);
-                }
-            }
-            None => out.extend_from_slice(&rdata[pos..end]),
-        }
-        pos = end;
-    }
-    Some(out)
+        None => Some(Edit::Keep),
+    })
 }
 
 /// Strip the `ipv6hint` SvcParam from an HTTPS/SVCB RDATA blob.
 ///
-/// Returns `Some(new_rdata)` if `ipv6hint` was present and removed.
-/// Returns `None` if the record had no `ipv6hint`, or if the RDATA
-/// couldn't be parsed — in both cases the caller should keep the
-/// original bytes untouched.
-///
-/// SVCB RDATA (RFC 9460 §2.2):
-///   SvcPriority (u16)
-///   TargetName  (uncompressed DNS name — labels terminated by 0 octet)
-///   SvcParams   (series of {u16 key, u16 len, opaque[len] value}, sorted by key)
+/// Returns `Some(new_rdata)` if `ipv6hint` was present and removed, `None` if
+/// the record had no `ipv6hint` or the RDATA couldn't be parsed — in both
+/// cases the caller keeps the original bytes untouched.
 pub fn strip_ipv6hint(rdata: &[u8]) -> Option<Vec<u8>> {
-    if rdata.len() < 2 {
-        return None;
-    }
-    let params_start = skip_target_name(rdata, 2)?;
-
-    // Scan params once to decide whether we need to rebuild.
-    let mut scan = params_start;
-    let mut has_ipv6hint = false;
-    while scan < rdata.len() {
-        if scan + 4 > rdata.len() {
-            return None;
-        }
-        let key = u16::from_be_bytes([rdata[scan], rdata[scan + 1]]);
-        let vlen = u16::from_be_bytes([rdata[scan + 2], rdata[scan + 3]]) as usize;
-        let end = scan.checked_add(4)?.checked_add(vlen)?;
-        if end > rdata.len() {
-            return None;
-        }
-        if key == IPV6_HINT_KEY {
-            has_ipv6hint = true;
-        }
-        scan = end;
-    }
-    if scan != rdata.len() || !has_ipv6hint {
-        return None;
-    }
-
-    // Rebuild without ipv6hint, preserving param order (RFC 9460 requires
-    // ascending key order, which we preserve by filtering in place).
-    let mut out = Vec::with_capacity(rdata.len());
-    out.extend_from_slice(&rdata[..params_start]);
-    let mut pos = params_start;
-    while pos < rdata.len() {
-        let key = u16::from_be_bytes([rdata[pos], rdata[pos + 1]]);
-        let vlen = u16::from_be_bytes([rdata[pos + 2], rdata[pos + 3]]) as usize;
-        let end = pos + 4 + vlen;
-        if key != IPV6_HINT_KEY {
-            out.extend_from_slice(&rdata[pos..end]);
-        }
-        pos = end;
-    }
-    Some(out)
+    edit_svcparams(rdata, |key, _| {
+        Some(if key == IPV6_HINT_KEY {
+            Edit::Rewrite(Vec::new())
+        } else {
+            Edit::Keep
+        })
+    })
 }
 
 /// Build an SVCB RDATA blob from a priority, target labels, and

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -67,6 +67,7 @@ pub async fn test_ctx() -> ServerCtx {
         filter_aaaa: false,
         allow_from: crate::acl::AllowFromAcl::default(),
         client_policy: crate::client_policy::ClientPolicySet::default(),
+        rebind: crate::rebind::RebindFilter::default(),
     }
 }
 


### PR DESCRIPTION
Closes #240 (layer 1).

## What

Adds an opt-in **DNS rebinding filter**: when `[server] rebind_protect = true`, answers resolved via the upstream/recursive/cache paths have their private/special-use addresses stripped, so a public hostname can't be rebound to an address inside the client's perimeter (router admin, localhost services, NAS dashboards).

```toml
[server]
rebind_protect = true
rebind_allowlist = ["example.com"]   # split-horizon services; suffix match
rebind_private_ranges = []           # empty = built-in defaults
```

## Design

- **Reuses `acl::CidrMatcher`** rather than adding a dependency. Its `to_canonical()` step means v4-mapped IPv6 (`::ffff:10.0.0.1`) matches the v4 ranges for free — no dead `::ffff:0:0/96` default entry.
- **Path-gated:** runs only for `Recursive`/`Forwarded`/`Upstream`/`Cached`/`Coalesced`. Local data (zones, overrides, `.numa`, blocklist sinkhole) returns on `Local`/`Overridden`/`Blocked` and is exempt by construction — no allowlist entry needed for `.numa` services.
- **Default ranges include loopback** (`127.0.0.0/8` + `::1`) — it's the canonical rebind target and the field default (dnsmasq/Knot/ControlD/NextDNS all block it). DNSBL/RBL users, and upstreams that sinkhole ads to `127.0.0.1`, add those zones to `rebind_allowlist`; the `REBIND` log line makes any such breakage diagnosable. *(Revised from the first commit, which omitted loopback on a since-disproven sinkhole-collision argument — the sinkhole is on the `Blocked` path, already exempt.)*
- **Value-selective SVCB/HTTPS scrub:** `strip_private_hints` drops only the private addresses from `ipv4hint`/`ipv6hint` (keeps public ones, preserves `alpn`/`port`/`ech`); a hint left empty is dropped. Closes the obvious `ipv4hint=192.168.1.1` bypass. Shared TargetName parsing factored out of the existing `strip_ipv6hint`.
- **Response semantics:** surviving safe IPs are returned; all-stripped → **NODATA** (NOERROR + empty), never NXDOMAIN. Clears `AD` on any stripped Secure answer so we don't assert authenticity over a NODATA the validator never proved.
- **Off by default.** Cache stores the unfiltered packet, so toggling needs no flush.

## Tests (14 new)

- `rebind.rs`: RFC1918 v4, link-local/`0.0.0.0`, ULA/link-local v6, v4-mapped private, loopback stripped + DNSBL-allowlist exemption, allowlist suffix (exempts `nas.example.com`, not `evilexample.com`), disabled passthrough, custom-ranges override, invalid-range error.
- `svcb.rs`: keep-public/drop-private, drop-emptied-param-keep-alpn, ipv6 filter, all-public→None, malformed-hint→None.
- `ctx.rs`: forwarded private answer stripped (NODATA); local override's private IP untouched (path gating).