### PR TITLE
feat(rebind): runtime API, stripped-query visibility, stats counter

### DIFF
--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1128,9 +1128,9 @@ function applyLogFilter() {
 
   tbody.innerHTML = filtered.map(e => {
     const allowBtn = e.path === 'BLOCKED'
-      ? ` <button class="btn-delete" onclick="allowDomain('${e.domain}')" title="Allow this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
+      ? ` <button class="btn-delete" onclick="postDomain('/blocking/allowlist','${e.domain}')" title="Allow this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
       : e.rebind_stripped
-      ? ` <button class="btn-delete" onclick="allowRebind('${e.domain}')" title="Stop stripping private IPs for this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
+      ? ` <button class="btn-delete" onclick="postDomain('/rebind/allowlist','${e.domain}')" title="Stop stripping private IPs for this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
       : '';
     const rebindTag = e.rebind_stripped
       ? ` <span class="path-tag" style="background:rgba(192,98,58,0.12);color:var(--amber-dim);" title="Private IPs stripped by rebind protection">stripped</span>`
@@ -1391,26 +1391,18 @@ async function unpauseBlocking() {
   } catch (err) {}
 }
 
-async function allowDomain(domain) {
+async function postDomain(path, domain) {
   try {
-    await fetch(API + '/blocking/allowlist', {
+    await fetch(API + path, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ domain: domain }),
+      body: JSON.stringify({ domain }),
     });
     refresh();
-  } catch (err) {}
-}
-
-async function allowRebind(domain) {
-  try {
-    await fetch(API + '/rebind/allowlist', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ domain: domain }),
-    });
-    refresh();
-  } catch (err) {}
+    return true;
+  } catch (err) {
+    return false;
+  }
 }
 
 async function checkDomain(event) {
@@ -1425,7 +1417,7 @@ async function checkDomain(event) {
       el.className = 'check-result-blocked';
       el.innerHTML = `<strong>Blocked</strong> — ${h(result.reason)}` +
         (result.matched_rule ? `<br>Rule: <code>${h(result.matched_rule)}</code>` : '') +
-        ` <button class="btn-delete" onclick="allowDomain('${h(domain)}')" style="color:var(--emerald);font-size:0.7rem;margin-left:0.4rem;">allow</button>`;
+        ` <button class="btn-delete" onclick="postDomain('/blocking/allowlist','${h(domain)}')" style="color:var(--emerald);font-size:0.7rem;margin-left:0.4rem;">allow</button>`;
     } else {
       el.className = 'check-result-allowed';
       el.innerHTML = `<strong>Allowed</strong> — ${h(result.reason)}` +
@@ -1499,16 +1491,7 @@ async function addAllowlistDomain(event) {
   event.preventDefault();
   const input = document.getElementById('allowDomainInput');
   const domain = input.value.trim();
-  if (!domain) return false;
-  try {
-    await fetch(API + '/blocking/allowlist', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ domain }),
-    });
-    input.value = '';
-    refresh();
-  } catch (err) {}
+  if (domain && (await postDomain('/blocking/allowlist', domain))) input.value = '';
   return false;
 }
 

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1129,13 +1129,18 @@ function applyLogFilter() {
   tbody.innerHTML = filtered.map(e => {
     const allowBtn = e.path === 'BLOCKED'
       ? ` <button class="btn-delete" onclick="allowDomain('${e.domain}')" title="Allow this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
+      : e.rebind_stripped
+      ? ` <button class="btn-delete" onclick="allowRebind('${e.domain}')" title="Stop stripping private IPs for this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
+      : '';
+    const rebindTag = e.rebind_stripped
+      ? ` <span class="path-tag" style="background:rgba(192,98,58,0.12);color:var(--amber-dim);" title="Private IPs stripped by rebind protection">stripped</span>`
       : '';
     return `
     <tr title="Source: ${e.src || 'unknown'}">
       <td>${formatTime(e.timestamp_epoch)}<br><span class="src-tag">${shortSrc(e.src)}</span></td>
       <td>${e.query_type}</td>
       <td class="domain-cell" title="${e.domain}">${e.domain}${allowBtn}</td>
-      <td><span class="path-tag ${e.path}">${e.path}</span></td>
+      <td><span class="path-tag ${e.path}">${e.path}</span>${rebindTag}</td>
       <td><span class="path-tag ${e.transport}">${e.transport}</span></td>
       <td style="white-space:nowrap;"><span style="display:inline-block;width:15px;text-align:center;">${e.dnssec === 'secure' ? '<svg title="DNSSEC verified" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--emerald)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>' : ''}</span>${e.rescode}</td>
       <td>${e.latency_ms.toFixed(1)}ms</td>
@@ -1389,6 +1394,17 @@ async function unpauseBlocking() {
 async function allowDomain(domain) {
   try {
     await fetch(API + '/blocking/allowlist', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ domain: domain }),
+    });
+    refresh();
+  } catch (err) {}
+}
+
+async function allowRebind(domain) {
+  try {
+    await fetch(API + '/rebind/allowlist', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ domain: domain }),

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1128,9 +1128,9 @@ function applyLogFilter() {
 
   tbody.innerHTML = filtered.map(e => {
     const allowBtn = e.path === 'BLOCKED'
-      ? ` <button class="btn-delete" onclick="postDomain('/blocking/allowlist','${e.domain}')" title="Allow this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
+      ? ` <button class="btn-delete" data-domain="${h(e.domain)}" onclick="postDomain('/blocking/allowlist', this.dataset.domain)" title="Allow this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
       : e.rebind_stripped
-      ? ` <button class="btn-delete" onclick="postDomain('/rebind/allowlist','${e.domain}')" title="Stop stripping private IPs for this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
+      ? ` <button class="btn-delete" data-domain="${h(e.domain)}" onclick="postDomain('/rebind/allowlist', this.dataset.domain)" title="Stop stripping private IPs for this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
       : '';
     const rebindTag = e.rebind_stripped
       ? ` <span class="path-tag" style="background:rgba(192,98,58,0.12);color:var(--amber-dim);" title="Private IPs stripped by rebind protection">stripped</span>`
@@ -1139,7 +1139,7 @@ function applyLogFilter() {
     <tr title="Source: ${e.src || 'unknown'}">
       <td>${formatTime(e.timestamp_epoch)}<br><span class="src-tag">${shortSrc(e.src)}</span></td>
       <td>${e.query_type}</td>
-      <td class="domain-cell" title="${e.domain}">${e.domain}${allowBtn}</td>
+      <td class="domain-cell" title="${h(e.domain)}">${h(e.domain)}${allowBtn}</td>
       <td><span class="path-tag ${e.path}">${e.path}</span>${rebindTag}</td>
       <td><span class="path-tag ${e.transport}">${e.transport}</span></td>
       <td style="white-space:nowrap;"><span style="display:inline-block;width:15px;text-align:center;">${e.dnssec === 'secure' ? '<svg title="DNSSEC verified" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--emerald)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>' : ''}</span>${e.rescode}</td>
@@ -1222,7 +1222,7 @@ function renderCache(entries) {
   const sorted = entries.sort((a, b) => b.ttl_remaining - a.ttl_remaining).slice(0, 50);
   el.innerHTML = sorted.map(e => `
     <div class="cache-item">
-      <span class="cache-domain" title="${e.domain}">${e.domain}</span>
+      <span class="cache-domain" title="${h(e.domain)}">${h(e.domain)}</span>
       <span class="cache-ttl">${e.query_type} ${e.ttl_remaining}s</span>
     </div>
   `).join('');
@@ -1417,7 +1417,7 @@ async function checkDomain(event) {
       el.className = 'check-result-blocked';
       el.innerHTML = `<strong>Blocked</strong> — ${h(result.reason)}` +
         (result.matched_rule ? `<br>Rule: <code>${h(result.matched_rule)}</code>` : '') +
-        ` <button class="btn-delete" onclick="postDomain('/blocking/allowlist','${h(domain)}')" style="color:var(--emerald);font-size:0.7rem;margin-left:0.4rem;">allow</button>`;
+        ` <button class="btn-delete" data-domain="${h(domain)}" onclick="postDomain('/blocking/allowlist', this.dataset.domain)" style="color:var(--emerald);font-size:0.7rem;margin-left:0.4rem;">allow</button>`;
     } else {
       el.className = 'check-result-allowed';
       el.innerHTML = `<strong>Allowed</strong> — ${h(result.reason)}` +

--- a/src/api.rs
+++ b/src/api.rs
@@ -50,6 +50,14 @@ pub fn router(ctx: Arc<ServerCtx>) -> Router {
             "/blocking/allowlist/{domain}",
             delete(blocking_allowlist_remove),
         )
+        .route("/rebind", get(rebind_status))
+        .route("/rebind/toggle", put(rebind_toggle))
+        .route("/rebind/allowlist", get(rebind_allowlist))
+        .route("/rebind/allowlist", post(rebind_allowlist_add))
+        .route(
+            "/rebind/allowlist/{domain}",
+            delete(rebind_allowlist_remove),
+        )
         .route("/services", get(list_services))
         .route("/services", post(create_service))
         .route("/services/{name}", delete(remove_service))
@@ -161,6 +169,7 @@ struct QueryLogResponse {
     rescode: String,
     latency_ms: f64,
     dnssec: String,
+    rebind_stripped: bool,
 }
 
 #[derive(Serialize)]
@@ -236,6 +245,7 @@ struct QueriesStats {
     overridden: u64,
     blocked: u64,
     errors: u64,
+    rebind_stripped: u64,
 }
 
 #[derive(Serialize)]
@@ -521,6 +531,7 @@ async fn query_log(
                     rescode: e.rescode.as_str().to_string(),
                     latency_ms: e.latency_us as f64 / 1000.0,
                     dnssec: e.dnssec.as_str().to_string(),
+                    rebind_stripped: e.rebind_stripped,
                 }
             })
             .collect()
@@ -582,6 +593,7 @@ async fn stats(State(ctx): State<Arc<ServerCtx>>) -> Json<StatsResponse> {
             overridden: snap.overridden,
             blocked: snap.blocked,
             errors: snap.errors,
+            rebind_stripped: snap.rebind_stripped,
         },
         transport: TransportStats {
             udp: snap.transport_udp,
@@ -769,6 +781,63 @@ async fn blocking_allowlist_remove(
         .unwrap()
         .remove_from_allowlist(&domain)
     {
+        StatusCode::NO_CONTENT
+    } else {
+        StatusCode::NOT_FOUND
+    }
+}
+
+// --- DNS rebinding-protection handlers ---
+
+#[derive(Serialize)]
+struct RebindResponse {
+    enabled: bool,
+    ranges: Vec<String>,
+    allowlist: Vec<String>,
+}
+
+async fn rebind_status(State(ctx): State<Arc<ServerCtx>>) -> Json<RebindResponse> {
+    let r = ctx.rebind.read().unwrap();
+    Json(RebindResponse {
+        enabled: r.is_enabled(),
+        ranges: r.ranges().to_vec(),
+        allowlist: r.allowlist(),
+    })
+}
+
+#[derive(Deserialize)]
+struct RebindToggleRequest {
+    enabled: bool,
+}
+
+async fn rebind_toggle(
+    State(ctx): State<Arc<ServerCtx>>,
+    Json(req): Json<RebindToggleRequest>,
+) -> Json<serde_json::Value> {
+    ctx.rebind.write().unwrap().set_enabled(req.enabled);
+    Json(serde_json::json!({ "enabled": req.enabled }))
+}
+
+async fn rebind_allowlist(State(ctx): State<Arc<ServerCtx>>) -> Json<Vec<String>> {
+    Json(ctx.rebind.read().unwrap().allowlist())
+}
+
+async fn rebind_allowlist_add(
+    State(ctx): State<Arc<ServerCtx>>,
+    Json(req): Json<AllowlistRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    ctx.rebind.write().unwrap().add_to_allowlist(&req.domain);
+    (
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "allowed": req.domain })),
+    )
+}
+
+async fn rebind_allowlist_remove(
+    State(ctx): State<Arc<ServerCtx>>,
+    Path(domain): Path<String>,
+) -> StatusCode {
+    if ctx.rebind.write().unwrap().remove_from_allowlist(&domain) {
         StatusCode::NO_CONTENT
     } else {
         StatusCode::NOT_FOUND

--- a/src/api.rs
+++ b/src/api.rs
@@ -52,7 +52,6 @@ pub fn router(ctx: Arc<ServerCtx>) -> Router {
         )
         .route("/rebind", get(rebind_status))
         .route("/rebind/toggle", put(rebind_toggle))
-        .route("/rebind/allowlist", get(rebind_allowlist))
         .route("/rebind/allowlist", post(rebind_allowlist_add))
         .route(
             "/rebind/allowlist/{domain}",
@@ -816,10 +815,6 @@ async fn rebind_toggle(
 ) -> Json<serde_json::Value> {
     ctx.rebind.write().unwrap().set_enabled(req.enabled);
     Json(serde_json::json!({ "enabled": req.enabled }))
-}
-
-async fn rebind_allowlist(State(ctx): State<Arc<ServerCtx>>) -> Json<Vec<String>> {
-    Json(ctx.rebind.read().unwrap().allowlist())
 }
 
 async fn rebind_allowlist_add(

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -85,7 +85,7 @@ pub struct ServerCtx {
     pub filter_aaaa: bool,
     pub allow_from: crate::acl::AllowFromAcl,
     pub client_policy: crate::client_policy::ClientPolicySet,
-    pub rebind: crate::rebind::RebindFilter,
+    pub rebind: RwLock<crate::rebind::RebindFilter>,
 }
 
 /// Transport-agnostic DNS resolution. Runs the full pipeline (overrides, blocklist,
@@ -149,12 +149,16 @@ pub async fn resolve_query(
     // Runs after DNSSEC validation + the unfiltered cache insert above (so the
     // cache keeps the true record), before shaping. UpstreamError carries no
     // answers, so it's a no-op.
-    if !path.returns_trusted_local_data() {
-        let stripped = ctx.rebind.apply(&qname, &mut response);
+    let rebind_stripped = !path.returns_trusted_local_data() && {
+        let stripped = ctx.rebind.read().unwrap().apply(&qname, &mut response);
         if stripped > 0 {
             // A stripped Secure answer is no longer the validated one; don't
             // claim AD over a NODATA the validator never proved.
             response.header.authed_data = false;
+            ctx.stats
+                .lock()
+                .unwrap()
+                .record_rebind_stripped(stripped as u64);
             info!(
                 "REBIND | {} | stripped {} private RR(s) | {}",
                 qname,
@@ -162,7 +166,8 @@ pub async fn resolve_query(
                 path.as_str()
             );
         }
-    }
+        stripped > 0
+    };
 
     shape_response_for_client(&mut response, &query, ctx.filter_aaaa);
 
@@ -206,6 +211,7 @@ pub async fn resolve_query(
         rescode: response.header.rescode,
         latency_us: elapsed.as_micros() as u64,
         dnssec,
+        rebind_stripped,
     });
 
     Ok((resp_buffer, path))
@@ -926,7 +932,7 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
     use std::net::{Ipv4Addr, Ipv6Addr};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, RwLock};
     use tokio::sync::broadcast;
 
     // ---- InflightGuard unit tests ----
@@ -1391,7 +1397,7 @@ mod tests {
         let upstream_addr = crate::testutil::mock_upstream(resp).await;
 
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.rebind = crate::rebind::RebindFilter::new(true, &[], &[]).unwrap();
+        ctx.rebind = RwLock::new(crate::rebind::RebindFilter::new(true, &[], &[]).unwrap());
         ctx.forwarding_rules = vec![ForwardingRule::new(
             "evil.test".to_string(),
             UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]),
@@ -1411,7 +1417,7 @@ mod tests {
     #[tokio::test]
     async fn pipeline_rebind_leaves_local_override_untouched() {
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.rebind = crate::rebind::RebindFilter::new(true, &[], &[]).unwrap();
+        ctx.rebind = RwLock::new(crate::rebind::RebindFilter::new(true, &[], &[]).unwrap());
         ctx.overrides
             .write()
             .unwrap()
@@ -1438,7 +1444,7 @@ mod tests {
         // ranges — so the exclusion gate must exempt it, or rebind protection
         // would silently eat ad-blocking.
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.rebind = crate::rebind::RebindFilter::new(true, &[], &[]).unwrap();
+        ctx.rebind = RwLock::new(crate::rebind::RebindFilter::new(true, &[], &[]).unwrap());
         let mut domains = std::collections::HashSet::new();
         domains.insert("ads.tracker.test".to_string());
         ctx.blocklist.write().unwrap().swap_domains(domains, vec![]);

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -155,10 +155,7 @@ pub async fn resolve_query(
             // A stripped Secure answer is no longer the validated one; don't
             // claim AD over a NODATA the validator never proved.
             response.header.authed_data = false;
-            ctx.stats
-                .lock()
-                .unwrap()
-                .record_rebind_stripped(stripped as u64);
+            ctx.stats.lock().unwrap().record_rebind_stripped();
             info!(
                 "REBIND | {} | stripped {} private RR(s) | {}",
                 qname,
@@ -1412,6 +1409,37 @@ mod tests {
             "all-stripped is NODATA, not NXDOMAIN"
         );
         assert!(resp.answers.is_empty(), "private answer must be stripped");
+    }
+
+    #[tokio::test]
+    async fn pipeline_rebind_stats_count_queries_not_records() {
+        let mut resp = DnsPacket::new();
+        resp.header.response = true;
+        resp.header.rescode = ResultCode::NOERROR;
+        for last_octet in [1, 2] {
+            resp.answers.push(DnsRecord::A {
+                domain: "intranet.evil.test".to_string(),
+                addr: format!("192.168.1.{last_octet}").parse().unwrap(),
+                ttl: 60,
+            });
+        }
+        let upstream_addr = crate::testutil::mock_upstream(resp).await;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.rebind = RwLock::new(crate::rebind::RebindFilter::new(true, &[], &[]).unwrap());
+        ctx.forwarding_rules = vec![ForwardingRule::new(
+            "evil.test".to_string(),
+            UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]),
+        )];
+        let ctx = Arc::new(ctx);
+
+        let (resp, _) = resolve_in_test(&ctx, "intranet.evil.test", QueryType::A).await;
+        assert!(resp.answers.is_empty(), "both private answers stripped");
+        assert_eq!(
+            ctx.stats.lock().unwrap().snapshot().rebind_stripped,
+            1,
+            "queries.rebind_stripped counts affected queries, not stripped RRs"
+        );
     }
 
     #[tokio::test]

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -17,6 +17,7 @@ pub struct QueryLogEntry {
     pub rescode: ResultCode,
     pub latency_us: u64,
     pub dnssec: DnssecStatus,
+    pub rebind_stripped: bool,
 }
 
 pub struct QueryLog {
@@ -112,6 +113,7 @@ mod tests {
             rescode: ResultCode::NOERROR,
             latency_us: 500,
             dnssec: DnssecStatus::Indeterminate,
+            rebind_stripped: false,
         });
         assert!(log.heap_bytes() > empty);
     }

--- a/src/rebind.rs
+++ b/src/rebind.rs
@@ -33,6 +33,7 @@ const DEFAULT_RANGES: &[&str] = &[
 pub struct RebindFilter {
     enabled: bool,
     ranges: CidrMatcher,
+    range_strings: Vec<String>, // effective ranges, kept verbatim for the API
     allowlist: HashSet<String>, // normalized: lowercase, no trailing dot
 }
 
@@ -42,21 +43,46 @@ impl RebindFilter {
         allowlist: &[String],
         custom_ranges: &[String],
     ) -> Result<Self, String> {
-        let ranges = if custom_ranges.is_empty() {
-            let defaults: Vec<String> = DEFAULT_RANGES.iter().map(|s| s.to_string()).collect();
-            CidrMatcher::from_entries(&defaults, &[], "rebind_private_ranges")?
+        let range_strings: Vec<String> = if custom_ranges.is_empty() {
+            DEFAULT_RANGES.iter().map(|s| s.to_string()).collect()
         } else {
-            CidrMatcher::from_entries(custom_ranges, &[], "rebind_private_ranges")?
+            custom_ranges.to_vec()
         };
+        let ranges = CidrMatcher::from_entries(&range_strings, &[], "rebind_private_ranges")?;
         Ok(RebindFilter {
             enabled,
             ranges,
+            range_strings,
             allowlist: allowlist.iter().map(|d| normalize(d)).collect(),
         })
     }
 
     pub fn is_enabled(&self) -> bool {
         self.enabled
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    /// Effective private ranges (custom or built-in defaults), for the API.
+    pub fn ranges(&self) -> &[String] {
+        &self.range_strings
+    }
+
+    /// Allowlisted domains, sorted for stable output.
+    pub fn allowlist(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.allowlist.iter().cloned().collect();
+        v.sort();
+        v
+    }
+
+    pub fn add_to_allowlist(&mut self, domain: &str) {
+        self.allowlist.insert(normalize(domain));
+    }
+
+    pub fn remove_from_allowlist(&mut self, domain: &str) -> bool {
+        self.allowlist.remove(&normalize(domain))
     }
 
     /// Strip private A/AAAA answers (and private SVCB/HTTPS address hints) from

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -202,7 +202,7 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         filter_aaaa: config.server.filter_aaaa,
         allow_from,
         client_policy,
-        rebind,
+        rebind: RwLock::new(rebind),
     });
 
     let zone_count: usize = ctx.zone_map.len();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -292,8 +292,10 @@ impl ServerStats {
         }
     }
 
-    pub fn record_rebind_stripped(&mut self, n: u64) {
-        self.rebind_stripped += n;
+    /// One per affected query (not per stripped RR), matching the other
+    /// per-query counters in `queries.*`.
+    pub fn record_rebind_stripped(&mut self) {
+        self.rebind_stripped += 1;
     }
 
     pub fn record(

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -134,6 +134,7 @@ pub struct ServerStats {
     pub(crate) proxy_v2_rejected_signature: u64,
     pub(crate) proxy_v2_local_command: u64,
     pub(crate) proxy_v2_timeout: u64,
+    rebind_stripped: u64,
     started_at: SystemTime,
 }
 
@@ -286,8 +287,13 @@ impl ServerStats {
             proxy_v2_rejected_signature: 0,
             proxy_v2_local_command: 0,
             proxy_v2_timeout: 0,
+            rebind_stripped: 0,
             started_at: SystemTime::now(),
         }
+    }
+
+    pub fn record_rebind_stripped(&mut self, n: u64) {
+        self.rebind_stripped += n;
     }
 
     pub fn record(
@@ -361,6 +367,7 @@ impl ServerStats {
             proxy_v2_rejected_signature: self.proxy_v2_rejected_signature,
             proxy_v2_local_command: self.proxy_v2_local_command,
             proxy_v2_timeout: self.proxy_v2_timeout,
+            rebind_stripped: self.rebind_stripped,
         }
     }
 
@@ -371,7 +378,7 @@ impl ServerStats {
         let secs = uptime.as_secs() % 60;
 
         log::info!(
-            "STATS | uptime {}h{}m{}s | total {} | fwd {} | upstream {} | recursive {} | coalesced {} | cached {} | local {} | override {} | blocked {} | errors {} | up-udp {} | up-tcp {} | up-doh {} | up-dot {} | up-odoh {}",
+            "STATS | uptime {}h{}m{}s | total {} | fwd {} | upstream {} | recursive {} | coalesced {} | cached {} | local {} | override {} | blocked {} | errors {} | up-udp {} | up-tcp {} | up-doh {} | up-dot {} | up-odoh {} | rebind {}",
             hours, mins, secs,
             self.queries_total,
             self.queries_forwarded,
@@ -388,6 +395,7 @@ impl ServerStats {
             self.upstream_transport_doh,
             self.upstream_transport_dot,
             self.upstream_transport_odoh,
+            self.rebind_stripped,
         );
     }
 }
@@ -418,4 +426,5 @@ pub struct StatsSnapshot {
     pub proxy_v2_rejected_signature: u64,
     pub proxy_v2_local_command: u64,
     pub proxy_v2_timeout: u64,
+    pub rebind_stripped: u64,
 }

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -67,7 +67,7 @@ pub async fn test_ctx() -> ServerCtx {
         filter_aaaa: false,
         allow_from: crate::acl::AllowFromAcl::default(),
         client_policy: crate::client_policy::ClientPolicySet::default(),
-        rebind: crate::rebind::RebindFilter::default(),
+        rebind: std::sync::RwLock::new(crate::rebind::RebindFilter::default()),
     }
 }
 


### PR DESCRIPTION
Stacked follow-up to #279, which shipped the static DNS-rebinding filter but explicitly left runtime management and observability as a TODO ("REST API for runtime enable/allowlist management is a stacked follow-up").

## What's in this PR

**REST API:**
- `GET /rebind` → `{ enabled, ranges, allowlist }` — full status, including the allowlist
- `PUT /rebind/toggle` `{ enabled }`
- `POST /rebind/allowlist` `{ domain }`
- `DELETE /rebind/allowlist/{domain}`

(No separate `GET /rebind/allowlist` — `GET /rebind` already returns the list. This differs from `/blocking/*`, where `/blocking/stats` reports only the allowlist *size*, so blocking needs its own list route.)

`RebindFilter` moves into `RwLock` for runtime mutation and grows `set_enabled` / `add_to_allowlist` / `remove_from_allowlist` / `ranges` / `allowlist` accessors.

**Query-log visibility (the safety-critical bit).** A per-query `rebind_stripped` flag flows into the query log, the `/query-log` API, and the dashboard, where stripped rows get a "stripped" badge and an inline **allow** button (cloning the BLOCKED-row flow). This converts the feature's core footgun — silently breaking split-horizon/homelab DNS with no visible cause — into a one-click fix.

**Observability.** A `rebind_stripped` counter in `GET /stats` (`queries.rebind_stripped`) and the periodic `STATS` log line.

## Deferred to a later PR
The dedicated dashboard **Rebinding-Protection panel** (toggle + allowlist management + enable confirmation), per the UX review. This PR ships the diagnosability that makes the feature safe to enable; the management panel is additive.

## Testing
- 521 lib tests pass; `cargo fmt --check` and `clippy` clean on all changed files.
- Existing rebind/svcb/ipv6hint tests unchanged and green.