### PR TITLE
fix(parser): reject DNSKEY/DS records with rdlength < fixed fields

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -70,10 +70,11 @@ impl BytePacketBuffer {
     }
 
     pub fn get_range(&self, start: usize, len: usize) -> Result<&[u8]> {
-        if start + len > BUF_SIZE {
+        let end = start.checked_add(len).ok_or("End of buffer")?;
+        if end > BUF_SIZE {
             return Err("End of buffer".into());
         }
-        Ok(&self.buf[start..start + len])
+        Ok(&self.buf[start..end])
     }
 
     pub fn read_u16(&mut self) -> Result<u16> {
@@ -460,5 +461,15 @@ mod tests {
         let mut buf = BytePacketBuffer::from_bytes(b"\x03foo\x00\xc0\x02");
         buf.seek(5).unwrap();
         assert!(buf.read_qname(&mut String::new()).is_err());
+    }
+
+    #[test]
+    fn get_range_length_overflow_errors_not_panics() {
+        // A length near usize::MAX must not overflow the bounds check into a
+        // false pass (then a reversed-slice panic). Guards the rdlength-underflow
+        // class at the buffer layer.
+        let buf = BytePacketBuffer::from_bytes(b"abcd");
+        assert!(buf.get_range(2, usize::MAX).is_err());
+        assert!(buf.get_range(usize::MAX, 8).is_err());
     }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -321,7 +321,10 @@ impl DnsRecord {
                 let flags = buffer.read_u16()?;
                 let protocol = buffer.read()?;
                 let algorithm = buffer.read()?;
-                let key_len = data_len as usize - 4; // flags(2) + protocol(1) + algorithm(1)
+                let rdata_end = rdata_start + data_len as usize;
+                let key_len = rdata_end
+                    .checked_sub(buffer.pos())
+                    .ok_or("DNSKEY data_len too short for fixed fields")?;
                 let public_key = buffer.get_range(buffer.pos(), key_len)?.to_vec();
                 buffer.step(key_len)?;
                 Ok(DnsRecord::DNSKEY {
@@ -337,7 +340,10 @@ impl DnsRecord {
                 let key_tag = buffer.read_u16()?;
                 let algorithm = buffer.read()?;
                 let digest_type = buffer.read()?;
-                let digest_len = data_len as usize - 4; // key_tag(2) + algorithm(1) + digest_type(1)
+                let rdata_end = rdata_start + data_len as usize;
+                let digest_len = rdata_end
+                    .checked_sub(buffer.pos())
+                    .ok_or("DS data_len too short for fixed fields")?;
                 let digest = buffer.get_range(buffer.pos(), digest_len)?.to_vec();
                 buffer.step(digest_len)?;
                 Ok(DnsRecord::DS {
@@ -817,6 +823,28 @@ mod tests {
         };
         let parsed = round_trip(&rec);
         assert_eq!(rec, parsed);
+    }
+
+    #[test]
+    fn dnskey_ds_short_rdlength_errors_not_panics() {
+        // rdlength < fixed-field size must be a clean Err, not an arithmetic
+        // underflow panic (a crafted upstream answer / relayed query is fully
+        // attacker-controlled). Found by fuzzing the packet parser.
+        for qtype in [QueryType::DNSKEY.to_num(), QueryType::DS.to_num()] {
+            for rdlength in [0u16, 1, 2, 3] {
+                let mut buf = BytePacketBuffer::new();
+                write_header(&mut buf, "example.com", qtype, 3600).unwrap();
+                buf.write_u16(rdlength).unwrap();
+                for _ in 0..rdlength {
+                    buf.write_u8(0).unwrap();
+                }
+                buf.seek(0).unwrap();
+                assert!(
+                    DnsRecord::read(&mut buf).is_err(),
+                    "qtype {qtype} rdlength {rdlength} should error"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fuzzing the hand-rolled wire parser (`cargo-fuzz`) surfaced a remote-DoS panic: a 16-byte packet crashes `DnsRecord::read`.

A **DNSKEY** or **DS** record declaring `rdlength < 4` underflowed `data_len as usize - 4`. The wrapped huge length then defeated `get_range`'s bounds check — `start + len > BUF_SIZE` overflows the sum *below* `BUF_SIZE`, so the check passes and the slice `&buf[start..end]` panics on reversed bounds. This reproduces **in release**, not just debug.

**Reachability:** the parser runs on every DNS answer numa reads, so a crafted answer (malicious authoritative server in the resolution path, a MITM upstream, or a query packet with `ancount>0` sent to a public DoH/ODoH *target*) crashes a resolver. Note the public ODoH **relay** (`numa relay`) is *not* affected — it forwards opaque encrypted envelopes without parsing DNS.

## Fix (two layers, one idiom)

- DNSKEY/DS now derive their trailing-field length via `rdata_end.checked_sub(buffer.pos())` — the exact idiom RRSIG/NSEC/NSEC3 already use, so all five variable-length DNSSEC arms are now consistent and underflow-safe.
- `get_range` uses `checked_add` for its bounds check, so no future caller can defeat it via length overflow (defense-in-depth at the buffer primitive).

## Tests

- `record::tests::dnskey_ds_short_rdlength_errors_not_panics` — DNSKEY+DS × rdlength {0,1,2,3} all return `Err`, not panic
- `buffer::tests::get_range_length_overflow_errors_not_panics` — near-`usize::MAX` lengths `Err` cleanly
- Full suite green; `/simplify` pass came back clean (matches established idiom)
- Post-fix fuzzing: ~8M executions across parse / write→reparse / SVCB-scrub targets, coverage plateaued, no further crashes

The fuzz harness that found this will follow as a separate PR (tooling, no disclosure-risk delta).