### PR TITLE
build(nix): bump cargoHash for current vendor tree

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
                 pname = "numa";
                 version = (lib.importTOML ./Cargo.toml).package.version;
                 src = ./.;
-                cargoHash = "sha256-DU+pAgIy76FcKFs1p25o8S1MxcT5hdGphVqpi60pIus=";
+                cargoHash = "sha256-UQaJZYHtECSKU4Fulocn0LzJkXPZJfjhdpie6niwTtM=";
                 meta = {
                   description = "Portable DNS resolver in Rust";
                   homepage = "https://numa.rs";


### PR DESCRIPTION
`nix-build` is red on `main` (and every PR branched from it) — a `cargoHash` mismatch in the vendored-deps fixed-output derivation. The pinned hash drifted from the actual vendor tree:

```
error: hash mismatch in fixed-output derivation '…numa-0.20.0-vendor-staging.drv':
         specified: sha256-DU+pAgIy76FcKFs1p25o8S1MxcT5hdGphVqpi60pIus=
            got:    sha256-UQaJZYHtECSKU4Fulocn0LzJkXPZJfjhdpie6niwTtM=
```

This pins the value CI itself computed. One-line change; unblocks `nix-build` on main and on open PRs (e.g. #279) once they rebase.

Source-only; no `Cargo.lock` change.