### PR TITLE
feat(client_policy): per-client filter_aaaa override (#286)

### DIFF
--- a/numa.toml
+++ b/numa.toml
@@ -137,6 +137,7 @@ api_port = 5380
 # [[client_policy]]
 # from  = ["10.0.0.50"]          # a single host: stricter rules just for it
 # block = ["reddit.com"]
+# filter_aaaa = true             # override global [server].filter_aaaa for these clients (alone makes a rule valid)
 
 [cache]
 max_entries = 100000

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -90,11 +90,12 @@ impl ClientPolicySet {
 
     /// Rules matching `peer`, in declaration order. Canonicalizes so the
     /// loopback bypass also covers `::ffff:127.0.0.1` from a dual-stack bind;
-    /// loopback (and an empty rule set) yields nothing, so a stub resolver on
-    /// the same host never reaches the matcher and cannot be filtered.
+    /// loopback yields nothing, so a stub resolver on the same host never
+    /// reaches the matcher and cannot be filtered. An empty rule set yields
+    /// nothing on its own.
     fn matching_rules(&self, peer: IpAddr) -> impl Iterator<Item = &ClientPolicy> {
         let peer = peer.to_canonical();
-        let bypass = self.rules.is_empty() || peer.is_loopback();
+        let bypass = peer.is_loopback();
         self.rules
             .iter()
             .filter(move |rule| !bypass && rule.nets.matches(peer))

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -23,8 +23,6 @@ pub struct ClientPolicyConfig {
     pub block: Vec<String>,
     #[serde(default)]
     pub allow: Vec<String>,
-    /// Per-client override of `[server].filter_aaaa`; `None` inherits the
-    /// global default (issue #286).
     #[serde(default)]
     pub filter_aaaa: Option<bool>,
 }

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -23,12 +23,18 @@ pub struct ClientPolicyConfig {
     pub block: Vec<String>,
     #[serde(default)]
     pub allow: Vec<String>,
+    /// Per-client override of `[server].filter_aaaa`. `None` (unset) inherits
+    /// the global default; `Some` forces AAAA filtering on/off for this rule's
+    /// clients (issue #286).
+    #[serde(default)]
+    pub filter_aaaa: Option<bool>,
 }
 
 #[derive(Debug)]
 struct ClientPolicy {
     nets: CidrMatcher,
     store: BlocklistStore,
+    filter_aaaa: Option<bool>,
 }
 
 #[derive(Debug, Default)]
@@ -54,9 +60,9 @@ impl ClientPolicySet {
             // Reuse the global blocklist parser so per-client and global lists can't drift.
             let blocks = parse_blocklist(&cfg.block.join("\n"));
             let allows = parse_blocklist(&cfg.allow.join("\n"));
-            if blocks.is_empty() && allows.is_empty() {
+            if blocks.is_empty() && allows.is_empty() && cfg.filter_aaaa.is_none() {
                 return Err(format!(
-                    "{ctx}: must specify at least one valid domain in `block` or `allow`"
+                    "{ctx}: must specify at least one valid domain in `block`/`allow`, or set `filter_aaaa`"
                 ));
             }
             let mut allow = crate::domain_list::PersistedDomainList::unpersisted();
@@ -71,6 +77,7 @@ impl ClientPolicySet {
             rules.push(ClientPolicy {
                 nets: CidrMatcher::from_entries(&cfg.from, &cfg.exclude, &format!("{ctx}.from"))?,
                 store,
+                filter_aaaa: cfg.filter_aaaa,
             });
         }
         Ok(ClientPolicySet { rules })
@@ -109,6 +116,25 @@ impl ClientPolicySet {
         }
         Decision::Passthrough
     }
+
+    /// Effective `filter_aaaa` for `peer`: the first matching rule that sets an
+    /// explicit override wins (declaration order, mirroring `evaluate`);
+    /// otherwise the global `[server].filter_aaaa` default applies. Loopback
+    /// bypasses the per-client path and keeps the global value.
+    pub fn effective_filter_aaaa(&self, peer: IpAddr, global: bool) -> bool {
+        let peer = peer.to_canonical();
+        if self.rules.is_empty() || peer.is_loopback() {
+            return global;
+        }
+        for rule in &self.rules {
+            if rule.nets.matches(peer) {
+                if let Some(v) = rule.filter_aaaa {
+                    return v;
+                }
+            }
+        }
+        global
+    }
 }
 
 #[cfg(test)]
@@ -131,6 +157,15 @@ mod tests {
             exclude: exclude.iter().map(|s| s.to_string()).collect(),
             block: block.iter().map(|s| s.to_string()).collect(),
             allow: allow.iter().map(|s| s.to_string()).collect(),
+            filter_aaaa: None,
+        }
+    }
+
+    fn cfg_aaaa(from: &[&str], filter_aaaa: Option<bool>) -> ClientPolicyConfig {
+        ClientPolicyConfig {
+            from: from.iter().map(|s| s.to_string()).collect(),
+            filter_aaaa,
+            ..Default::default()
         }
     }
 
@@ -310,7 +345,7 @@ mod tests {
     #[test]
     fn rejects_empty_block_and_allow() {
         let err = ClientPolicySet::from_configs(&[cfg(&["192.168.1.0/24"], &[], &[])]).unwrap_err();
-        assert!(err.contains("`block` or `allow`"));
+        assert!(err.contains("`block`/`allow`"));
     }
 
     #[test]
@@ -337,5 +372,88 @@ mod tests {
                 ("192.168.1.254", "youtube.com", Passthrough),
             ],
         );
+    }
+
+    // ── per-client filter_aaaa override (issue #286) ────────────────────────
+
+    fn eff(set: &ClientPolicySet, peer: &str, global: bool) -> bool {
+        set.effective_filter_aaaa(peer.parse().unwrap(), global)
+    }
+
+    #[test]
+    fn filter_aaaa_inherits_global_when_no_rule_matches() {
+        let set = policy(&[cfg_aaaa(&["10.210.0.0/16"], Some(true))]);
+        assert!(
+            !eff(&set, "192.168.1.5", false),
+            "unmatched inherits global"
+        );
+        assert!(eff(&set, "192.168.1.5", true), "unmatched inherits global");
+    }
+
+    #[test]
+    fn filter_aaaa_override_forces_on_over_global_false() {
+        let set = policy(&[cfg_aaaa(&["10.210.0.0/16"], Some(true))]);
+        assert!(eff(&set, "10.210.0.5", false), "match forces filter on");
+    }
+
+    #[test]
+    fn filter_aaaa_override_forces_off_over_global_true() {
+        let set = policy(&[cfg_aaaa(&["2001:db8::/32"], Some(false))]);
+        assert!(
+            !eff(&set, "2001:db8::abcd", true),
+            "match forces filter off"
+        );
+    }
+
+    #[test]
+    fn filter_aaaa_unset_rule_inherits_global() {
+        // A block/allow rule with no filter_aaaa key must not force-disable.
+        let set = policy(&[cfg(&["10.0.0.0/8"], &["ads.example"], &[])]);
+        assert!(eff(&set, "10.0.0.5", true), "unset inherits global true");
+        assert!(!eff(&set, "10.0.0.5", false), "unset inherits global false");
+    }
+
+    #[test]
+    fn filter_aaaa_first_explicit_override_wins() {
+        let set = policy(&[
+            cfg(&["10.0.0.0/8"], &["ads.example"], &[]), // matches, silent on aaaa
+            cfg_aaaa(&["10.0.0.0/8"], Some(true)),       // first explicit override
+        ]);
+        assert!(eff(&set, "10.0.0.5", false), "first explicit override wins");
+    }
+
+    #[test]
+    fn filter_aaaa_loopback_inherits_global() {
+        let set = policy(&[cfg_aaaa(&["127.0.0.0/8"], Some(true))]);
+        for peer in ["127.0.0.1", "::1", "::ffff:127.0.0.1"] {
+            assert!(!eff(&set, peer, false), "{peer} bypasses to global");
+        }
+    }
+
+    #[test]
+    fn filter_aaaa_dual_stack_mapped_peer_matches_v4_rule() {
+        let set = policy(&[cfg_aaaa(&["10.210.0.0/16"], Some(true))]);
+        assert!(eff(&set, "::ffff:10.210.0.5", false), "v4-mapped matches");
+    }
+
+    #[test]
+    fn filter_aaaa_only_rule_is_accepted() {
+        // No block/allow domains, just a filter_aaaa override → valid.
+        assert!(ClientPolicySet::from_configs(&[cfg_aaaa(&["10.0.0.0/8"], Some(true))]).is_ok());
+    }
+
+    #[test]
+    fn rule_with_nothing_is_rejected() {
+        // No block, no allow, no filter_aaaa → still an error.
+        let err = ClientPolicySet::from_configs(&[cfg_aaaa(&["10.0.0.0/8"], None)]).unwrap_err();
+        assert!(err.contains("filter_aaaa"), "got: {err}");
+    }
+
+    #[test]
+    fn filter_aaaa_only_rule_still_requires_from() {
+        let mut c = cfg_aaaa(&[], Some(true));
+        c.from.clear();
+        let err = ClientPolicySet::from_configs(&[c]).unwrap_err();
+        assert!(err.contains("at least one CIDR"), "got: {err}");
     }
 }

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -23,9 +23,8 @@ pub struct ClientPolicyConfig {
     pub block: Vec<String>,
     #[serde(default)]
     pub allow: Vec<String>,
-    /// Per-client override of `[server].filter_aaaa`. `None` (unset) inherits
-    /// the global default; `Some` forces AAAA filtering on/off for this rule's
-    /// clients (issue #286).
+    /// Per-client override of `[server].filter_aaaa`; `None` inherits the
+    /// global default (issue #286).
     #[serde(default)]
     pub filter_aaaa: Option<bool>,
 }
