### PR TITLE
feat(query-log): stamp a monotonic seq on each entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1937,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/src/api.rs
+++ b/src/api.rs
@@ -165,6 +165,7 @@ struct QueryLogParams {
 
 #[derive(Serialize)]
 struct QueryLogResponse {
+    seq: u64,
     timestamp_epoch: f64,
     src: String,
     domain: String,
@@ -513,7 +514,6 @@ async fn query_log(
         domain: params.domain,
         query_type: qtype,
         path,
-        since: None,
         limit: params.limit,
     };
 
@@ -528,6 +528,7 @@ async fn query_log(
                     .unwrap_or_default()
                     .as_secs_f64();
                 QueryLogResponse {
+                    seq: e.seq,
                     timestamp_epoch: epoch,
                     src: e.src_addr.to_string(),
                     domain: e.domain.clone(),

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -202,6 +202,7 @@ pub async fn resolve_query(
     }
 
     ctx.query_log.lock().unwrap().push(QueryLogEntry {
+        seq: 0, // stamped by QueryLog::push
         timestamp: SystemTime::now(),
         src_addr,
         domain: qname,

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -105,19 +105,7 @@ mod tests {
     fn heap_bytes_grows_with_entries() {
         let mut log = QueryLog::new(100);
         let empty = log.heap_bytes();
-        log.push(QueryLogEntry {
-            seq: 0,
-            timestamp: SystemTime::now(),
-            src_addr: "127.0.0.1:1234".parse().unwrap(),
-            domain: "example.com".into(),
-            query_type: QueryType::A,
-            path: QueryPath::Forwarded,
-            transport: Transport::Udp,
-            rescode: ResultCode::NOERROR,
-            latency_us: 500,
-            dnssec: DnssecStatus::Indeterminate,
-            rebind_stripped: false,
-        });
+        log.push(entry("example.com"));
         assert!(log.heap_bytes() > empty);
     }
 

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -8,6 +8,10 @@ use crate::question::QueryType;
 use crate::stats::{QueryPath, Transport};
 
 pub struct QueryLogEntry {
+    /// Monotonic insertion sequence, stamped by `QueryLog::push` (1-based).
+    /// Lets a polling consumer dedup exactly and detect gaps/restarts without a
+    /// `since` filter. Set to 0 at construction; `push` overwrites it.
+    pub seq: u64,
     pub timestamp: SystemTime,
     pub src_addr: SocketAddr,
     pub domain: String,
@@ -23,6 +27,7 @@ pub struct QueryLogEntry {
 pub struct QueryLog {
     entries: VecDeque<QueryLogEntry>,
     capacity: usize,
+    next_seq: u64,
 }
 
 impl QueryLog {
@@ -30,10 +35,13 @@ impl QueryLog {
         QueryLog {
             entries: VecDeque::with_capacity(capacity),
             capacity,
+            next_seq: 0,
         }
     }
 
-    pub fn push(&mut self, entry: QueryLogEntry) {
+    pub fn push(&mut self, mut entry: QueryLogEntry) {
+        self.next_seq += 1;
+        entry.seq = self.next_seq;
         if self.entries.len() >= self.capacity {
             self.entries.pop_front();
         }
@@ -75,11 +83,6 @@ impl QueryLog {
                         return false;
                     }
                 }
-                if let Some(since) = filter.since {
-                    if e.timestamp < since {
-                        return false;
-                    }
-                }
                 true
             })
             .take(filter.limit.unwrap_or(50))
@@ -91,7 +94,6 @@ pub struct QueryLogFilter {
     pub domain: Option<String>,
     pub query_type: Option<QueryType>,
     pub path: Option<QueryPath>,
-    pub since: Option<SystemTime>,
     pub limit: Option<usize>,
 }
 
@@ -104,6 +106,7 @@ mod tests {
         let mut log = QueryLog::new(100);
         let empty = log.heap_bytes();
         log.push(QueryLogEntry {
+            seq: 0,
             timestamp: SystemTime::now(),
             src_addr: "127.0.0.1:1234".parse().unwrap(),
             domain: "example.com".into(),
@@ -116,5 +119,40 @@ mod tests {
             rebind_stripped: false,
         });
         assert!(log.heap_bytes() > empty);
+    }
+
+    fn entry(domain: &str) -> QueryLogEntry {
+        QueryLogEntry {
+            seq: 0,
+            timestamp: SystemTime::now(),
+            src_addr: "127.0.0.1:1234".parse().unwrap(),
+            domain: domain.into(),
+            query_type: QueryType::A,
+            path: QueryPath::Forwarded,
+            transport: Transport::Udp,
+            rescode: ResultCode::NOERROR,
+            latency_us: 500,
+            dnssec: DnssecStatus::Indeterminate,
+            rebind_stripped: false,
+        }
+    }
+
+    #[test]
+    fn push_stamps_monotonic_seq() {
+        let mut log = QueryLog::new(2);
+        for d in ["a", "b", "c"] {
+            log.push(entry(d));
+        }
+        // Capacity 2: "a" was evicted, "b" and "c" remain with their stamped
+        // seqs (2, 3) intact — seq is stamped at push, never derived from
+        // position, so eviction does not renumber survivors.
+        let filter = QueryLogFilter {
+            domain: None,
+            query_type: None,
+            path: None,
+            limit: Some(10),
+        };
+        let seqs: Vec<u64> = log.query(&filter).into_iter().map(|e| e.seq).collect();
+        assert_eq!(seqs, vec![3, 2]); // query() returns newest-first
     }
 }


### PR DESCRIPTION
## What

Adds a 1-based monotonic `seq` to each `/query-log` entry, stamped by `QueryLog::push` and surfaced in the JSON response. Also deletes the dead `since` filter.

## Why

The `numa-metrics` sidecar polls `/query-log` (newest-first, no `since` filter) every 10s and must figure out which entries it hasn't already counted. Today it does this by reconstructing a `src|domain|qtype|timestamp` **fingerprint** of the last-seen newest entry and walking the newest-first page until it matches — fuzzy, and unable to distinguish "nothing new" from "I fell behind and lost rows."

A monotonic `seq` replaces all of that with an exact integer compare on the consumer side:

- **Exact dedup** — keep entries with `seq > watermark`; no fingerprinting.
- **Gap detection** — if the smallest returned `seq > watermark + 1`, entries rolled off the 1000-entry ring between polls; the gap size is exact.
- **Restart detection** — on numa restart `seq` resets, so a backwards jump is observable (no silent stall).

## Design notes

- **Stamped at push, never derived from position.** Eviction (`pop_front` at capacity) does not renumber survivors — see the `push_stamps_monotonic_seq` test.
- **No overflow guard.** `u64` at even an unrealistic 10k q/s overflows in ~58M years; a guard would be ceremony.
- **Non-breaking.** Response stays newest-first and a bare array; `seq` is purely additive. The cursor *filter* (`?after=`) was deliberately **not** added — with a 1000-entry loopback ring polled every 10s it would buy negligible bandwidth while adding API surface and *requiring* a session token to avoid silent-stall-on-restart. The field alone is the minimal, correct change.
- **Dead `since` filter removed** — it was never exposed (handler hardcoded `since: None`), and `SystemTime` is a strictly worse cursor (non-monotonic under NTP/skew).

## Follow-up

A companion numa-metrics PR deletes the fingerprint/watermark machinery and dedups on `seq`. It depends on this landing first.

## Test

`cargo build`, `cargo fmt --check`, `cargo clippy --lib`, and `cargo test --lib query_log` all green; new `push_stamps_monotonic_seq` covers stamp-survives-eviction.