### PR TITLE
docs(config): document [[client_policy]] in example numa.toml

### DIFF
--- a/numa.toml
+++ b/numa.toml
@@ -121,6 +121,23 @@ api_port = 5380
 # ]
 # allowlist = ["example.com"]  # domains to never block
 
+# ── Per-client domain policies ─────────────────────────────────────
+# Block or allow specific domains for specific clients, on top of the
+# global blocklist above. `block`/`allow` use the same adblock syntax
+# as global lists. Loopback always bypasses. Rules layer in order: the
+# first rule matching the client that has an explicit block/allow for
+# the name wins; within a rule, allow beats block.
+#
+# [[client_policy]]
+# from    = ["192.168.1.0/24"]   # clients this rule applies to (CIDRs/IPs)
+# exclude = ["192.168.1.254"]    # carve hosts out of the range (e.g. your own device)
+# block   = ["youtube.com", "*.tiktok.com"]
+# allow   = ["safe.example.com"] # exempt a name the global list would block
+#
+# [[client_policy]]
+# from  = ["10.0.0.50"]          # a single host: stricter rules just for it
+# block = ["reddit.com"]
+
 [cache]
 max_entries = 100000
 min_ttl = 60


### PR DESCRIPTION
## Summary

- The per-client domain block/allow feature (`[[client_policy]]`, shipped in #239) had **zero presence in the example `numa.toml`**, making it undiscoverable to anyone configuring Numa from the example rather than reading the source or docs site.
- Adds a commented `[[client_policy]]` block right after `[blocking]` (its global counterpart), documenting `from` / `exclude` / `block` / `allow` plus the rule-layering semantics (loopback bypass, first explicit decision wins, allow beats block within a rule).
- Field names verified against `ClientPolicyConfig` in `src/config.rs`. Comment-only — no behavior change, no parse impact on defaults.

Surfaced while triaging #286 (per-CIDR `filter_aaaa`), which would add a second per-client CIDR feature; this closes the existing doc gap first.

## Test plan

- Comment-only change to `numa.toml`; touches no Rust and no active config (all lines commented). Nothing to run.
- Sanity-checked the field names against `ClientPolicyConfig` so an uncommented copy round-trips.