@@ -119,9 +118,7 @@ impl ClientPolicySet {
         Decision::Passthrough
     }
 
-    /// Effective `filter_aaaa` for `peer`: the first matching rule that sets an
-    /// explicit override wins; otherwise the global `[server].filter_aaaa`
-    /// default applies.
+    /// First matching rule with an explicit override wins; else `global`.
     pub fn effective_filter_aaaa(&self, peer: IpAddr, global: bool) -> bool {
         self.matching_rules(peer)
             .find_map(|rule| rule.filter_aaaa)

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -369,28 +369,28 @@ mod tests {
     }
 
     #[test]
-    fn filter_aaaa_inherits_global_when_no_rule_matches() {
-        let set = policy(&[cfg_aaaa(&["10.210.0.0/16"], Some(true))]);
-        assert!(
-            !eff(&set, "192.168.1.5", false),
-            "unmatched inherits global"
-        );
-        assert!(eff(&set, "192.168.1.5", true), "unmatched inherits global");
-    }
-
-    #[test]
-    fn filter_aaaa_override_forces_on_over_global_false() {
-        let set = policy(&[cfg_aaaa(&["10.210.0.0/16"], Some(true))]);
-        assert!(eff(&set, "10.210.0.5", false), "match forces filter on");
-    }
-
-    #[test]
-    fn filter_aaaa_override_forces_off_over_global_true() {
-        let set = policy(&[cfg_aaaa(&["2001:db8::/32"], Some(false))]);
-        assert!(
-            !eff(&set, "2001:db8::abcd", true),
-            "match forces filter off"
-        );
+    fn effective_filter_aaaa_matrix() {
+        // (rule cidr, override, peer, global) -> expected effective filter.
+        let cases: &[(&str, Option<bool>, &str, bool, bool)] = &[
+            ("10.210.0.0/16", Some(true), "192.168.1.5", false, false), // unmatched inherits global
+            ("10.210.0.0/16", Some(true), "192.168.1.5", true, true),   // unmatched inherits global
+            ("10.210.0.0/16", Some(true), "10.210.0.5", false, true), // match forces on over global off
+            ("2001:db8::/32", Some(false), "2001:db8::abcd", true, false), // match forces off over global on
+            (
+                "10.210.0.0/16",
+                Some(true),
+                "::ffff:10.210.0.5",
+                false,
+                true,
+            ), // v4-mapped matches v4 rule
+            ("127.0.0.0/8", Some(true), "127.0.0.1", false, false), // loopback bypasses to global
+            ("127.0.0.0/8", Some(true), "::1", false, false),       // loopback bypasses to global
+            ("127.0.0.0/8", Some(true), "::ffff:127.0.0.1", false, false), // loopback bypasses to global
+        ];
+        for (cidr, ovr, peer, global, want) in cases {
+            let set = policy(&[cfg_aaaa(&[cidr], *ovr)]);
+            assert_eq!(eff(&set, peer, *global), *want, "{peer} global={global}");
+        }
     }
 
     #[test]
@@ -408,20 +408,6 @@ mod tests {
             cfg_aaaa(&["10.0.0.0/8"], Some(true)),       // first explicit override
         ]);
         assert!(eff(&set, "10.0.0.5", false), "first explicit override wins");
-    }
-
-    #[test]
-    fn filter_aaaa_loopback_inherits_global() {
-        let set = policy(&[cfg_aaaa(&["127.0.0.0/8"], Some(true))]);
-        for peer in ["127.0.0.1", "::1", "::ffff:127.0.0.1"] {
-            assert!(!eff(&set, peer, false), "{peer} bypasses to global");
-        }
-    }
-
-    #[test]
-    fn filter_aaaa_dual_stack_mapped_peer_matches_v4_rule() {
-        let set = policy(&[cfg_aaaa(&["10.210.0.0/16"], Some(true))]);
-        assert!(eff(&set, "::ffff:10.210.0.5", false), "v4-mapped matches");
     }
 
     #[test]

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -91,21 +91,23 @@ impl ClientPolicySet {
         self.rules.len()
     }
 
