### PR TITLE
fix(nix): vendor hash-free via cargoLock.lockFile; sync Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,15 +3110,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779877693,
-        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
+        "lastModified": 1780930886,
+        "narHash": "sha256-rppURzHviaQN131F+nLiLdGfcb0uCd9gGP0E5+iw9MI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
+        "rev": "8c3cede7ddc26bd659d2d383b5610efbd2c7a16e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,11 @@
                 pname = "numa";
                 version = (lib.importTOML ./Cargo.toml).package.version;
                 src = ./.;
-                cargoHash = "sha256-UQaJZYHtECSKU4Fulocn0LzJkXPZJfjhdpie6niwTtM=";
+                # Per-crate hashes come from Cargo.lock, so there is no aggregate
+                # cargoHash to recompute on every dep change. Needs nixpkgs >= the
+                # 2026-05-27 importCargoLock->static.crates.io migration (PR #524985)
+                # to avoid crates.io/api/v1 403s in the build sandbox.
+                cargoLock.lockFile = ./Cargo.lock;
                 meta = {
                   description = "Portable DNS resolver in Rust";
                   homepage = "https://numa.rs";


### PR DESCRIPTION
## What

Turns CI green and **ends the `cargoHash` treadmill** — three coupled changes:

| File | Change |
|---|---|
| `Cargo.lock` | drop orphaned `windows-sys 0.59.0` stanza |
| `flake.nix` | `cargoLock.lockFile = ./Cargo.lock;` — delete the pinned `cargoHash` |
| `flake.lock` | nixpkgs `4100e83` → `8c3cede` (2026-05-27 → 2026-06-08) |

## Why

**The red CI** is the AUR publish job (not the docs PR that preceded it). `Cargo.lock` carried an orphaned `windows-sys 0.59.0` left by the ring-provider / windows-sys-bump commits, so the AUR `cargo --locked` build refused to proceed. Syncing the lock fixes it.

**The treadmill.** That lock sync would normally force a manual `cargoHash` recompute (the tax we pay on every dep change). Instead this switches vendoring to `cargoLock.lockFile`, which derives per-crate hashes from `Cargo.lock` itself — no aggregate hash to maintain, ever again.

**Why this is now safe** (it wasn't before — see #252). `importCargoLock` used to fetch from `crates.io/api/v1`, which 403s for non-cargo User-Agents in the nix sandbox — the exact reason #252 moved us *to* `cargoHash`. nixpkgs **PR #524985** (merged 2026-05-27) migrated `importCargoLock` to `static.crates.io`. Bumping the nixpkgs pin past that commit is the load-bearing change.

## Verification

Local "green" is meaningless here (the cache masks the 403). So I reproduced the **CI sandbox condition**: deleted a vendored crate and re-realized it with the binary cache disabled (`--option substitute false --option substituters ""`), forcing a real network fetch. It pulled from `static.crates.io`, exit 0, **no 403**. The new pinned `import-cargo-lock.nix` confirms the `static.crates.io` URL at the source level.

The `nix-build` CI job (clean Linux sandbox) is the final word — that's the check to watch on this PR.