### PR TITLE
feat(blocking): manual blocklist from the dashboard (closes #257)

### DIFF
--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1132,7 +1132,7 @@ function applyLogFilter() {
       : e.rebind_stripped
       ? ` <button class="btn-delete" data-domain="${h(e.domain)}" onclick="postDomain('/rebind/allowlist', this.dataset.domain)" title="Stop stripping private IPs for this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
       : e.path !== 'LOCAL'
-      ? ` <button class="btn-delete" data-domain="${h(e.domain.replace(/^www\./, ''))}" onclick="postDomain('/blocking/blocklist', this.dataset.domain)" title="Block this domain (and subdomains)" style="font-size:0.65rem;">block</button>`
+      ? ` <button class="btn-delete" data-domain="${h(e.domain)}" onclick="postDomain('/blocking/blocklist', this.dataset.domain)" title="Blocks this domain and its subdomains" style="font-size:0.65rem;">block</button>`
       : '';
     const rebindTag = e.rebind_stripped
       ? ` <span class="path-tag" style="background:rgba(192,98,58,0.12);color:var(--amber-dim);" title="Private IPs stripped by rebind protection">stripped</span>`

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1131,6 +1131,8 @@ function applyLogFilter() {
       ? ` <button class="btn-delete" data-domain="${h(e.domain)}" onclick="postDomain('/blocking/allowlist', this.dataset.domain)" title="Allow this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
       : e.rebind_stripped
       ? ` <button class="btn-delete" data-domain="${h(e.domain)}" onclick="postDomain('/rebind/allowlist', this.dataset.domain)" title="Stop stripping private IPs for this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
+      : e.path !== 'LOCAL'
+      ? ` <button class="btn-delete" data-domain="${h(e.domain)}" onclick="postDomain('/blocking/blocklist', this.dataset.domain)" title="Block this domain" style="font-size:0.65rem;">block</button>`
       : '';
     const rebindTag = e.rebind_stripped
       ? ` <span class="path-tag" style="background:rgba(192,98,58,0.12);color:var(--amber-dim);" title="Private IPs stripped by rebind protection">stripped</span>`
@@ -1230,7 +1232,7 @@ function renderCache(entries) {
 
 async function refresh() {
   try {
-    const [stats, logs, overrides, cache, services, blockingInfo, allowlist] = await Promise.all([
+    const [stats, logs, overrides, cache, services, blockingInfo, allowlist, manualBlocks] = await Promise.all([
       fetchJSON('/stats'),
       fetchJSON('/query-log?limit=200'),
       fetchJSON('/overrides'),
@@ -1238,6 +1240,7 @@ async function refresh() {
       fetchJSON('/services'),
       fetchJSON('/blocking/stats'),
       fetchJSON('/blocking/allowlist'),
+      fetchJSON('/blocking/blocklist'),
     ]);
 
     // Connection status
@@ -1350,7 +1353,7 @@ async function refresh() {
     renderCache(cache);
     renderServices(services);
     renderBlockingInfo(blockingInfo);
-    renderAllowlist(allowlist);
+    renderAllowlist(allowlist, manualBlocks);
     renderMemory(stats.memory, stats);
 
   } catch (err) {
@@ -1468,18 +1471,27 @@ function renderBlockingInfo(info) {
   `;
 }
 
-function renderAllowlist(entries) {
+function renderAllowlist(entries, manualBlocks) {
   if (document.activeElement && document.activeElement.id === 'allowDomainInput') return;
   const el = document.getElementById('blockingAllowlist');
   const count = entries.length;
+  const blocked = manualBlocks || [];
   el.innerHTML = `
     <div style="font-size:0.65rem;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-dim);margin-bottom:0.4rem;">Allowlist${count ? ` (${count})` : ''}</div>
     ${count ? entries.map(d => `
       <div style="display:flex;justify-content:space-between;align-items:center;padding:0.25rem 0;border-bottom:1px solid var(--border);">
-        <span style="font-family:var(--font-mono);font-size:0.75rem;color:var(--emerald);">${d}</span>
-        <button class="btn-delete" onclick="removeAllowlistDomain('${d}')">&times;</button>
+        <span style="font-family:var(--font-mono);font-size:0.75rem;color:var(--emerald);">${h(d)}</span>
+        <button class="btn-delete" data-domain="${h(d)}" onclick="deleteDomain('/blocking/allowlist', this.dataset.domain)">&times;</button>
       </div>
     `).join('') : '<div class="empty-state">No exceptions</div>'}
+    ${blocked.length ? `
+    <div style="font-size:0.65rem;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-dim);margin:0.8rem 0 0.4rem;">Manually blocked (${blocked.length})</div>
+    ${blocked.map(d => `
+      <div style="display:flex;justify-content:space-between;align-items:center;padding:0.25rem 0;border-bottom:1px solid var(--border);">
+        <span style="font-family:var(--font-mono);font-size:0.75rem;color:var(--rose);">${h(d)}</span>
+        <button class="btn-delete" data-domain="${h(d)}" onclick="deleteDomain('/blocking/blocklist', this.dataset.domain)">&times;</button>
+      </div>
+    `).join('')}` : ''}
     <form onsubmit="return addAllowlistDomain(event)" style="display:flex;gap:0.4rem;margin-top:0.4rem;">
       <input type="text" id="allowDomainInput" placeholder="domain to allow" required style="flex:1;font-family:var(--font-mono);font-size:0.75rem;padding:0.35rem 0.5rem;border:1px solid var(--border);border-radius:4px;background:var(--bg-surface);color:var(--text-primary);outline:none;">
       <button type="submit" class="btn" style="background:var(--emerald);color:var(--text-on-btn);flex-shrink:0;">Allow</button>
@@ -1495,9 +1507,9 @@ async function addAllowlistDomain(event) {
   return false;
 }
 
-async function removeAllowlistDomain(domain) {
+async function deleteDomain(path, domain) {
   try {
-    await fetch(API + '/blocking/allowlist/' + encodeURIComponent(domain), { method: 'DELETE' });
+    await fetch(API + path + '/' + encodeURIComponent(domain), { method: 'DELETE' });
     refresh();
   } catch (err) {}
 }

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1132,7 +1132,7 @@ function applyLogFilter() {
       : e.rebind_stripped
       ? ` <button class="btn-delete" data-domain="${h(e.domain)}" onclick="postDomain('/rebind/allowlist', this.dataset.domain)" title="Stop stripping private IPs for this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
       : e.path !== 'LOCAL'
-      ? ` <button class="btn-delete" data-domain="${h(e.domain)}" onclick="postDomain('/blocking/blocklist', this.dataset.domain)" title="Block this domain" style="font-size:0.65rem;">block</button>`
+      ? ` <button class="btn-delete" data-domain="${h(e.domain.replace(/^www\./, ''))}" onclick="postDomain('/blocking/blocklist', this.dataset.domain)" title="Block this domain (and subdomains)" style="font-size:0.65rem;">block</button>`
       : '';
     const rebindTag = e.rebind_stripped
       ? ` <span class="path-tag" style="background:rgba(192,98,58,0.12);color:var(--amber-dim);" title="Private IPs stripped by rebind protection">stripped</span>`

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1128,7 +1128,7 @@ function applyLogFilter() {
 
   tbody.innerHTML = filtered.map(e => {
     const allowBtn = e.path === 'BLOCKED'
-      ? ` <button class="btn-delete" data-domain="${h(e.domain)}" onclick="postDomain('/blocking/allowlist', this.dataset.domain)" title="Allow this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
+      ? ` <button class="btn-delete" data-domain="${h(e.domain)}" onclick="unblockDomain(this.dataset.domain)" title="Allow this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
       : e.rebind_stripped
       ? ` <button class="btn-delete" data-domain="${h(e.domain)}" onclick="postDomain('/rebind/allowlist', this.dataset.domain)" title="Stop stripping private IPs for this domain" style="color:var(--emerald);font-size:0.65rem;">allow</button>`
       : e.path !== 'LOCAL'
@@ -1420,7 +1420,7 @@ async function checkDomain(event) {
       el.className = 'check-result-blocked';
       el.innerHTML = `<strong>Blocked</strong> — ${h(result.reason)}` +
         (result.matched_rule ? `<br>Rule: <code>${h(result.matched_rule)}</code>` : '') +
-        ` <button class="btn-delete" data-domain="${h(domain)}" onclick="postDomain('/blocking/allowlist', this.dataset.domain)" style="color:var(--emerald);font-size:0.7rem;margin-left:0.4rem;">allow</button>`;
+        ` <button class="btn-delete" data-domain="${h(domain)}" onclick="unblockDomain(this.dataset.domain)" style="color:var(--emerald);font-size:0.7rem;margin-left:0.4rem;">allow</button>`;
     } else {
       el.className = 'check-result-allowed';
       el.innerHTML = `<strong>Allowed</strong> — ${h(result.reason)}` +
@@ -1505,6 +1505,16 @@ async function addAllowlistDomain(event) {
   const domain = input.value.trim();
   if (domain && (await postDomain('/blocking/allowlist', domain))) input.value = '';
   return false;
+}
+
+// Undo a manual block if one exists; otherwise add an allowlist exception
+// (for domains blocked by a list, which the user can't edit).
+async function unblockDomain(domain) {
+  try {
+    const res = await fetch(API + '/blocking/blocklist/' + encodeURIComponent(domain), { method: 'DELETE' });
+    if (res.ok) refresh();
+    else postDomain('/blocking/allowlist', domain);
+  } catch (err) {}
 }
 
 async function deleteDomain(path, domain) {

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1484,6 +1484,10 @@ function renderAllowlist(entries, manualBlocks) {
         <button class="btn-delete" data-domain="${h(d)}" onclick="deleteDomain('/blocking/allowlist', this.dataset.domain)">&times;</button>
       </div>
     `).join('') : '<div class="empty-state">No exceptions</div>'}
+    <form onsubmit="return addAllowlistDomain(event)" style="display:flex;gap:0.4rem;margin-top:0.4rem;">
+      <input type="text" id="allowDomainInput" placeholder="domain to allow" required style="flex:1;font-family:var(--font-mono);font-size:0.75rem;padding:0.35rem 0.5rem;border:1px solid var(--border);border-radius:4px;background:var(--bg-surface);color:var(--text-primary);outline:none;">
+      <button type="submit" class="btn" style="background:var(--emerald);color:var(--text-on-btn);flex-shrink:0;">Allow</button>
+    </form>
     ${blocked.length ? `
     <div style="font-size:0.65rem;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-dim);margin:0.8rem 0 0.4rem;">Manually blocked (${blocked.length})</div>
     ${blocked.map(d => `
@@ -1492,10 +1496,6 @@ function renderAllowlist(entries, manualBlocks) {
         <button class="btn-delete" data-domain="${h(d)}" onclick="deleteDomain('/blocking/blocklist', this.dataset.domain)">&times;</button>
       </div>
     `).join('')}` : ''}
-    <form onsubmit="return addAllowlistDomain(event)" style="display:flex;gap:0.4rem;margin-top:0.4rem;">
-      <input type="text" id="allowDomainInput" placeholder="domain to allow" required style="flex:1;font-family:var(--font-mono);font-size:0.75rem;padding:0.35rem 0.5rem;border:1px solid var(--border);border-radius:4px;background:var(--bg-surface);color:var(--text-primary);outline:none;">
-      <button type="submit" class="btn" style="background:var(--emerald);color:var(--text-on-btn);flex-shrink:0;">Allow</button>
-    </form>
   `;
 }
 

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1472,7 +1472,8 @@ function renderBlockingInfo(info) {
 }
 
 function renderAllowlist(entries, manualBlocks) {
-  if (document.activeElement && document.activeElement.id === 'allowDomainInput') return;
+  const focused = document.activeElement && document.activeElement.id;
+  if (focused === 'allowDomainInput' || focused === 'blockDomainInput') return;
   const el = document.getElementById('blockingAllowlist');
   const count = entries.length;
   const blocked = manualBlocks || [];
@@ -1484,26 +1485,29 @@ function renderAllowlist(entries, manualBlocks) {
         <button class="btn-delete" data-domain="${h(d)}" onclick="deleteDomain('/blocking/allowlist', this.dataset.domain)">&times;</button>
       </div>
     `).join('') : '<div class="empty-state">No exceptions</div>'}
-    <form onsubmit="return addAllowlistDomain(event)" style="display:flex;gap:0.4rem;margin-top:0.4rem;">
+    <form onsubmit="return addDomain(event, '/blocking/allowlist')" style="display:flex;gap:0.4rem;margin-top:0.4rem;">
       <input type="text" id="allowDomainInput" placeholder="domain to allow" required style="flex:1;font-family:var(--font-mono);font-size:0.75rem;padding:0.35rem 0.5rem;border:1px solid var(--border);border-radius:4px;background:var(--bg-surface);color:var(--text-primary);outline:none;">
       <button type="submit" class="btn" style="background:var(--emerald);color:var(--text-on-btn);flex-shrink:0;">Allow</button>
     </form>
-    ${blocked.length ? `
-    <div style="font-size:0.65rem;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-dim);margin:0.8rem 0 0.4rem;">Manually blocked (${blocked.length})</div>
+    <div style="font-size:0.65rem;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-dim);margin:0.8rem 0 0.4rem;">Manually blocked${blocked.length ? ` (${blocked.length})` : ''}</div>
     ${blocked.map(d => `
       <div style="display:flex;justify-content:space-between;align-items:center;padding:0.25rem 0;border-bottom:1px solid var(--border);">
         <span style="font-family:var(--font-mono);font-size:0.75rem;color:var(--rose);">${h(d)}</span>
         <button class="btn-delete" data-domain="${h(d)}" onclick="deleteDomain('/blocking/blocklist', this.dataset.domain)">&times;</button>
       </div>
-    `).join('')}` : ''}
+    `).join('')}
+    <form onsubmit="return addDomain(event, '/blocking/blocklist')" style="display:flex;gap:0.4rem;margin-top:0.4rem;">
+      <input type="text" id="blockDomainInput" placeholder="domain to block" required style="flex:1;font-family:var(--font-mono);font-size:0.75rem;padding:0.35rem 0.5rem;border:1px solid var(--border);border-radius:4px;background:var(--bg-surface);color:var(--text-primary);outline:none;">
+      <button type="submit" class="btn" style="background:var(--rose);color:var(--text-on-btn);flex-shrink:0;">Block</button>
+    </form>
   `;
 }
 
-async function addAllowlistDomain(event) {
+async function addDomain(event, path) {
   event.preventDefault();
-  const input = document.getElementById('allowDomainInput');
+  const input = event.target.querySelector('input');
   const domain = input.value.trim();
-  if (domain && (await postDomain('/blocking/allowlist', domain))) input.value = '';
+  if (domain && (await postDomain(path, domain))) input.value = '';
   return false;
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -50,6 +50,12 @@ pub fn router(ctx: Arc<ServerCtx>) -> Router {
             "/blocking/allowlist/{domain}",
             delete(blocking_allowlist_remove),
         )
+        .route("/blocking/blocklist", get(blocking_blocklist))
+        .route("/blocking/blocklist", post(blocking_blocklist_add))
+        .route(
+            "/blocking/blocklist/{domain}",
+            delete(blocking_blocklist_remove),
+        )
         .route("/rebind", get(rebind_status))
         .route("/rebind/toggle", put(rebind_toggle))
         .route("/rebind/allowlist", post(rebind_allowlist_add))
@@ -779,6 +785,38 @@ async fn blocking_allowlist_remove(
         .write()
         .unwrap()
         .remove_from_allowlist(&domain)
+    {
+        StatusCode::NO_CONTENT
+    } else {
+        StatusCode::NOT_FOUND
+    }
+}
+
+async fn blocking_blocklist(State(ctx): State<Arc<ServerCtx>>) -> Json<Vec<String>> {
+    let list = ctx.blocklist.read().unwrap().manual_blocklist();
+    Json(list)
+}
+
+async fn blocking_blocklist_add(
+    State(ctx): State<Arc<ServerCtx>>,
+    Json(req): Json<AllowlistRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    ctx.blocklist.write().unwrap().add_to_blocklist(&req.domain);
+    (
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "blocked": req.domain })),
+    )
+}
+
+async fn blocking_blocklist_remove(
+    State(ctx): State<Arc<ServerCtx>>,
+    Path(domain): Path<String>,
+) -> StatusCode {
+    if ctx
+        .blocklist
+        .write()
+        .unwrap()
+        .remove_from_blocklist(&domain)
     {
         StatusCode::NO_CONTENT
     } else {

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -9,6 +9,7 @@ use crate::domain_list::PersistedDomainList;
 pub struct BlocklistStore {
     domains: HashSet<String>,
     allowlist: PersistedDomainList,
+    manual: PersistedDomainList, // UI/API-blocked domains; survives list refresh
     enabled: bool,
     paused_until: Option<Instant>,
     list_sources: Vec<String>,
@@ -63,12 +64,13 @@ pub struct BlocklistStats {
 }
 
 impl BlocklistStore {
-    /// `allowlist` arrives pre-seeded (config entries + persisted runtime
-    /// entries) — the orchestrator owns that wiring.
-    pub fn new(allowlist: PersistedDomainList) -> Self {
+    /// Lists arrive pre-seeded (config entries + persisted runtime entries) —
+    /// the orchestrator owns that wiring.
+    pub fn new(allowlist: PersistedDomainList, manual: PersistedDomainList) -> Self {
         BlocklistStore {
             domains: HashSet::new(),
             allowlist,
+            manual,
             enabled: true,
             paused_until: None,
             list_sources: Vec::new(),
@@ -89,7 +91,8 @@ impl BlocklistStore {
         if self.allowlist.find_normalized(&domain).is_some() {
             return false;
         }
-        find_in_set(&domain, &self.domains).is_some()
+        self.manual.find_normalized(&domain).is_some()
+            || find_in_set(&domain, &self.domains).is_some()
     }
 
     pub fn check(&self, domain: &str) -> BlockCheckResult {
@@ -112,6 +115,10 @@ impl BlocklistStore {
                 "parent domain in allowlist"
             };
             return BlockCheckResult::allowed(matched, reason);
+        }
+
+        if let Some(matched) = self.manual.find_normalized(&domain) {
+            return BlockCheckResult::blocked(matched, "manually blocked");
         }
 
         if let Some(matched) = find_in_set(&domain, &self.domains) {
@@ -170,11 +177,25 @@ impl BlocklistStore {
         self.allowlist.entries()
     }
 
+    /// Persists across restarts; survives blocklist refresh (separate from
+    /// `domains`, which `swap_domains` replaces wholesale).
+    pub fn add_to_blocklist(&mut self, domain: &str) {
+        self.manual.insert(domain);
+    }
+
+    pub fn remove_from_blocklist(&mut self, domain: &str) -> bool {
+        self.manual.remove(domain)
+    }
+
+    pub fn manual_blocklist(&self) -> Vec<String> {
+        self.manual.entries()
+    }
+
     pub fn heap_bytes(&self) -> usize {
         let per_slot_overhead = std::mem::size_of::<u64>() + std::mem::size_of::<String>() + 1;
         let domains_table = self.domains.capacity() * per_slot_overhead;
         let domains_heap: usize = self.domains.iter().map(|d| d.capacity()).sum();
-        domains_table + domains_heap + self.allowlist.heap_bytes()
+        domains_table + domains_heap + self.allowlist.heap_bytes() + self.manual.heap_bytes()
     }
 
     pub fn stats(&self) -> BlocklistStats {
@@ -252,7 +273,10 @@ mod tests {
     use super::*;
 
     fn store_with(domains: &[&str], allowlist: &[&str]) -> BlocklistStore {
-        let mut store = BlocklistStore::new(PersistedDomainList::unpersisted());
+        let mut store = BlocklistStore::new(
+            PersistedDomainList::unpersisted(),
+            PersistedDomainList::unpersisted(),
+        );
         store.swap_domains(domains.iter().map(|s| s.to_string()).collect(), vec![]);
         for d in allowlist {
             store.add_to_allowlist(d);
@@ -314,7 +338,7 @@ mod tests {
     fn config_allowlist_entry_not_runtime_removable() {
         let mut allow = PersistedDomainList::unpersisted();
         allow.insert_from_config("safe.example.com");
-        let mut store = BlocklistStore::new(allow);
+        let mut store = BlocklistStore::new(allow, PersistedDomainList::unpersisted());
         store.swap_domains(
             [
                 "safe.example.com".to_string(),
@@ -331,6 +355,23 @@ mod tests {
         assert!(!store.is_blocked("ads.example.com"));
         assert!(store.remove_from_allowlist("ads.example.com"));
         assert!(store.is_blocked("ads.example.com"));
+    }
+
+    #[test]
+    fn manual_block_survives_refresh_and_respects_allowlist() {
+        let mut store = store_with(&[], &["safe.example.com"]);
+        store.add_to_blocklist("bad.example.com");
+        store.add_to_blocklist("safe.example.com");
+        assert!(store.is_blocked("bad.example.com"));
+        assert!(store.is_blocked("sub.bad.example.com"), "suffix match");
+        // Allowlist wins over a manual block, same as over list blocks.
+        assert!(!store.is_blocked("safe.example.com"));
+        // List refresh replaces `domains` wholesale; manual entries survive.
+        store.swap_domains(HashSet::new(), vec![]);
+        assert!(store.is_blocked("bad.example.com"));
+        assert_eq!(store.check("bad.example.com").reason, "manually blocked");
+        assert!(store.remove_from_blocklist("bad.example.com"));
+        assert!(!store.is_blocked("bad.example.com"));
     }
 
     #[test]
@@ -414,7 +455,10 @@ mod tests {
 
     #[test]
     fn heap_bytes_grows_with_domains() {
-        let mut store = BlocklistStore::new(PersistedDomainList::unpersisted());
+        let mut store = BlocklistStore::new(
+            PersistedDomainList::unpersisted(),
+            PersistedDomainList::unpersisted(),
+        );
         let empty = store.heap_bytes();
         let domains: HashSet<String> = ["example.com", "example.org", "test.net"]
             .iter()

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -63,7 +63,10 @@ impl ClientPolicySet {
             for a in &allows {
                 allow.insert_from_config(a);
             }
-            let mut store = BlocklistStore::new(allow);
+            let mut store = BlocklistStore::new(
+                allow,
+                crate::domain_list::PersistedDomainList::unpersisted(),
+            );
             store.swap_domains(blocks, vec![]);
             rules.push(ClientPolicy {
                 nets: CidrMatcher::from_entries(&cfg.from, &cfg.exclude, &format!("{ctx}.from"))?,

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1516,6 +1516,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pipeline_manual_block_routes_through_blocked_path() {
+        // #257: domains blocked from the UI must hit the same sinkhole as
+        // list-blocked domains — NOT overrides (TTL auto-revert, wrong HTML).
+        let ctx = crate::testutil::test_ctx().await;
+        ctx.blocklist
+            .write()
+            .unwrap()
+            .add_to_blocklist("manually.blocked.test");
+        let ctx = Arc::new(ctx);
+
+        let (resp, path) = resolve_in_test(&ctx, "manually.blocked.test", QueryType::A).await;
+        assert_eq!(path, QueryPath::Blocked);
+        match &resp.answers[0] {
+            DnsRecord::A { addr, .. } => assert_eq!(*addr, Ipv4Addr::UNSPECIFIED),
+            other => panic!("expected sinkhole A record, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
     async fn pipeline_override_takes_precedence() {
         let ctx = crate::testutil::test_ctx().await;
         ctx.overrides

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -63,10 +63,13 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         resolve_upstream_pool(&config, &system_dns, &root_hints, &bootstrap_resolver).await?;
     let api_port = config.server.api_port;
 
-    let mut blocklist = BlocklistStore::new(crate::domain_list::PersistedDomainList::new(
-        "blocking-allow.json",
-        &config.blocking.allowlist,
-    ));
+    let mut blocklist = BlocklistStore::new(
+        crate::domain_list::PersistedDomainList::new(
+            "blocking-allow.json",
+            &config.blocking.allowlist,
+        ),
+        crate::domain_list::PersistedDomainList::new("blocking-block.json", &[]),
+    );
     if !config.blocking.enabled {
         blocklist.set_enabled(false);
     }

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -33,6 +33,7 @@ pub async fn test_ctx() -> ServerCtx {
         overrides: RwLock::new(OverrideStore::new()),
         blocklist: RwLock::new(BlocklistStore::new(
             crate::domain_list::PersistedDomainList::unpersisted(),
+            crate::domain_list::PersistedDomainList::unpersisted(),
         )),
         query_log: Mutex::new(QueryLog::new(100)),
         services: Mutex::new(ServiceStore::new()),


### PR DESCRIPTION
Final PR of the persistence chain (#287 → #288 → #293 → this). Requested by @XhstormR in #257.

## What's here

**Block a domain in one click.** Every non-blocked, non-local query-log row gets a **block** button; the blocking panel gains a removable **Manually blocked** list. Entries persist to `blocking-block.json` via `PersistedDomainList` (pure user layer — no TOML key) and survive both restart and blocklist refresh (`swap_domains` replaces `domains` wholesale; the manual list is separate state).

**Routing.** Manual blocks resolve through the same `QueryPath::Blocked` sinkhole as list-blocked domains — deliberately *not* overrides, whose 300s TTL auto-revert and different sinkhole HTML are what the reporter originally hit. `check()` reports `"manually blocked"` with the matched rule; allowlist still wins, suffix matching applies (`bad.example.com` blocks `sub.bad.example.com`).

**API.** `GET /blocking/blocklist`, `POST /blocking/blocklist {domain}`, `DELETE /blocking/blocklist/{domain}` — mirrors the allowlist trio.

**Dashboard.** Block buttons use the `data-domain` + `h()` pattern from the XSS fix (qnames are attacker-supplied); the allowlist remove handler is generalized to `deleteDomain(path, domain)` rather than growing a third copy.

## Testing
- Pipeline test: manually blocked domain returns the `0.0.0.0` sinkhole on the `Blocked` path.
- Store test: survives refresh, allowlist precedence, suffix match, `"manually blocked"` reason, removal.
- 534 lib tests pass (+2); fmt clean; clippy clean on changed files; dashboard JS syntax-checked.

Closes #257.