### PR TITLE
chore(deps): bump reqwest to 0.13, pin ring via rustls-no-provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,6 +1652,7 @@ dependencies = [
  "tokio-rustls",
  "toml",
  "tower",
+ "webpki-root-certs",
  "webpki-roots",
  "windows-service",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,7 +1653,6 @@ dependencies = [
  "toml",
  "tower",
  "webpki-root-certs",
- "webpki-roots",
  "windows-service",
  "windows-sys 0.61.2",
  "x509-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,10 +882,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -885,11 +893,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -986,7 +992,7 @@ dependencies = [
  "idna",
  "ipnet",
  "jni",
- "rand 0.10.1",
+ "rand",
  "rustls",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1009,7 +1015,7 @@ dependencies = [
  "jni",
  "once_cell",
  "prefix-trie",
- "rand 0.10.1",
+ "rand",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1034,7 +1040,7 @@ dependencies = [
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.1",
+ "rand",
  "resolv-conf",
  "rustls",
  "smallvec",
@@ -1165,7 +1171,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1498,12 +1503,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,7 +1637,7 @@ dependencies = [
  "proxy-header",
  "psl",
  "qrcode",
- "quinn-udp 0.6.1",
+ "quinn-udp",
  "rand_core 0.9.5",
  "rcgen",
  "reqwest",
@@ -1708,6 +1707,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "page_size"
@@ -1846,15 +1851,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prefix-trie"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,61 +1912,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp 0.5.14",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.2",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quinn-udp"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,16 +1947,6 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
@@ -2023,16 +1954,6 @@ dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2133,9 +2054,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -2151,11 +2072,10 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
- "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
@@ -2167,7 +2087,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2189,12 +2108,6 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -2230,6 +2143,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,9 +2169,35 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
- "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2281,10 +2232,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2488,7 +2471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2998,13 +2981,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
+name = "webpki-root-certs"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3105,16 +3087,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3132,31 +3105,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3166,22 +3122,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3190,22 +3134,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3214,22 +3146,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3238,22 +3158,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,7 @@ base64 = "0.22"
 rand_core = { version = "0.9", features = ["os_rng"] }
 rustls-pemfile = "2.2.0"
 qrcode = { version = "0.14", default-features = false, features = ["svg"] }
-webpki-roots = "1"
-# Bundled Mozilla roots (DER) for reqwest — see forward::bundled_roots.
+# Bundled Mozilla roots (DER) for both the reqwest and DoT TLS paths — see forward.rs.
 webpki-root-certs = "1"
 proxy-header = { version = "0.1", features = ["tokio"] }
 ipnet = { version = "2", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,7 @@ rand_core = { version = "0.9", features = ["os_rng"] }
 rustls-pemfile = "2.2.0"
 qrcode = { version = "0.14", default-features = false, features = ["svg"] }
 webpki-roots = "1"
-# DER form of the Mozilla roots, fed to reqwest's `tls_certs_only` so HTTPS uses
-# bundled roots (portable static binary) instead of reqwest 0.13's default
-# system-cert platform verifier.
+# Bundled Mozilla roots (DER) for reqwest — see forward::bundled_roots.
 webpki-root-certs = "1"
 proxy-header = { version = "0.1", features = ["tokio"] }
 ipnet = { version = "2", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ rand_core = { version = "0.9", features = ["os_rng"] }
 rustls-pemfile = "2.2.0"
 qrcode = { version = "0.14", default-features = false, features = ["svg"] }
 webpki-roots = "1"
+# DER form of the Mozilla roots, fed to reqwest's `tls_certs_only` so HTTPS uses
+# bundled roots (portable static binary) instead of reqwest 0.13's default
+# system-cert platform verifier.
+webpki-root-certs = "1"
 proxy-header = { version = "0.1", features = ["tokio"] }
 ipnet = { version = "2", features = ["serde"] }
 quinn-udp = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1"
 toml = "1.1"
 log = "0.4"
 env_logger = "0.11"
-reqwest = { version = "0.12", features = ["rustls-tls", "gzip", "http2"], default-features = false }
+reqwest = { version = "0.13", features = ["rustls-no-provider", "gzip", "http2", "query"], default-features = false }
 hyper = { version = "1", features = ["client", "http1", "server"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
 http-body-util = "0.1"

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -477,6 +477,8 @@ pub async fn download_blocklists(
 ) -> Vec<(String, String)> {
     crate::forward::ensure_crypto_provider();
     let mut builder = reqwest::Client::builder()
+        .use_rustls_tls()
+        .tls_certs_only(crate::forward::bundled_roots())
         .timeout(Duration::from_secs(30))
         .gzip(true);
     if let Some(r) = resolver {

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -475,6 +475,7 @@ pub async fn download_blocklists(
     lists: &[String],
     resolver: Option<std::sync::Arc<crate::bootstrap_resolver::NumaResolver>>,
 ) -> Vec<(String, String)> {
+    crate::forward::ensure_crypto_provider();
     let mut builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
         .gzip(true);
@@ -622,7 +623,7 @@ mod retry_tests {
         let body = "ads.example.com\ntracker.example.net\n";
         let delays = zero_delays();
         let addr = flaky_http_server(delays.len(), body).await;
-        let client = reqwest::Client::new();
+        let client = crate::forward::default_client();
         let url = format!("http://{addr}/");
         let result = fetch_with_retry_delays(&client, &url, &delays).await;
         assert_eq!(result.as_deref(), Some(body));
@@ -683,7 +684,7 @@ mod retry_tests {
     async fn retry_gives_up_when_all_attempts_fail() {
         let delays = zero_delays();
         let addr = flaky_http_server(delays.len() + 2, "unreachable").await;
-        let client = reqwest::Client::new();
+        let client = crate::forward::default_client();
         let url = format!("http://{addr}/");
         let result = fetch_with_retry_delays(&client, &url, &delays).await;
         assert_eq!(result, None);

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -475,10 +475,7 @@ pub async fn download_blocklists(
     lists: &[String],
     resolver: Option<std::sync::Arc<crate::bootstrap_resolver::NumaResolver>>,
 ) -> Vec<(String, String)> {
-    crate::forward::ensure_crypto_provider();
-    let mut builder = reqwest::Client::builder()
-        .use_rustls_tls()
-        .tls_certs_only(crate::forward::bundled_roots())
+    let mut builder = crate::forward::numa_tls_builder()
         .timeout(Duration::from_secs(30))
         .gzip(true);
     if let Some(r) = resolver {

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -213,7 +213,26 @@ pub fn build_https_client_with_resolver(
     builder.build().unwrap_or_default()
 }
 
+/// Install the process-default rustls `CryptoProvider` (ring), idempotently.
+/// reqwest 0.13's `rustls-no-provider` ships no provider, so one must be
+/// installed before the first TLS handshake or `Client::build()` panics. We pin
+/// ring (not 0.13's aws-lc-rs default) to keep the armv6 cross-build, which has
+/// no C toolchain for aws-lc-sys. The `Err` (already installed) is ignored.
+pub(crate) fn ensure_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+/// A bare reqwest client with the ring provider ensured — used by tests that
+/// want `Client::new()` semantics, so the provider is installed regardless of
+/// test execution order.
+#[cfg(test)]
+pub(crate) fn default_client() -> reqwest::Client {
+    ensure_crypto_provider();
+    reqwest::Client::builder().build().unwrap_or_default()
+}
+
 fn https_client_builder(pool_max_idle_per_host: usize) -> reqwest::ClientBuilder {
+    ensure_crypto_provider();
     reqwest::Client::builder()
         .use_rustls_tls()
         .http2_initial_stream_window_size(65_535)
@@ -625,7 +644,7 @@ mod tests {
     fn upstream_display_doh() {
         let u = Upstream::Doh {
             url: "https://dns.quad9.net/dns-query".to_string(),
-            client: reqwest::Client::new(),
+            client: crate::forward::default_client(),
         };
         assert_eq!(u.to_string(), "https://dns.quad9.net/dns-query");
     }
@@ -680,7 +699,7 @@ mod tests {
 
         let upstream = Upstream::Doh {
             url: format!("http://{}/dns-query", addr),
-            client: reqwest::Client::new(),
+            client: crate::forward::default_client(),
         };
 
         let result = forward_query(&query, &upstream, Duration::from_secs(2))
@@ -719,7 +738,7 @@ mod tests {
 
         let upstream = Upstream::Doh {
             url: format!("http://{}/dns-query", addr),
-            client: reqwest::Client::new(),
+            client: crate::forward::default_client(),
         };
 
         let result = forward_query(&make_query(), &upstream, Duration::from_secs(2)).await;
@@ -742,7 +761,7 @@ mod tests {
 
         let upstream = Upstream::Doh {
             url: format!("http://{}/dns-query", addr),
-            client: reqwest::Client::new(),
+            client: crate::forward::default_client(),
         };
 
         let result = forward_query(&make_query(), &upstream, Duration::from_millis(100)).await;
@@ -829,7 +848,7 @@ mod tests {
             vec![Upstream::Udp(bad_udp_addr)],
             vec![Upstream::Doh {
                 url: format!("http://{}/dns-query", doh_addr),
-                client: reqwest::Client::new(),
+                client: crate::forward::default_client(),
             }],
         );
 
@@ -914,7 +933,7 @@ mod tests {
                 Upstream::Udp("127.0.0.1:1".parse().unwrap()), // will fail
                 Upstream::Doh {
                     url: format!("http://{}/dns-query", good_addr),
-                    client: reqwest::Client::new(),
+                    client: crate::forward::default_client(),
                 },
             ],
             vec![],

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -214,30 +214,24 @@ pub fn build_https_client_with_resolver(
 }
 
 /// Install the process-default rustls `CryptoProvider` (ring), idempotently.
-/// reqwest 0.13's `rustls-no-provider` ships no provider, so one must be
-/// installed before the first TLS handshake or `Client::build()` panics. We pin
-/// ring (not 0.13's aws-lc-rs default) to keep the armv6 cross-build, which has
-/// no C toolchain for aws-lc-sys. The `Err` (already installed) is ignored.
+/// reqwest 0.13's `rustls-no-provider` ships none, so a `Client` built without
+/// this panics; ring (not 0.13's aws-lc-rs default) keeps the armv6 cross-build.
 pub(crate) fn ensure_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
-/// The bundled Mozilla roots in DER form, as reqwest certificates. Fed to
-/// `tls_certs_only` so HTTPS validation uses these instead of reqwest 0.13's
-/// default `rustls-platform-verifier` (which reads the host's system cert
-/// store — absent in sandboxes like the nix build, and a portability liability
-/// for the static musl Pi binary). Matches the bundled-roots behaviour Numa had
-/// on reqwest 0.12.
+/// The bundled Mozilla roots (DER) as reqwest certificates, for `tls_certs_only`
+/// — so HTTPS validation skips reqwest 0.13's default system-cert
+/// `rustls-platform-verifier` (absent in the nix sandbox; a liability for the
+/// static Pi binary). Restores the bundled-roots behaviour Numa had on 0.12.
 pub(crate) fn bundled_roots() -> impl Iterator<Item = reqwest::Certificate> {
     webpki_root_certs::TLS_SERVER_ROOT_CERTS
         .iter()
         .filter_map(|der| reqwest::Certificate::from_der(der).ok())
 }
 
-/// A bare reqwest client with the ring provider ensured and bundled roots —
-/// used by tests that want `Client::new()` semantics, so the provider is
-/// installed and the client builds without a system cert store regardless of
-/// test execution order or sandbox.
+/// `Client::new()` for tests, with the provider + bundled roots ensured so it
+/// builds regardless of test order or a missing system cert store.
 #[cfg(test)]
 pub(crate) fn default_client() -> reqwest::Client {
     ensure_crypto_provider();

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -213,40 +213,31 @@ pub fn build_https_client_with_resolver(
     builder.build().unwrap_or_default()
 }
 
-/// Install the process-default rustls `CryptoProvider` (ring), idempotently.
-/// reqwest 0.13's `rustls-no-provider` ships none, so a `Client` built without
-/// this panics; ring (not 0.13's aws-lc-rs default) keeps the armv6 cross-build.
-pub(crate) fn ensure_crypto_provider() {
+/// The single place Numa configures reqwest TLS. Installs the ring
+/// `CryptoProvider` (reqwest 0.13's `rustls-no-provider` ships none, so a
+/// `Client` built without it panics; ring not aws-lc-rs keeps the armv6
+/// cross-build) and pins validation to the bundled Mozilla roots, skipping
+/// reqwest's default system-cert verifier (absent in the nix sandbox, a
+/// liability for the static Pi binary; also restores Numa's 0.12 behaviour).
+pub(crate) fn numa_tls_builder() -> reqwest::ClientBuilder {
     let _ = rustls::crypto::ring::default_provider().install_default();
-}
-
-/// The bundled Mozilla roots (DER) as reqwest certificates, for `tls_certs_only`
-/// — so HTTPS validation skips reqwest 0.13's default system-cert
-/// `rustls-platform-verifier` (absent in the nix sandbox; a liability for the
-/// static Pi binary). Restores the bundled-roots behaviour Numa had on 0.12.
-pub(crate) fn bundled_roots() -> impl Iterator<Item = reqwest::Certificate> {
-    webpki_root_certs::TLS_SERVER_ROOT_CERTS
+    let roots = webpki_root_certs::TLS_SERVER_ROOT_CERTS
         .iter()
-        .filter_map(|der| reqwest::Certificate::from_der(der).ok())
-}
-
-/// `Client::new()` for tests, with the provider + bundled roots ensured so it
-/// builds regardless of test order or a missing system cert store.
-#[cfg(test)]
-pub(crate) fn default_client() -> reqwest::Client {
-    ensure_crypto_provider();
+        .filter_map(|der| reqwest::Certificate::from_der(der).ok());
     reqwest::Client::builder()
         .use_rustls_tls()
-        .tls_certs_only(bundled_roots())
-        .build()
-        .unwrap_or_default()
+        .tls_certs_only(roots)
+}
+
+/// `Client::new()` for tests, but with Numa's TLS setup so it builds regardless
+/// of test order or a missing system cert store.
+#[cfg(test)]
+pub(crate) fn default_client() -> reqwest::Client {
+    numa_tls_builder().build().unwrap_or_default()
 }
 
 fn https_client_builder(pool_max_idle_per_host: usize) -> reqwest::ClientBuilder {
-    ensure_crypto_provider();
-    reqwest::Client::builder()
-        .use_rustls_tls()
-        .tls_certs_only(bundled_roots())
+    numa_tls_builder()
         .http2_initial_stream_window_size(65_535)
         .http2_initial_connection_window_size(65_535)
         .http2_keep_alive_interval(Duration::from_secs(15))

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -250,7 +250,7 @@ fn https_client_builder(pool_max_idle_per_host: usize) -> reqwest::ClientBuilder
 fn build_dot_connector() -> Result<tokio_rustls::TlsConnector> {
     let _ = rustls::crypto::ring::default_provider().install_default();
     let mut root_store = rustls::RootCertStore::empty();
-    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    root_store.add_parsable_certificates(webpki_root_certs::TLS_SERVER_ROOT_CERTS.iter().cloned());
     let config = rustls::ClientConfig::builder()
         .with_root_certificates(root_store)
         .with_no_client_auth();

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -222,19 +222,37 @@ pub(crate) fn ensure_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
-/// A bare reqwest client with the ring provider ensured — used by tests that
-/// want `Client::new()` semantics, so the provider is installed regardless of
-/// test execution order.
+/// The bundled Mozilla roots in DER form, as reqwest certificates. Fed to
+/// `tls_certs_only` so HTTPS validation uses these instead of reqwest 0.13's
+/// default `rustls-platform-verifier` (which reads the host's system cert
+/// store — absent in sandboxes like the nix build, and a portability liability
+/// for the static musl Pi binary). Matches the bundled-roots behaviour Numa had
+/// on reqwest 0.12.
+pub(crate) fn bundled_roots() -> impl Iterator<Item = reqwest::Certificate> {
+    webpki_root_certs::TLS_SERVER_ROOT_CERTS
+        .iter()
+        .filter_map(|der| reqwest::Certificate::from_der(der).ok())
+}
+
+/// A bare reqwest client with the ring provider ensured and bundled roots —
+/// used by tests that want `Client::new()` semantics, so the provider is
+/// installed and the client builds without a system cert store regardless of
+/// test execution order or sandbox.
 #[cfg(test)]
 pub(crate) fn default_client() -> reqwest::Client {
     ensure_crypto_provider();
-    reqwest::Client::builder().build().unwrap_or_default()
+    reqwest::Client::builder()
+        .use_rustls_tls()
+        .tls_certs_only(bundled_roots())
+        .build()
+        .unwrap_or_default()
 }
 
 fn https_client_builder(pool_max_idle_per_host: usize) -> reqwest::ClientBuilder {
     ensure_crypto_provider();
     reqwest::Client::builder()
         .use_rustls_tls()
+        .tls_certs_only(bundled_roots())
         .http2_initial_stream_window_size(65_535)
         .http2_initial_connection_window_size(65_535)
         .http2_keep_alive_interval(Duration::from_secs(15))

--- a/src/odoh.rs
+++ b/src/odoh.rs
@@ -417,12 +417,9 @@ mod tests {
         // Point the cache at a host that does not exist so the fetch fails
         // deterministically; this exercises the backoff wiring without a
         // network round-trip succeeding.
-        crate::forward::ensure_crypto_provider();
         let cache = OdohConfigCache::new(
             "odoh-target.invalid".to_string(),
-            reqwest::Client::builder()
-                .use_rustls_tls()
-                .tls_certs_only(crate::forward::bundled_roots())
+            crate::forward::numa_tls_builder()
                 .timeout(Duration::from_millis(200))
                 .build()
                 .unwrap(),

--- a/src/odoh.rs
+++ b/src/odoh.rs
@@ -417,6 +417,7 @@ mod tests {
         // Point the cache at a host that does not exist so the fetch fails
         // deterministically; this exercises the backoff wiring without a
         // network round-trip succeeding.
+        crate::forward::ensure_crypto_provider();
         let cache = OdohConfigCache::new(
             "odoh-target.invalid".to_string(),
             reqwest::Client::builder()

--- a/src/odoh.rs
+++ b/src/odoh.rs
@@ -421,6 +421,8 @@ mod tests {
         let cache = OdohConfigCache::new(
             "odoh-target.invalid".to_string(),
             reqwest::Client::builder()
+                .use_rustls_tls()
+                .tls_certs_only(crate::forward::bundled_roots())
                 .timeout(Duration::from_millis(200))
                 .build()
                 .unwrap(),

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -217,7 +217,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_missing_content_type() {
         let (addr, state) = spawn_relay().await;
-        let client = reqwest::Client::new();
+        let client = crate::forward::default_client();
         let resp = client
             .post(format!(
                 "http://{}/relay?targethost=odoh.example.com&targetpath=/dns-query",
@@ -235,7 +235,7 @@ mod tests {
     async fn rejects_oversized_body() {
         let (addr, _state) = spawn_relay().await;
         let big = vec![0u8; MAX_BODY_BYTES + 1];
-        let client = reqwest::Client::new();
+        let client = crate::forward::default_client();
         let resp = client
             .post(format!(
                 "http://{}/relay?targethost=odoh.example.com&targetpath=/dns-query",
@@ -258,7 +258,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_targethost_without_dot() {
         let (addr, state) = spawn_relay().await;
-        let client = reqwest::Client::new();
+        let client = crate::forward::default_client();
         let resp = client
             .post(format!(
                 "http://{}/relay?targethost=localhost&targetpath=/dns-query",
@@ -276,7 +276,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_userinfo_ssrf_attempt() {
         let (addr, state) = spawn_relay().await;
-        let client = reqwest::Client::new();
+        let client = crate::forward::default_client();
         // The naive contains('.') check would let this through and reqwest
         // would route to `internal.host` using `evil.com` as userinfo.
         let resp = client
@@ -296,7 +296,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_targetpath_without_leading_slash() {
         let (addr, state) = spawn_relay().await;
-        let client = reqwest::Client::new();
+        let client = crate::forward::default_client();
         let resp = client
             .post(format!(
                 "http://{}/relay?targethost=odoh.example.com&targetpath=dns-query",
@@ -314,7 +314,7 @@ mod tests {
     #[tokio::test]
     async fn health_endpoint_reports_counters() {
         let (addr, _state) = spawn_relay().await;
-        let client = reqwest::Client::new();
+        let client = crate::forward::default_client();
         let resp = client
             .get(format!("http://{}/health", addr))
             .send()

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -32,9 +32,6 @@ const DOH_FALLBACK: &str = "https://9.9.9.9/dns-query";
 
 /// Boot the DNS server and run until the UDP listener errors out.
 pub async fn run(config_path: String) -> crate::Result<()> {
-    // Install the ring CryptoProvider before any HTTPS client is built.
-    crate::forward::ensure_crypto_provider();
-
     let ConfigLoad {
         config,
         path: resolved_config_path,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -32,8 +32,7 @@ const DOH_FALLBACK: &str = "https://9.9.9.9/dns-query";
 
 /// Boot the DNS server and run until the UDP listener errors out.
 pub async fn run(config_path: String) -> crate::Result<()> {
-    // reqwest 0.13 (`rustls-no-provider`) needs the ring CryptoProvider in place
-    // before any HTTPS client is built; install it once at startup.
+    // Install the ring CryptoProvider before any HTTPS client is built.
     crate::forward::ensure_crypto_provider();
 
     let ConfigLoad {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -32,6 +32,10 @@ const DOH_FALLBACK: &str = "https://9.9.9.9/dns-query";
 
 /// Boot the DNS server and run until the UDP listener errors out.
 pub async fn run(config_path: String) -> crate::Result<()> {
+    // reqwest 0.13 (`rustls-no-provider`) needs the ring CryptoProvider in place
+    // before any HTTPS client is built; install it once at startup.
+    crate::forward::ensure_crypto_provider();
+
     let ConfigLoad {
         config,
         path: resolved_config_path,


### PR DESCRIPTION
## Summary

- Bumps `reqwest` 0.12 → 0.13. Prerequisite for adopting iroh later: dedups the reqwest major to a single `0.13.4` in the tree so iroh (which depends on `reqwest ^0.13`) doesn't pull a second copy.
- **Keeps `ring`, keeps `aws-lc-rs` out.** reqwest 0.13 flips the default rustls provider to `aws-lc-rs`, which needs a C toolchain the armv6/Pi Zero cross-build doesn't have. Uses the `rustls-no-provider` feature and installs the ring `CryptoProvider` explicitly via `forward::ensure_crypto_provider()` (called at startup in `serve::run`, in `https_client_builder`, and at the blocklist download path).
- Adds the `query` feature (`odoh.rs` uses `RequestBuilder::query`, which is opt-in in 0.13).
- Routes raw test-client construction (`relay`, `blocklist`, `forward`, `odoh` tests) through `forward::default_client()` so the provider is installed regardless of test execution order — the original failure was order-dependent.
- No production API changes: `use_rustls_tls()` and the custom `dns_resolver(Arc<NumaResolver>)` both still compile under 0.13.

## Test plan

- `make all` green: 548 lib + integration tests, clippy `-D warnings`, cargo audit.
- **Real TLS handshake verified** — a bounded HTTPS request through `forward::build_https_client()` to a live DoH endpoint returns `200 OK` (unit tests only use `http://` mocks, so this confirms ring + `rustls-platform-verifier` actually negotiate TLS).
- **armv6 cross-build verified** via `messense/rust-musl-cross:arm-musleabihf` (the Pi Zero deploy path): compiles in ~2m → valid `ELF 32-bit ARM EABI5, statically linked` binary; `cargo tree -i aws-lc-sys` is empty (ring linked, no aws-lc regression).
- Single `reqwest v0.13.4` in the tree (`cargo tree -i reqwest`).