### PR TITLE
fix(stats): report wall-clock uptime so dashboard matches systemd

### DIFF
--- a/src/health.rs
+++ b/src/health.rs
@@ -14,7 +14,7 @@
 
 use std::net::Ipv4Addr;
 use std::path::Path;
-use std::time::Instant;
+use std::time::SystemTime;
 
 use ring::digest::{digest, SHA256};
 use serde::Serialize;
@@ -31,7 +31,9 @@ pub struct HealthMeta {
     pub api_port: u16,
     pub ca_fingerprint_sha256: Option<String>,
     pub features: Vec<String>,
-    pub started_at: Instant,
+    // SystemTime, not Instant: monotonic time freezes during host suspend
+    // (Linux/macOS), so uptime would drift below systemd's "active since" (#281).
+    pub started_at: SystemTime,
 }
 
 impl HealthMeta {
@@ -50,7 +52,7 @@ impl HealthMeta {
             api_port: 8765,
             ca_fingerprint_sha256: None,
             features: vec![],
-            started_at: Instant::now(),
+            started_at: SystemTime::now(),
         }
     }
 
@@ -106,7 +108,7 @@ impl HealthMeta {
             api_port,
             ca_fingerprint_sha256,
             features,
-            started_at: Instant::now(),
+            started_at: SystemTime::now(),
         }
     }
 }
