### PR TITLE
feat(persist): durable rebind + blocking allowlists

### DIFF
--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -3,10 +3,12 @@ use std::time::{Duration, Instant};
 
 use log::{info, warn};
 
+use crate::domain_list::PersistedDomainList;
+
 #[derive(Debug)]
 pub struct BlocklistStore {
     domains: HashSet<String>,
-    allowlist: HashSet<String>,
+    allowlist: PersistedDomainList,
     enabled: bool,
     paused_until: Option<Instant>,
     list_sources: Vec<String>,
@@ -60,17 +62,13 @@ pub struct BlocklistStats {
     pub last_refresh_secs_ago: Option<u64>,
 }
 
-impl Default for BlocklistStore {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl BlocklistStore {
-    pub fn new() -> Self {
+    /// `allowlist` arrives pre-seeded (config entries + persisted runtime
+    /// entries) — the orchestrator owns that wiring.
+    pub fn new(allowlist: PersistedDomainList) -> Self {
         BlocklistStore {
             domains: HashSet::new(),
-            allowlist: HashSet::new(),
+            allowlist,
             enabled: true,
             paused_until: None,
             list_sources: Vec::new(),
@@ -88,7 +86,7 @@ impl BlocklistStore {
             }
         }
         let domain = normalize(domain);
-        if find_in_set(&domain, &self.allowlist).is_some() {
+        if self.allowlist.find_normalized(&domain).is_some() {
             return false;
         }
         find_in_set(&domain, &self.domains).is_some()
@@ -107,7 +105,7 @@ impl BlocklistStore {
 
         let domain = normalize(domain);
 
-        if let Some(matched) = find_in_set(&domain, &self.allowlist) {
+        if let Some(matched) = self.allowlist.find_normalized(&domain) {
             let reason = if matched == domain {
                 "exact match in allowlist"
             } else {
@@ -158,25 +156,25 @@ impl BlocklistStore {
             .unwrap_or(false)
     }
 
+    /// Persists across restarts (no-op for domains the config already covers).
     pub fn add_to_allowlist(&mut self, domain: &str) {
-        self.allowlist.insert(normalize(domain));
+        self.allowlist.insert(domain);
     }
 
+    /// False for config-declared entries — those are file-owned.
     pub fn remove_from_allowlist(&mut self, domain: &str) -> bool {
-        self.allowlist.remove(&normalize(domain))
+        self.allowlist.remove(domain)
     }
 
     pub fn allowlist(&self) -> Vec<String> {
-        self.allowlist.iter().cloned().collect()
+        self.allowlist.entries()
     }
 
     pub fn heap_bytes(&self) -> usize {
         let per_slot_overhead = std::mem::size_of::<u64>() + std::mem::size_of::<String>() + 1;
         let domains_table = self.domains.capacity() * per_slot_overhead;
         let domains_heap: usize = self.domains.iter().map(|d| d.capacity()).sum();
-        let allow_table = self.allowlist.capacity() * per_slot_overhead;
-        let allow_heap: usize = self.allowlist.iter().map(|d| d.capacity()).sum();
-        domains_table + domains_heap + allow_table + allow_heap
+        domains_table + domains_heap + self.allowlist.heap_bytes()
     }
 
     pub fn stats(&self) -> BlocklistStats {
@@ -254,7 +252,7 @@ mod tests {
     use super::*;
 
     fn store_with(domains: &[&str], allowlist: &[&str]) -> BlocklistStore {
-        let mut store = BlocklistStore::new();
+        let mut store = BlocklistStore::new(PersistedDomainList::unpersisted());
         store.swap_domains(domains.iter().map(|s| s.to_string()).collect(), vec![]);
         for d in allowlist {
             store.add_to_allowlist(d);
@@ -310,6 +308,29 @@ mod tests {
         let result = store.check("www.goatcounter.com");
         assert!(!result.blocked);
         assert_eq!(result.matched_rule.as_deref(), Some("goatcounter.com"));
+    }
+
+    #[test]
+    fn config_allowlist_entry_not_runtime_removable() {
+        let mut allow = PersistedDomainList::unpersisted();
+        allow.insert_from_config("safe.example.com");
+        let mut store = BlocklistStore::new(allow);
+        store.swap_domains(
+            [
+                "safe.example.com".to_string(),
+                "ads.example.com".to_string(),
+            ]
+            .into_iter()
+            .collect(),
+            vec![],
+        );
+        assert!(!store.remove_from_allowlist("safe.example.com"));
+        assert!(!store.is_blocked("safe.example.com"));
+        // Runtime entries stay removable.
+        store.add_to_allowlist("ads.example.com");
+        assert!(!store.is_blocked("ads.example.com"));
+        assert!(store.remove_from_allowlist("ads.example.com"));
+        assert!(store.is_blocked("ads.example.com"));
     }
 
     #[test]
@@ -393,7 +414,7 @@ mod tests {
 
     #[test]
     fn heap_bytes_grows_with_domains() {
-        let mut store = BlocklistStore::new();
+        let mut store = BlocklistStore::new(PersistedDomainList::unpersisted());
         let empty = store.heap_bytes();
         let domains: HashSet<String> = ["example.com", "example.org", "test.net"]
             .iter()

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -59,11 +59,12 @@ impl ClientPolicySet {
                     "{ctx}: must specify at least one valid domain in `block` or `allow`"
                 ));
             }
-            let mut store = BlocklistStore::new();
-            store.swap_domains(blocks, vec![]);
+            let mut allow = crate::domain_list::PersistedDomainList::unpersisted();
             for a in &allows {
-                store.add_to_allowlist(a);
+                allow.insert_from_config(a);
             }
+            let mut store = BlocklistStore::new(allow);
+            store.swap_domains(blocks, vec![]);
             rules.push(ClientPolicy {
                 nets: CidrMatcher::from_entries(&cfg.from, &cfg.exclude, &format!("{ctx}.from"))?,
                 store,

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1394,7 +1394,14 @@ mod tests {
         let upstream_addr = crate::testutil::mock_upstream(resp).await;
 
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.rebind = RwLock::new(crate::rebind::RebindFilter::new(true, &[], &[]).unwrap());
+        ctx.rebind = RwLock::new(
+            crate::rebind::RebindFilter::new(
+                true,
+                crate::domain_list::PersistedDomainList::unpersisted(),
+                &[],
+            )
+            .unwrap(),
+        );
         ctx.forwarding_rules = vec![ForwardingRule::new(
             "evil.test".to_string(),
             UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]),
@@ -1426,7 +1433,14 @@ mod tests {
         let upstream_addr = crate::testutil::mock_upstream(resp).await;
 
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.rebind = RwLock::new(crate::rebind::RebindFilter::new(true, &[], &[]).unwrap());
+        ctx.rebind = RwLock::new(
+            crate::rebind::RebindFilter::new(
+                true,
+                crate::domain_list::PersistedDomainList::unpersisted(),
+                &[],
+            )
+            .unwrap(),
+        );
         ctx.forwarding_rules = vec![ForwardingRule::new(
             "evil.test".to_string(),
             UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]),
@@ -1445,7 +1459,14 @@ mod tests {
     #[tokio::test]
     async fn pipeline_rebind_leaves_local_override_untouched() {
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.rebind = RwLock::new(crate::rebind::RebindFilter::new(true, &[], &[]).unwrap());
+        ctx.rebind = RwLock::new(
+            crate::rebind::RebindFilter::new(
+                true,
+                crate::domain_list::PersistedDomainList::unpersisted(),
+                &[],
+            )
+            .unwrap(),
+        );
         ctx.overrides
             .write()
             .unwrap()
@@ -1472,7 +1493,14 @@ mod tests {
         // ranges — so the exclusion gate must exempt it, or rebind protection
         // would silently eat ad-blocking.
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.rebind = RwLock::new(crate::rebind::RebindFilter::new(true, &[], &[]).unwrap());
+        ctx.rebind = RwLock::new(
+            crate::rebind::RebindFilter::new(
+                true,
+                crate::domain_list::PersistedDomainList::unpersisted(),
+                &[],
+            )
+            .unwrap(),
+        );
         let mut domains = std::collections::HashSet::new();
         domains.insert("ads.tracker.test".to_string());
         ctx.blocklist.write().unwrap().swap_domains(domains, vec![]);

--- a/src/domain_list.rs
+++ b/src/domain_list.rs
@@ -11,10 +11,11 @@ use std::path::PathBuf;
 use crate::blocklist::{find_in_set, normalize};
 use crate::persist::{load_json_vec, save_json};
 
+#[derive(Debug)]
 pub struct PersistedDomainList {
     config: HashSet<String>, // from numa.toml; reloaded each boot, never saved
     user: HashSet<String>,   // runtime-added; persisted to `persist_path`
-    persist_path: PathBuf,
+    persist_path: Option<PathBuf>,
 }
 
 impl PersistedDomainList {
@@ -24,7 +25,17 @@ impl PersistedDomainList {
         PersistedDomainList {
             config: HashSet::new(),
             user: HashSet::new(),
-            persist_path: crate::config_dir().join(filename),
+            persist_path: Some(crate::config_dir().join(filename)),
+        }
+    }
+
+    /// In-memory only: save and load are no-ops. For lists that are pure
+    /// config (per-client policies) and for tests.
+    pub fn unpersisted() -> Self {
+        PersistedDomainList {
+            config: HashSet::new(),
+            user: HashSet::new(),
+            persist_path: None,
         }
     }
 
@@ -56,8 +67,13 @@ impl PersistedDomainList {
     /// Exact-or-parent suffix match against either layer: `example.com`
     /// matches `nas.example.com` but never `evilexample.com`.
     pub fn matches(&self, qname: &str) -> bool {
-        let n = normalize(qname);
-        find_in_set(&n, &self.config).is_some() || find_in_set(&n, &self.user).is_some()
+        self.find_normalized(&normalize(qname)).is_some()
+    }
+
+    /// The matched suffix for an already-normalized domain (config layer
+    /// first), or None. Lets callers report *which* entry matched.
+    pub fn find_normalized<'a>(&self, domain: &'a str) -> Option<&'a str> {
+        find_in_set(domain, &self.config).or_else(|| find_in_set(domain, &self.user))
     }
 
     /// Whether the exact (normalized) domain came from config — lets the UI
@@ -73,10 +89,36 @@ impl PersistedDomainList {
         v
     }
 
+    /// Entry count. The layers are disjoint: runtime inserts and persisted
+    /// loads both skip domains the config layer already holds.
+    pub fn len(&self) -> usize {
+        self.config.len() + self.user.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.config.is_empty() && self.user.is_empty()
+    }
+
+    /// Estimated heap usage, mirroring `BlocklistStore::heap_bytes`.
+    pub fn heap_bytes(&self) -> usize {
+        let per_slot_overhead = std::mem::size_of::<u64>() + std::mem::size_of::<String>() + 1;
+        let table = (self.config.capacity() + self.user.capacity()) * per_slot_overhead;
+        let strings: usize = self
+            .config
+            .iter()
+            .chain(self.user.iter())
+            .map(|d| d.capacity())
+            .sum();
+        table + strings
+    }
+
     /// Load persisted runtime entries. Call once at startup, after seeding
     /// config entries (so config takes precedence on overlap).
     pub fn load_persisted(&mut self) {
-        for domain in load_json_vec::<String>(&self.persist_path) {
+        let Some(path) = &self.persist_path else {
+            return;
+        };
+        for domain in load_json_vec::<String>(path) {
             let d = normalize(&domain);
             if !self.config.contains(&d) {
                 self.user.insert(d);
@@ -85,9 +127,12 @@ impl PersistedDomainList {
     }
 
     fn save(&self) {
+        let Some(path) = &self.persist_path else {
+            return;
+        };
         let mut entries: Vec<&String> = self.user.iter().collect();
         entries.sort();
-        save_json(&self.persist_path, &entries);
+        save_json(path, &entries);
     }
 }
 
@@ -95,14 +140,30 @@ impl PersistedDomainList {
 mod tests {
     use super::*;
 
-    /// Store whose persisted writes go to /dev/null (mirrors `service_store`
-    /// tests) — exercises the save path without touching the real config dir.
     fn test_list() -> PersistedDomainList {
-        PersistedDomainList {
-            config: HashSet::new(),
-            user: HashSet::new(),
-            persist_path: PathBuf::from("/dev/null"),
-        }
+        PersistedDomainList::unpersisted()
+    }
+
+    #[test]
+    fn save_load_roundtrip_preserves_user_entries() {
+        let path =
+            std::env::temp_dir().join(format!("numa-domain-list-{}.json", std::process::id()));
+        let mut l = test_list();
+        l.persist_path = Some(path.clone());
+        l.insert("user.example");
+        l.insert("config-overlap.example");
+
+        let mut reloaded = test_list();
+        reloaded.persist_path = Some(path.clone());
+        reloaded.insert_from_config("config-overlap.example");
+        reloaded.load_persisted();
+        let _ = std::fs::remove_file(&path);
+
+        assert!(reloaded.matches("user.example"));
+        assert!(!reloaded.is_config("user.example"));
+        // Config wins on overlap: the persisted copy must not shadow it.
+        assert!(reloaded.is_config("config-overlap.example"));
+        assert_eq!(reloaded.len(), 2);
     }
 
     #[test]

--- a/src/domain_list.rs
+++ b/src/domain_list.rs
@@ -19,14 +19,20 @@ pub struct PersistedDomainList {
 }
 
 impl PersistedDomainList {
-    /// `filename` is resolved under the platform config dir, e.g.
-    /// `rebind-allow.json`.
-    pub fn new(filename: &str) -> Self {
-        PersistedDomainList {
+    /// The production list: seeds `config_seeds`, then loads persisted
+    /// runtime entries from `filename` (resolved under the platform config
+    /// dir) — in that order, so config takes precedence on overlap.
+    pub fn new(filename: &str, config_seeds: &[String]) -> Self {
+        let mut list = PersistedDomainList {
             config: HashSet::new(),
             user: HashSet::new(),
             persist_path: Some(crate::config_dir().join(filename)),
+        };
+        for domain in config_seeds {
+            list.insert_from_config(domain);
         }
+        list.load_persisted();
+        list
     }
 
     /// In-memory only: save and load are no-ops. For lists that are pure
@@ -112,9 +118,7 @@ impl PersistedDomainList {
         table + strings
     }
 
-    /// Load persisted runtime entries. Call once at startup, after seeding
-    /// config entries (so config takes precedence on overlap).
-    pub fn load_persisted(&mut self) {
+    fn load_persisted(&mut self) {
         let Some(path) = &self.persist_path else {
             return;
         };

--- a/src/rebind.rs
+++ b/src/rebind.rs
@@ -3,11 +3,10 @@
 //! client's perimeter. Off by default. Runs only on remote/cache paths; local
 //! data (zones, overrides, `.numa`, sinkhole) is exempt by gating in `ctx.rs`.
 
-use std::collections::HashSet;
 use std::net::IpAddr;
 
 use crate::acl::CidrMatcher;
-use crate::blocklist::{find_in_set, normalize};
+use crate::domain_list::PersistedDomainList;
 use crate::packet::DnsPacket;
 use crate::question::QueryType;
 use crate::record::DnsRecord;
@@ -29,18 +28,19 @@ const DEFAULT_RANGES: &[&str] = &[
     "::/128",         // unspecified
 ];
 
-#[derive(Clone, Debug, Default)]
 pub struct RebindFilter {
     enabled: bool,
     ranges: CidrMatcher,
     range_strings: Vec<String>, // effective ranges, kept verbatim for the API
-    allowlist: HashSet<String>, // normalized: lowercase, no trailing dot
+    allowlist: PersistedDomainList,
 }
 
 impl RebindFilter {
+    /// `allowlist` arrives pre-seeded (config entries + persisted runtime
+    /// entries) — the orchestrator owns that wiring.
     pub fn new(
         enabled: bool,
-        allowlist: &[String],
+        allowlist: PersistedDomainList,
         custom_ranges: &[String],
     ) -> Result<Self, String> {
         let range_strings: Vec<String> = if custom_ranges.is_empty() {
@@ -53,7 +53,7 @@ impl RebindFilter {
             enabled,
             ranges,
             range_strings,
-            allowlist: allowlist.iter().map(|d| normalize(d)).collect(),
+            allowlist,
         })
     }
 
@@ -72,17 +72,17 @@ impl RebindFilter {
 
     /// Allowlisted domains, sorted for stable output.
     pub fn allowlist(&self) -> Vec<String> {
-        let mut v: Vec<String> = self.allowlist.iter().cloned().collect();
-        v.sort();
-        v
+        self.allowlist.entries()
     }
 
+    /// Persists across restarts (no-op for domains the config already covers).
     pub fn add_to_allowlist(&mut self, domain: &str) {
-        self.allowlist.insert(normalize(domain));
+        self.allowlist.insert(domain);
     }
 
+    /// False for config-declared entries — those are file-owned.
     pub fn remove_from_allowlist(&mut self, domain: &str) -> bool {
-        self.allowlist.remove(&normalize(domain))
+        self.allowlist.remove(domain)
     }
 
     /// Strip private A/AAAA answers (and private SVCB/HTTPS address hints) from
@@ -119,7 +119,7 @@ impl RebindFilter {
     }
 
     fn is_allowed(&self, qname: &str) -> bool {
-        !self.allowlist.is_empty() && find_in_set(&normalize(qname), &self.allowlist).is_some()
+        !self.allowlist.is_empty() && self.allowlist.matches(qname)
     }
 }
 
@@ -128,8 +128,11 @@ mod tests {
     use super::*;
 
     fn filter(allowlist: &[&str]) -> RebindFilter {
-        let allow: Vec<String> = allowlist.iter().map(|s| s.to_string()).collect();
-        RebindFilter::new(true, &allow, &[]).unwrap()
+        let mut allow = PersistedDomainList::unpersisted();
+        for d in allowlist {
+            allow.insert_from_config(d);
+        }
+        RebindFilter::new(true, allow, &[]).unwrap()
     }
 
     fn a(addr: &str) -> DnsRecord {
@@ -221,7 +224,7 @@ mod tests {
 
     #[test]
     fn disabled_passes_through() {
-        let f = RebindFilter::new(false, &[], &[]).unwrap();
+        let f = RebindFilter::new(false, PersistedDomainList::unpersisted(), &[]).unwrap();
         assert_eq!(
             run(&f, "evil.com", vec![a("192.168.1.1")]),
             (0, vec![a("192.168.1.1")])
@@ -231,13 +234,35 @@ mod tests {
     #[test]
     fn custom_ranges_override_defaults() {
         // Only block ULA; RFC1918 v4 now passes.
-        let f = RebindFilter::new(true, &[], &["fc00::/7".to_string()]).unwrap();
+        let f = RebindFilter::new(
+            true,
+            PersistedDomainList::unpersisted(),
+            &["fc00::/7".to_string()],
+        )
+        .unwrap();
         let r = run(&f, "evil.com", vec![a("192.168.1.1"), aaaa("fd00::1")]);
         assert_eq!(r, (1, vec![a("192.168.1.1")]));
     }
 
     #[test]
     fn invalid_custom_range_errors() {
-        assert!(RebindFilter::new(true, &[], &["not-a-cidr".to_string()]).is_err());
+        assert!(RebindFilter::new(
+            true,
+            PersistedDomainList::unpersisted(),
+            &["not-a-cidr".to_string()]
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn runtime_allowlist_add_exempts_remove_restores() {
+        let mut f = filter(&["config.example"]);
+        f.add_to_allowlist("nas.example.com");
+        assert_eq!(run(&f, "nas.example.com", vec![a("192.168.1.50")]).0, 0);
+        assert!(f.remove_from_allowlist("nas.example.com"));
+        assert_eq!(run(&f, "nas.example.com", vec![a("192.168.1.50")]).0, 1);
+        // Config entries are file-owned: not removable at runtime.
+        assert!(!f.remove_from_allowlist("config.example"));
+        assert_eq!(run(&f, "config.example", vec![a("10.0.0.1")]).0, 0);
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -63,10 +63,12 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         resolve_upstream_pool(&config, &system_dns, &root_hints, &bootstrap_resolver).await?;
     let api_port = config.server.api_port;
 
-    let mut blocklist = BlocklistStore::new();
+    let mut blocking_allow = crate::domain_list::PersistedDomainList::new("blocking-allow.json");
     for domain in &config.blocking.allowlist {
-        blocklist.add_to_allowlist(domain);
+        blocking_allow.insert_from_config(domain);
     }
+    blocking_allow.load_persisted();
+    let mut blocklist = BlocklistStore::new(blocking_allow);
     if !config.blocking.enabled {
         blocklist.set_enabled(false);
     }
@@ -140,17 +142,20 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         );
     }
 
+    let mut rebind_allow = crate::domain_list::PersistedDomainList::new("rebind-allow.json");
+    for domain in &config.server.rebind_allowlist {
+        rebind_allow.insert_from_config(domain);
+    }
+    rebind_allow.load_persisted();
+    let rebind_allow_count = rebind_allow.len();
     let rebind = crate::rebind::RebindFilter::new(
         config.server.rebind_protect,
-        &config.server.rebind_allowlist,
+        rebind_allow,
         &config.server.rebind_private_ranges,
     )
     .map_err(|e| format!("invalid [server] rebind config: {e}"))?;
     if rebind.is_enabled() {
-        info!(
-            "DNS rebinding protection enabled ({} allowlist entries)",
-            config.server.rebind_allowlist.len()
-        );
+        info!("DNS rebinding protection enabled ({rebind_allow_count} allowlist entries)");
     }
 
     let sockets = bind_udp_listeners(&config.server.bind_addr).await?;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -63,12 +63,10 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         resolve_upstream_pool(&config, &system_dns, &root_hints, &bootstrap_resolver).await?;
     let api_port = config.server.api_port;
 
-    let mut blocking_allow = crate::domain_list::PersistedDomainList::new("blocking-allow.json");
-    for domain in &config.blocking.allowlist {
-        blocking_allow.insert_from_config(domain);
-    }
-    blocking_allow.load_persisted();
-    let mut blocklist = BlocklistStore::new(blocking_allow);
+    let mut blocklist = BlocklistStore::new(crate::domain_list::PersistedDomainList::new(
+        "blocking-allow.json",
+        &config.blocking.allowlist,
+    ));
     if !config.blocking.enabled {
         blocklist.set_enabled(false);
     }
@@ -142,21 +140,22 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         );
     }
 
-    let mut rebind_allow = crate::domain_list::PersistedDomainList::new("rebind-allow.json");
-    for domain in &config.server.rebind_allowlist {
-        rebind_allow.insert_from_config(domain);
+    let rebind_allow = crate::domain_list::PersistedDomainList::new(
+        "rebind-allow.json",
+        &config.server.rebind_allowlist,
+    );
+    if config.server.rebind_protect {
+        info!(
+            "DNS rebinding protection enabled ({} allowlist entries)",
+            rebind_allow.len()
+        );
     }
-    rebind_allow.load_persisted();
-    let rebind_allow_count = rebind_allow.len();
     let rebind = crate::rebind::RebindFilter::new(
         config.server.rebind_protect,
         rebind_allow,
         &config.server.rebind_private_ranges,
     )
     .map_err(|e| format!("invalid [server] rebind config: {e}"))?;
-    if rebind.is_enabled() {
-        info!("DNS rebinding protection enabled ({rebind_allow_count} allowlist entries)");
-    }
 
     let sockets = bind_udp_listeners(&config.server.bind_addr).await?;
 

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -31,7 +31,9 @@ pub async fn test_ctx() -> ServerCtx {
         refreshing: Mutex::new(HashSet::new()),
         stats: Mutex::new(ServerStats::new()),
         overrides: RwLock::new(OverrideStore::new()),
-        blocklist: RwLock::new(BlocklistStore::new()),
+        blocklist: RwLock::new(BlocklistStore::new(
+            crate::domain_list::PersistedDomainList::unpersisted(),
+        )),
         query_log: Mutex::new(QueryLog::new(100)),
         services: Mutex::new(ServiceStore::new()),
         lan_peers: Mutex::new(PeerStore::new(90)),
@@ -67,7 +69,14 @@ pub async fn test_ctx() -> ServerCtx {
         filter_aaaa: false,
         allow_from: crate::acl::AllowFromAcl::default(),
         client_policy: crate::client_policy::ClientPolicySet::default(),
-        rebind: std::sync::RwLock::new(crate::rebind::RebindFilter::default()),
+        rebind: std::sync::RwLock::new(
+            crate::rebind::RebindFilter::new(
+                false,
+                crate::domain_list::PersistedDomainList::unpersisted(),
+                &[],
+            )
+            .unwrap(),
+        ),
     }
 }
 


### PR DESCRIPTION
PR 3 of the persistence chain (#287 → #288 → this → manual blocklist closing #257). Wires #288's `PersistedDomainList` into both runtime-editable allowlists, graduating them together from the ephemeral one-`HashSet` model so they stay uniform.

## What changes

**Behavior:** domains added via `POST /rebind/allowlist` or `POST /blocking/allowlist` (and the dashboard allow buttons) now survive restart, persisted to `rebind-allow.json` / `blocking-allow.json` under the config dir. The TOML is never rewritten.

**Semantics:** config-declared entries are file-owned — `DELETE` on them returns 404 instead of ephemerally removing them until restart. This matches the services persistence model. The dashboard panel that *marks* config vs runtime entries (`is_config`) is the deferred Rebinding-Protection panel's job.

**Wiring:** `serve.rs` (the orchestrator) seeds each list from `numa.toml`, calls `load_persisted()`, and injects the list into `RebindFilter::new` / `BlocklistStore::new`. Stores own behavior; construction wiring lives in one place.

**`PersistedDomainList` grows what the consumers needed:**
- `find_normalized` — `check()` still reports *which* allowlist entry matched
- `len` / `is_empty` / `heap_bytes` — stats and memory accounting
- `persist_path: Option<PathBuf>` + `unpersisted()` — pure in-memory lists for per-client `[[client_policy]]` stores (config-only by design) and for all tests, replacing the `/dev/null` test hack

## Testing
- save/load roundtrip through a real temp file, including config-shadows-persisted overlap
- config-vs-runtime removal semantics on both stores
- 532 lib tests pass (+4); fmt clean; clippy clean on changed files (the 4 remaining warnings are the known toolchain drift in `recursive.rs`/`srtt.rs`)

Refs #257.