### PR TITLE
docs: clarify Numa has no separate PROXY protocol port

### DIFF
--- a/recipes/dnsdist-front.md
+++ b/recipes/dnsdist-front.md
@@ -62,6 +62,11 @@ with TC-slip, RFC 8482 ANY-refusal, DNS Cookies, and `allow_recursion` split fro
 
 ## Numa config
 
+Unlike Unbound's dedicated `proxy-protocol-port`, Numa has **no separate proxy port**.
+PROXY v2 is a *mode* on the existing `:53` listener, switched on by a non-empty `from`
+allowlist — the listener keeps serving plain DNS, but now requires a PROXY header from
+the trusted front-end.
+
 ```toml
 [server.proxy_protocol]
 from = ["127.0.0.1/32"]  # trust the local dnsdist front-end to prepend PROXY v2


### PR DESCRIPTION
Adds an up-front note to the dnsdist recipe making the "no separate proxy port" distinction explicit.

Users arriving from Unbound expect a dedicated `proxy-protocol-port`; Numa instead layers PROXY v2 onto the existing `:53` listener, gated by a non-empty `from` allowlist. The recipe stated this only implicitly ("No changes to `[server]` bind", buried after the config block) and never contrasted it with the Unbound model — which is exactly the mental model that tripped up #163.

Closes #163.