### PR TITLE
fix(release): drop obsolete cargoHash refresh

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -33,30 +33,11 @@ sed -i.bak "s/^version = \"$CURRENT\"/version = \"$VERSION\"/" Cargo.toml
 rm -f Cargo.toml.bak
 cargo update --workspace
 
-# Refresh the Nix vendor hash. cargo update shifts the vendored crate set, so a
-# stale flake.nix cargoHash fails the nix-build CI job (deps are fetched via
-# cargoHash, not the lockfile — see #252). Recompute via the fake-hash dance.
-if command -v nix >/dev/null 2>&1; then
-  echo "Refreshing flake.nix cargoHash"
-  FAKE="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-  sed -i.bak "s|cargoHash = \"sha256-[^\"]*\";|cargoHash = \"$FAKE\";|" flake.nix
-  rm -f flake.nix.bak
-  NEW_HASH=$(nix build .#numa --no-link 2>&1 \
-    | sed -n 's/.*got:[[:space:]]*\(sha256-[A-Za-z0-9+/=]*\).*/\1/p' | tail -1 || true)
-  if [ -z "$NEW_HASH" ]; then
-    echo "ERROR: could not compute cargoHash from nix build" >&2
-    git checkout -- flake.nix
-    exit 1
-  fi
-  sed -i.bak "s|cargoHash = \"$FAKE\";|cargoHash = \"$NEW_HASH\";|" flake.nix
-  rm -f flake.nix.bak
-  echo "  cargoHash -> $NEW_HASH"
-else
-  echo "WARNING: nix not found — flake.nix cargoHash NOT refreshed; nix-build CI will fail until it is updated by hand." >&2
-fi
+# Nix vendoring follows Cargo.lock directly (flake.nix cargoLock.lockFile,
+# #292) — no cargoHash to refresh since the bump commits the updated lockfile.
 
 # Commit, tag, push
-git add Cargo.toml Cargo.lock flake.nix
+git add Cargo.toml Cargo.lock
 git commit -m "chore: bump version to $VERSION"
 git tag "$TAG"
 git push origin main "$TAG"


### PR DESCRIPTION
flake.nix vendors via cargoLock.lockFile since #292, so the fake-hash
dance matched nothing and aborted every release before the tag step.
