### PR TITLE
fix(dashboard): query log fills column height instead of leaving a void

### DIFF
--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -211,6 +211,10 @@ body {
   grid-template-columns: 1fr 340px;
   gap: 1.2rem;
 }
+.main-grid > .panel {
+  display: flex;
+  flex-direction: column;
+}
 
 /* Panels */
 .panel {
@@ -290,7 +294,13 @@ body {
 
 /* Query log table */
 .query-log {
-  max-height: 600px;
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+.query-log-scroll {
+  position: absolute;
+  inset: 0;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--bg-elevated) transparent;
@@ -746,21 +756,23 @@ body {
         </div>
       </div>
       <div class="query-log" id="queryLog">
-        <table>
-          <thead>
-            <tr>
-              <th>Time</th>
-              <th>Type</th>
-              <th>Domain</th>
-              <th>Path</th>
-              <th>Transport</th>
-              <th>Result</th>
-              <th>Latency</th>
-            </tr>
-          </thead>
-          <tbody id="queryLogBody">
-          </tbody>
-        </table>
+        <div class="query-log-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Type</th>
+                <th>Domain</th>
+                <th>Path</th>
+                <th>Transport</th>
+                <th>Result</th>
+                <th>Latency</th>
+              </tr>
+            </thead>
+            <tbody id="queryLogBody">
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #300.

## Summary
- The Recent Queries panel was capped at `max-height: 600px`, but its grid column shares a row with the much-taller sidebar. The panel stretched to the sidebar's height while the table stayed ≤600px, leaving a large blank area below it — **permanently**, regardless of how many queries were logged.
- The cap can't simply be removed: the query log is a 1000-entry ring buffer (`serve.rs`) and the dashboard renders every row, so an uncapped table would produce a ~40,000px page on a busy resolver.
- Fix: the query-log panel is now a flex column, and the table lives in an absolutely-positioned scroll container (`.query-log-scroll`) that fills the remaining panel height. The column matches the sidebar with no void, and a full log scrolls internally.

## Test plan
- Ran a local instance and measured layout via Chrome DevTools at 1727×1223:
  - **60 rows:** left panel height = sidebar height (1528px), no void; log scrolls internally.
  - **3 rows (fresh restart):** panel fills to the sidebar bottom as a clean empty scroll area (fills as traffic arrives) — no disproportionate blank box.
- `make all` (fmt + clippy -D warnings + audit + 539 tests) passes.