### PR TITLE
fix(ci): serialize AUR publish runs

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -35,6 +35,12 @@ on:
 permissions:
   contents: read
 
+# Releases push main twice within minutes (PR merge + version bump); parallel
+# runs race on the AUR git remote and the loser's push is rejected.
+concurrency:
+  group: publish-aur
+  cancel-in-progress: false
+
 jobs:
   # The 'validate' job ensures that the PKGBUILD is correct and the software builds/tests
   # successfully on Arch Linux before we attempt to publish it.


### PR DESCRIPTION
Release cuts push main twice within minutes (PR merge + version bump);
the parallel publish jobs raced on the AUR remote and the second push
was rejected as non-fast-forward (run 27425194816).
