### PR TITLE
docs(config): document HaGeZi NSFW blocklist path in example config

### DIFF
--- a/numa.toml
+++ b/numa.toml
@@ -115,6 +115,7 @@ api_port = 5380
 # refresh_hours = 24
 # lists = [
 #     "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/hosts/pro.txt",
+#     "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/nsfw-onlydomains.txt",  # adult-content (opt-in; hagezi ships nsfw only as wildcard/adblock, not hosts/)
 #     "file:///etc/numa/local-blocklist.txt",  # local hosts-style file
 #     "/etc/numa/extra-blocks.txt",            # bare absolute path also works
 # ]


### PR DESCRIPTION
## What

Adds a commented-out HaGeZi NSFW list entry to the example `numa.toml`, alongside the existing `pro.txt` line.

```toml
#     "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/nsfw-onlydomains.txt",  # adult-content (opt-in; hagezi ships nsfw only as wildcard/adblock, not hosts/)
```

## Why

HaGeZi **no longer publishes its NSFW list in `hosts/` format** — it now ships only as `wildcard/`, `adblock/`, `dnsmasq/`, and `rpz/`. The intuitive guess (`hosts/nsfw.txt`, mirroring `hosts/pro.txt`) **404s**. Numa fetches the 404 as an empty source, so the list loads 0 domains and adult content silently stays unblocked — no error surfaced to the user.

Hit this in practice: a config pointing at `hosts/nsfw.txt` showed `nsfw.txt` as an active source in the dashboard, yet `pornhub.com` resolved as *Allowed — not in blocklist*.

`wildcard/nsfw-onlydomains.txt` is plain apex domains (one per line), which `blocklist.rs` already parses, and it contains the major sites (`pornhub.com`, `xvideos.com`, `xnxx.com`, `redtube.com`). The trailing comment records *why* the path differs from the `hosts/pro.txt` line so the next person doesn't repeat the trap.

## Notes

- Opt-in only; NSFW is intentionally **not** added to any shipped default (it's absent from HaGeZi's combined Pro/Pro++/Ultimate tiers too).
- Docs-only; no code change.