@@ -155,7 +157,7 @@ impl HealthResponse {
         HealthResponse {
             status: "ok",
             version: meta.version,
-            uptime_secs: meta.started_at.elapsed().as_secs(),
+            uptime_secs: meta.started_at.elapsed().unwrap_or_default().as_secs(),
             hostname: meta.hostname.clone(),
             lan_ip: lan_ip.map(|ip| ip.to_string()),
             sni: meta.sni.clone(),
@@ -209,7 +211,7 @@ mod tests {
             api_port: 8765,
             ca_fingerprint_sha256: Some("abcd1234".to_string()),
             features: vec!["dot".to_string(), "dnssec".to_string()],
-            started_at: Instant::now(),
+            started_at: SystemTime::now(),
         };
 
         let response = HealthResponse::build(&meta, Some(Ipv4Addr::new(192, 168, 1, 50)));
@@ -237,7 +239,7 @@ mod tests {
             api_port: 8765,
             ca_fingerprint_sha256: None,
             features: vec![],
-            started_at: Instant::now(),
+            started_at: SystemTime::now(),
         };
 
         let response = HealthResponse::build(&meta, None);

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::SystemTime;
 
 /// Returns the process memory footprint in bytes, or 0 if unavailable.
 /// macOS: phys_footprint (matches Activity Monitor). Linux: RSS from /proc/self/statm.
@@ -134,7 +134,7 @@ pub struct ServerStats {
     pub(crate) proxy_v2_rejected_signature: u64,
     pub(crate) proxy_v2_local_command: u64,
     pub(crate) proxy_v2_timeout: u64,
-    started_at: Instant,
+    started_at: SystemTime,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -271,7 +271,7 @@ impl ServerStats {
             proxy_v2_rejected_signature: 0,
             proxy_v2_local_command: 0,
             proxy_v2_timeout: 0,
-            started_at: Instant::now(),
+            started_at: SystemTime::now(),
         }
     }
 
@@ -316,7 +316,7 @@ impl ServerStats {
     }
 
     pub fn uptime_secs(&self) -> u64 {
-        self.started_at.elapsed().as_secs()
+        self.started_at.elapsed().unwrap_or_default().as_secs()
     }
 
     pub fn snapshot(&self) -> StatsSnapshot {
@@ -350,7 +350,7 @@ impl ServerStats {
     }
 
     pub fn log_summary(&self) {
-        let uptime = self.started_at.elapsed();
+        let uptime = self.started_at.elapsed().unwrap_or_default();
         let hours = uptime.as_secs() / 3600;
         let mins = (uptime.as_secs() % 3600) / 60;
         let secs = uptime.as_secs() % 60;

--- a/tests/docker/issue-281-repro.sh
+++ b/tests/docker/issue-281-repro.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Regression for issue #281: dashboard uptime must track wall-clock so it
+# agrees with systemd's "active (running) since N ago" across host suspend.
+#
+# A container can't actually suspend, but suspend is observably just "the
+# real-time clock advanced while the monotonic clock did not". libfaketime
+# with DONT_FAKE_MONOTONIC=1 reproduces exactly that: it fakes
+# CLOCK_REALTIME (Rust's SystemTime) while passing CLOCK_MONOTONIC (Rust's
+# Instant) straight through.
+#
+#   1. start numa with the fake clock at T0           → uptime ~0
+#   2. jump the fake real-time clock to T0 + 10h       → simulates suspend
+#   3. read uptime again
+#        fixed  (SystemTime): ~36000s — matches a 10h systemd "active since"
+#        broken (Instant):    ~0s     — the #281 undercount
+#
+# PASS iff uptime followed the wall-clock jump. Builds numa inside the image
+# so it runs regardless of host OS/arch (the dev host is macOS).
+#
+# Usage:
+#   tests/docker/issue-281-repro.sh
+#   JUMP_HOURS=24 tests/docker/issue-281-repro.sh
+
+set -euo pipefail
+
+JUMP_HOURS="${JUMP_HOURS:-10}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+IMAGE="numa-281-repro"
+NAME="numa-281-$$"
+CTX="$(mktemp -d)"
+
+# Pin build + run to the host arch so the multi-arch base images don't
+# resolve build and run stages to different platforms.
+case "$(uname -m)" in
+    arm64|aarch64) PLATFORM="linux/arm64" ;;
+    x86_64|amd64)  PLATFORM="linux/amd64" ;;
+    *)             PLATFORM="" ;;
+esac
+PLAT_ARG=${PLATFORM:+--platform=$PLATFORM}
+
+GREEN="\033[32m"; RED="\033[31m"; DIM="\033[90m"; RESET="\033[0m"
+
+cleanup() {
+    docker rm -f "$NAME" >/dev/null 2>&1 || true
+    rm -rf "$CTX"
+}
+trap cleanup EXIT
+
+# ---- Build context: tracked files at HEAD (no target/, no .git) ----
+git -C "$REPO_ROOT" archive HEAD | tar -x -C "$CTX"
+
+cat > "$CTX/numa.toml" <<'EOF'
+[server]
+bind_addr = "127.0.0.1:5353"
+api_port = 5381
+data_dir = "/tmp/numa"
+
+[upstream]
+mode = "forward"
+address = "9.9.9.9:53"
+EOF
+
+cat > "$CTX/entrypoint.sh" <<'EOF'
+#!/bin/sh
+set -e
+mkdir -p /tmp/numa
+LIB="$(find /usr/lib -name 'libfaketime.so.1' | head -1)"
+export LD_PRELOAD="$LIB"
+export FAKETIME_TIMESTAMP_FILE=/faketime.rc
+export FAKETIME_NO_CACHE=1
+export DONT_FAKE_MONOTONIC=1
+exec numa /numa.toml
+EOF
+
+cat > "$CTX/Dockerfile" <<'EOF'
+FROM rust:1-bookworm AS build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake clang libclang-dev perl && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY . .
+RUN cargo build --bin numa
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libfaketime curl ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/target/debug/numa /usr/local/bin/numa
+COPY numa.toml /numa.toml
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh && echo "@2030-01-01 00:00:00" > /faketime.rc
+ENTRYPOINT ["/entrypoint.sh"]
+EOF
+
+# Force-pull bases at the target platform first: `docker run/build` reuses a
+# locally-tagged image regardless of --platform, so a stale wrong-arch base
+# would otherwise be silently inherited.
+for base in rust:1-bookworm debian:bookworm-slim; do
+    docker pull $PLAT_ARG -q "$base" >/dev/null
+done
+
+echo "${DIM}Building numa image (first run compiles the crate — a few min)...${RESET}"
+docker build $PLAT_ARG -q -t "$IMAGE" "$CTX" >/dev/null
+
+echo "${DIM}Starting numa under a frozen-monotonic fake clock...${RESET}"
+docker run $PLAT_ARG -d --name "$NAME" "$IMAGE" >/dev/null
+
+uptime_now() {
+    docker exec "$NAME" curl -s --max-time 3 http://127.0.0.1:5381/health \
+        | grep -o '"uptime_secs":[0-9]*' | cut -d: -f2
+}
+
+# Wait for the API to answer.
+for _ in $(seq 1 30); do
+    U="$(uptime_now || true)"
+    [ -n "${U:-}" ] && break
+    sleep 0.5
+done
+[ -n "${U:-}" ] || { echo "${RED}✗${RESET} numa API never came up"; docker logs "$NAME" 2>&1 | tail -20; exit 2; }
+
+UPTIME_BEFORE="$U"
+echo "${GREEN}✓${RESET} numa up; uptime before jump = ${UPTIME_BEFORE}s"
+
+# Jump the fake real-time clock forward — monotonic stays frozen (suspend).
+docker exec "$NAME" sh -c "echo '@2030-01-01 ${JUMP_HOURS}:00:00' > /faketime.rc"
+sleep 1
+UPTIME_AFTER="$(uptime_now)"
+echo "${DIM}jumped wall-clock +${JUMP_HOURS}h; uptime after = ${UPTIME_AFTER}s${RESET}"
+
+EXPECTED=$(( JUMP_HOURS * 3600 ))
+DELTA=$(( UPTIME_AFTER - UPTIME_BEFORE ))
+
+# Allow generous slack for startup/exec latency; the bug yields DELTA ~0.
+if [ "$DELTA" -ge $(( EXPECTED - 120 )) ]; then
+    echo "${GREEN}✓ PASS${RESET} uptime tracked the +${JUMP_HOURS}h wall-clock jump (Δ=${DELTA}s) — matches systemd"
+    exit 0
+else
+    echo "${RED}✗ FAIL${RESET} uptime did not follow wall-clock (Δ=${DELTA}s, expected ~${EXPECTED}s) — #281 undercount"
+    exit 1
+fi


### PR DESCRIPTION
## Problem

Issue #281: a user running numa 0.20.0 under systemd saw `systemctl status` report the service `active (running) since … 14h ago`, while the dashboard reported uptime of only **4h 34min**.

## Cause

Uptime was computed from `std::time::Instant`, whose monotonic clock **freezes while the host is suspended** — `CLOCK_MONOTONIC` on Linux, `CLOCK_UPTIME_RAW`/`mach_absolute_time` on macOS. systemd's "active since" reckons from the **real-time** clock, which keeps counting through sleep. After an overnight suspend (~9.5h here) the two diverge by the suspend duration.

This is current Rust behavior: the [PR to switch `Instant` to `CLOCK_BOOTTIME`](https://github.com/rust-lang/rust/pull/88714) was closed without merge (Dec 2022).

## Fix

Anchor `started_at` to `std::time::SystemTime` directly (no wrapper type). systemd measures uptime from the real-time clock too, so dashboard and systemd now move together across **both** suspend and NTP/clock steps. The three read sites use `.elapsed().unwrap_or_default()`, clamping to zero if the real-time clock steps back past the start point.

`CLOCK_BOOTTIME` (Linux-only, via libc) was considered but rejected: it only fixes Linux (macOS `Instant` has the same bug), adds `unsafe` + `cfg`, and would actually *diverge* from systemd's display on an NTP step. For a human-facing uptime readout whose job is to agree with systemd, matching systemd's clock source is the simpler and more correct choice. Uptime is never used for interval timing here, so giving up monotonicity costs nothing.

## Verification

**Automated** — `tests/docker/issue-281-repro.sh` reproduces the bug deterministically without a real suspend. A container can't suspend, but suspend is observationally just "real-time advanced while monotonic did not", which `libfaketime` with `DONT_FAKE_MONOTONIC=1` reproduces exactly (fakes `CLOCK_REALTIME`/`SystemTime`, passes `CLOCK_MONOTONIC`/`Instant` through). It starts numa at a fake T0, jumps the wall-clock +10h, and asserts uptime followed:

```
✓ numa up; uptime before jump = 0s
jumped wall-clock +10h; uptime after = 35999s
✓ PASS uptime tracked the +10h wall-clock jump (Δ=35999s) — matches systemd
```

Passes on this branch; on a `main`-built binary the delta is ~0 (the #281 undercount), so it doubles as a regression guard. Builds numa inside the image, so it's host-OS/arch independent.

**Manual (real suspend)** — run the service, note dashboard `uptime_secs`, `systemctl suspend`, resume: before this fix the dashboard lags `systemctl status … active since` by the suspend duration; after, they agree (±NTP jitter).

Existing `health`/`stats` unit tests pass; clippy clean on the changed files (the unrelated `srtt.rs`/`recursive.rs` 1.94 lints are pre-existing toolchain drift on `main`).

Closes #281.