### PR TITLE
docs(readme): link numa-metrics for durable query history

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Turnkey compose recipes:
 - [Blog: I Built a DNS Resolver from Scratch](https://numa.rs/blog/posts/dns-from-scratch.html)
 - [Configuration reference](numa.toml) — all options documented inline
 - [REST API](src/api.rs) — overrides, cache, blocking, services, diagnostics
+- [numa-metrics](https://github.com/razvandimescu/numa-metrics) — durable query history & analytics, off-host by design (no SD-card writes)
 
 ## Roadmap
 


### PR DESCRIPTION
Adds a Learn More pointer to [numa-metrics](https://github.com/razvandimescu/numa-metrics) — the off-host agent for durable query history & analytics.

Gives users asking for persistent logging (e.g. PR #309) a supported path that keeps the resolver host write-free, restating the no-SD-card-writes doctrine inline.