+    /// Rules matching `peer`, in declaration order. Canonicalizes so the
+    /// loopback bypass also covers `::ffff:127.0.0.1` from a dual-stack bind;
+    /// loopback (and an empty rule set) yields nothing, so a stub resolver on
+    /// the same host never reaches the matcher and cannot be filtered.
+    fn matching_rules(&self, peer: IpAddr) -> impl Iterator<Item = &ClientPolicy> {
+        let peer = peer.to_canonical();
+        let bypass = self.rules.is_empty() || peer.is_loopback();
+        self.rules
+            .iter()
+            .filter(move |rule| !bypass && rule.nets.matches(peer))
+    }
+
     /// Rules layer in declaration order: the first rule with an explicit
     /// Block/Allow for `qname` wins; a client-matching rule silent on `qname`
     /// falls through to the next. Within a rule, allow beats block.
     pub fn evaluate(&self, peer: IpAddr, qname: &str) -> Decision {
-        // Canonicalize so the loopback bypass also covers `::ffff:127.0.0.1`
-        // from a dual-stack bind. Loopback wins over any `exclude` — a loopback
-        // peer never reaches the matcher, so it cannot be filtered.
-        let peer = peer.to_canonical();
-        if self.rules.is_empty() || peer.is_loopback() {
-            return Decision::Passthrough;
-        }
-        for rule in &self.rules {
-            if !rule.nets.matches(peer) {
-                continue;
-            }
+        for rule in self.matching_rules(peer) {
             let r = rule.store.check(qname);
             if r.blocked {
                 return Decision::Block;
@@ -118,22 +120,12 @@ impl ClientPolicySet {
     }
 
     /// Effective `filter_aaaa` for `peer`: the first matching rule that sets an
-    /// explicit override wins (declaration order, mirroring `evaluate`);
-    /// otherwise the global `[server].filter_aaaa` default applies. Loopback
-    /// bypasses the per-client path and keeps the global value.
+    /// explicit override wins; otherwise the global `[server].filter_aaaa`
+    /// default applies.
     pub fn effective_filter_aaaa(&self, peer: IpAddr, global: bool) -> bool {
-        let peer = peer.to_canonical();
-        if self.rules.is_empty() || peer.is_loopback() {
-            return global;
-        }
-        for rule in &self.rules {
-            if rule.nets.matches(peer) {
-                if let Some(v) = rule.filter_aaaa {
-                    return v;
-                }
-            }
-        }
-        global
+        self.matching_rules(peer)
+            .find_map(|rule| rule.filter_aaaa)
+            .unwrap_or(global)
     }
 }
 

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -166,7 +166,10 @@ pub async fn resolve_query(
         stripped > 0
     };
 
-    shape_response_for_client(&mut response, &query, ctx.filter_aaaa);
+    let filter_aaaa = ctx
+        .client_policy
+        .effective_filter_aaaa(src_addr.ip(), ctx.filter_aaaa);
+    shape_response_for_client(&mut response, &query, filter_aaaa);
 
     let elapsed = start.elapsed();
 
@@ -187,7 +190,7 @@ pub async fn resolve_query(
         response.resources.len(),
     );
 
-    let resp_buffer = serialize_with_fallback(&mut response, &query, &qname, ctx.filter_aaaa)?;
+    let resp_buffer = serialize_with_fallback(&mut response, &query, &qname, filter_aaaa)?;
 
     // Record stats and query log
     {
@@ -387,7 +390,11 @@ fn resolve_local(
         ));
         return Some((resp, QueryPath::Blocked, DnssecStatus::Indeterminate));
     }
-    if qtype == QueryType::AAAA && ctx.filter_aaaa {
+    if qtype == QueryType::AAAA
+        && ctx
+            .client_policy
+            .effective_filter_aaaa(src_addr.ip(), ctx.filter_aaaa)
+    {
         // RFC 2308 NODATA: NOERROR with empty answer section. Prevents
         // Happy Eyeballs clients from waiting on an AAAA they'll never use
         // on IPv4-only networks.
@@ -2040,6 +2047,82 @@ mod tests {
 
         let (_, path) = resolve_in_test(&ctx, "ads.tracker.test", QueryType::A).await;
         assert_eq!(path, QueryPath::Blocked, "global blocklist still applies");
+    }
+
+    fn ctx_with_aaaa_policy(
+        from: &[&str],
+        filter_aaaa: Option<bool>,
+    ) -> crate::client_policy::ClientPolicySet {
+        crate::client_policy::ClientPolicySet::from_configs(&[
+            crate::client_policy::ClientPolicyConfig {
+                from: from.iter().map(|s| s.to_string()).collect(),
+                filter_aaaa,
+                ..Default::default()
+            },
+        ])
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn pipeline_per_client_filter_aaaa_strips_for_matched_peer() {
+        // Global filter off, but the rule forces it on for this CIDR (#286).
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.filter_aaaa = false;
+        ctx.client_policy = ctx_with_aaaa_policy(&["10.210.0.0/16"], Some(true));
+        let ctx = Arc::new(ctx);
+
+        let src: SocketAddr = "10.210.0.5:5000".parse().unwrap();
+        let (resp, path) = resolve_from_src(&ctx, src, "example.com", QueryType::AAAA).await;
+        assert_eq!(path, QueryPath::Local);
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert!(resp.answers.is_empty(), "matched peer AAAA must be NODATA");
+    }
+
+    #[tokio::test]
+    async fn pipeline_per_client_filter_aaaa_spares_unmatched_peer() {
+        let upstream_resp = crate::testutil::aaaa_record_response(
+            "example.com",
+            "2001:db8::1".parse().unwrap(),
+            300,
+        );
+        let upstream_addr = crate::testutil::mock_upstream(upstream_resp).await;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.filter_aaaa = false;
+        ctx.client_policy = ctx_with_aaaa_policy(&["10.210.0.0/16"], Some(true));
+        ctx.upstream_pool
+            .lock()
+            .unwrap()
+            .set_primary(vec![Upstream::Udp(upstream_addr)]);
+        let ctx = Arc::new(ctx);
+
+        let src: SocketAddr = "192.168.1.5:5000".parse().unwrap();
+        let (resp, _) = resolve_from_src(&ctx, src, "example.com", QueryType::AAAA).await;
+        assert_eq!(resp.answers.len(), 1, "unmatched peer keeps its AAAA");
+    }
+
+    #[tokio::test]
+    async fn pipeline_per_client_filter_aaaa_exempts_matched_peer_from_global() {
+        // Global filter on, rule carves out a v6-capable subnet (the inverse).
+        let upstream_resp = crate::testutil::aaaa_record_response(
+            "example.com",
+            "2001:db8::1".parse().unwrap(),
+            300,
+        );
+        let upstream_addr = crate::testutil::mock_upstream(upstream_resp).await;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.filter_aaaa = true;
+        ctx.client_policy = ctx_with_aaaa_policy(&["2001:db8:cafe::/48"], Some(false));
+        ctx.upstream_pool
+            .lock()
+            .unwrap()
+            .set_primary(vec![Upstream::Udp(upstream_addr)]);
+        let ctx = Arc::new(ctx);
+
+        let src: SocketAddr = "[2001:db8:cafe::5]:5000".parse().unwrap();
+        let (resp, _) = resolve_from_src(&ctx, src, "example.com", QueryType::AAAA).await;
+        assert_eq!(resp.answers.len(), 1, "exempt peer keeps its AAAA");
     }
 
     #[tokio::test]

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -2078,8 +2078,9 @@ mod tests {
         assert!(resp.answers.is_empty(), "matched peer AAAA must be NODATA");
     }
 
-    #[tokio::test]
-    async fn pipeline_per_client_filter_aaaa_spares_unmatched_peer() {
+    /// AAAA answers a peer receives when an upstream returns one record, under
+    /// the given global flag and single `filter_aaaa` rule. 0 = stripped.
+    async fn aaaa_answers(global: bool, rule: &[&str], ovr: Option<bool>, peer: &str) -> usize {
         let upstream_resp = crate::testutil::aaaa_record_response(
             "example.com",
             "2001:db8::1".parse().unwrap(),
@@ -2088,41 +2089,39 @@ mod tests {
         let upstream_addr = crate::testutil::mock_upstream(upstream_resp).await;
 
         let mut ctx = crate::testutil::test_ctx().await;
-        ctx.filter_aaaa = false;
-        ctx.client_policy = ctx_with_aaaa_policy(&["10.210.0.0/16"], Some(true));
+        ctx.filter_aaaa = global;
+        ctx.client_policy = ctx_with_aaaa_policy(rule, ovr);
         ctx.upstream_pool
             .lock()
             .unwrap()
             .set_primary(vec![Upstream::Udp(upstream_addr)]);
         let ctx = Arc::new(ctx);
 
-        let src: SocketAddr = "192.168.1.5:5000".parse().unwrap();
-        let (resp, _) = resolve_from_src(&ctx, src, "example.com", QueryType::AAAA).await;
-        assert_eq!(resp.answers.len(), 1, "unmatched peer keeps its AAAA");
+        let src: SocketAddr = peer.parse().unwrap();
+        resolve_from_src(&ctx, src, "example.com", QueryType::AAAA)
+            .await
+            .0
+            .answers
+            .len()
+    }
+
+    #[tokio::test]
+    async fn pipeline_per_client_filter_aaaa_spares_unmatched_peer() {
+        let n = aaaa_answers(false, &["10.210.0.0/16"], Some(true), "192.168.1.5:5000").await;
+        assert_eq!(n, 1, "unmatched peer keeps its AAAA");
     }
 
     #[tokio::test]
     async fn pipeline_per_client_filter_aaaa_exempts_matched_peer_from_global() {
         // Global filter on, rule carves out a v6-capable subnet (the inverse).
-        let upstream_resp = crate::testutil::aaaa_record_response(
-            "example.com",
-            "2001:db8::1".parse().unwrap(),
-            300,
-        );
-        let upstream_addr = crate::testutil::mock_upstream(upstream_resp).await;
-
-        let mut ctx = crate::testutil::test_ctx().await;
-        ctx.filter_aaaa = true;
-        ctx.client_policy = ctx_with_aaaa_policy(&["2001:db8:cafe::/48"], Some(false));
-        ctx.upstream_pool
-            .lock()
-            .unwrap()
-            .set_primary(vec![Upstream::Udp(upstream_addr)]);
-        let ctx = Arc::new(ctx);
-
-        let src: SocketAddr = "[2001:db8:cafe::5]:5000".parse().unwrap();
-        let (resp, _) = resolve_from_src(&ctx, src, "example.com", QueryType::AAAA).await;
-        assert_eq!(resp.answers.len(), 1, "exempt peer keeps its AAAA");
+        let n = aaaa_answers(
+            true,
+            &["2001:db8:cafe::/48"],
+            Some(false),
+            "[2001:db8:cafe::5]:5000",
+        )
+        .await;
+        assert_eq!(n, 1, "exempt peer keeps its AAAA");
     }
 
     #[tokio::test]

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -113,6 +113,19 @@ pub fn a_record_response(domain: &str, addr: Ipv4Addr, ttl: u32) -> DnsPacket {
     pkt
 }
 
+/// AAAA counterpart of `a_record_response`, for filter_aaaa pipeline tests.
+pub fn aaaa_record_response(domain: &str, addr: std::net::Ipv6Addr, ttl: u32) -> DnsPacket {
+    let mut pkt = DnsPacket::new();
+    pkt.header.response = true;
+    pkt.header.rescode = ResultCode::NOERROR;
+    pkt.answers.push(DnsRecord::AAAA {
+        domain: domain.to_string(),
+        addr,
+        ttl,
+    });
+    pkt
+}
+
 /// Spawn a UDP socket that replies to the first DNS query with the given
 /// response packet (patching the query ID to match). Returns the socket address.
 pub async fn mock_upstream(response: DnsPacket) -> SocketAddr {


### PR DESCRIPTION
Closes #286.

Lets a `[[client_policy]]` rule override the global `[server].filter_aaaa` for the CIDRs it matches. The global flag stays the default; a rule narrows or inverts it for a client subset.

### Motivating case
A v4-only bridge (e.g. uncloud) leaves a v6 address on `lo`, so any AAAA handed to those hosts is dialed over `lo` and fails. Strip AAAA only for that subnet while the rest of the network keeps IPv6 — without standing up a second resolver.

```toml
[server]
filter_aaaa = false           # default for everyone: AAAA passes through

[[client_policy]]
from = ["10.210.0.0/16"]      # the v4-only docker hosts
filter_aaaa = true            # ...synthesize NODATA for AAAA just for these
```

The inverse (global on, exempt a v6-capable subnet) is the same mechanism with the booleans flipped.

### Why client_policy, not a new flag
`client_policy` already owns per-client CIDR matching (incl. dual-stack `::ffff:` handling and loopback bypass). Keeping `[server].filter_aaaa` as the global default avoids breaking existing configs and keeps "filter for everyone" a one-liner; the rule is just an override layer.

### Changes
- `ClientPolicyConfig` gains optional `filter_aaaa: Option<bool>` (`None` = inherit global).
- `ClientPolicySet::effective_filter_aaaa(peer, global)`: first matching rule with an explicit override wins (declaration order, mirroring `evaluate`); loopback bypasses to the global value.
- `from_configs` accepts a rule with only `filter_aaaa` (no `block`/`allow`); `from` is still required.
- Pipeline threads the per-client effective value into both consumption points — the early AAAA NODATA short-circuit and response shaping (SVCB/HTTPS `ipv6hint` stripping).

### Tests
- Unit: override on/off vs global, unset-inherits, first-explicit-wins, loopback inherits, dual-stack `::ffff:` match, `filter_aaaa`-only rule accepted, rule-with-nothing rejected, empty `from` still rejected.
- Pipeline: matched peer → NODATA though global off; unmatched peer keeps AAAA; matched peer exempt though global on.

All 551 lib tests pass; `cargo fmt --check` and `clippy` clean on touched files.