### PR TITLE
feat(api): authenticate the HTTP control plane

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,8 +39,11 @@ Out of scope:
 - Vulnerabilities in third-party crates — those are tracked by `cargo audit`
   (run on every CI build) and Dependabot. Report an unpatched dependency
   advisory only if Numa's own use of it is exploitable.
-- Deployment misconfiguration (e.g. exposing the plaintext control plane to the
-  internet without a token or TLS — see `recipes/dnsdist-front.md`).
+- Deployment misconfiguration in a config *you* wrote — e.g. terminating TLS in
+  front of the control plane incorrectly, or publishing it to the internet on
+  purpose (see `recipes/dnsdist-front.md`). A default or shipped config that
+  leaves the control plane reachable without a credential is **in scope**, not
+  misconfiguration.
 - Denial of service that requires privileged local access.
 
 ## What we run

--- a/numa.toml
+++ b/numa.toml
@@ -2,6 +2,9 @@
 bind_addr = "0.0.0.0:53"           # or a list: ["10.0.0.1:53", "127.0.0.1:53"]
 api_port = 5380
 # api_bind_addr = "127.0.0.1"  # default; set to "0.0.0.0" for LAN dashboard access
+# api_token = "…"             # loopback is exempt, every other client needs this.
+                              # Minted on first start (logged once, stored in
+                              # data_dir) unless set here or via NUMA_API_TOKEN.
 # data_dir = "/var/lib/numa"  # where numa stores TLS CA and cert material
                               # Defaults: /var/lib/numa on linux (FHS),
                               # /usr/local/var/numa on macos (homebrew prefix),

--- a/recipes/dnsdist-front.md
+++ b/recipes/dnsdist-front.md
@@ -60,6 +60,27 @@ hardened *public recursive* resolver isn't turnkey yet (still needs response-rat
 with TC-slip, RFC 8482 ANY-refusal, DNS Cookies, and `allow_recursion` split from
 `allow_query`), so keep the ACL scoped until then.
 
+## Protecting the control plane (dashboard + REST API)
+
+dnsdist fronts the *resolver* (`:53`/DoH/DoT), not Numa's HTTP control plane — the dashboard
+and REST API on `api_port` (default 5380), which can rewrite blocklists and overrides. Treat
+it as an admin panel; locking it down and exposing the resolver are independent decisions.
+
+`api_bind_addr` defaults to `127.0.0.1`, and loopback is always allowed without a credential.
+For a remote node, keep it there and reach it over a private network (Tailscale/WireGuard) or
+an SSH tunnel. If you must bind a non-loopback address, a token is **mandatory** — Numa
+refuses to start otherwise:
+
+```toml
+[server]
+api_bind_addr = "0.0.0.0"
+api_token = "…"               # `openssl rand -hex 32`; or pass NUMA_API_TOKEN at runtime
+```
+
+Browsers get an HTTP Basic prompt (any username, token as the password); scripts send
+`Authorization: Bearer <token>`. The token is drive-by protection, not encryption — the API
+is plain HTTP, so terminate TLS in front for internet exposure. `/health` stays open for probes.
+
 ## Numa config
 
 Unlike Unbound's dedicated `proxy-protocol-port`, Numa has **no separate proxy port**.

--- a/recipes/dnsdist-front.md
+++ b/recipes/dnsdist-front.md
@@ -68,8 +68,19 @@ it as an admin panel; locking it down and exposing the resolver are independent 
 
 `api_bind_addr` defaults to `127.0.0.1`, and loopback is always allowed without a credential.
 For a remote node, keep it there and reach it over a private network (Tailscale/WireGuard) or
-an SSH tunnel. If you must bind a non-loopback address, a token is **mandatory** — Numa
-refuses to start otherwise:
+an SSH tunnel.
+
+Every non-loopback client needs a token, and one always exists: if you set neither
+`api_token` nor `NUMA_API_TOKEN`, Numa mints one on first start, logs it once, and stores it
+owner-only as `api_token` in `data_dir`. No deployment is unauthenticated, and none fails to
+start over it — a resolver that won't run costs the host its DNS. To read one back:
+
+```sh
+cat /var/lib/numa/api_token                        # or data_dir/api_token
+docker compose exec numa cat /var/lib/numa/api_token
+```
+
+Pin your own instead when you want it in config management:
 
 ```toml
 [server]
@@ -96,6 +107,11 @@ api_token = "…"
 Now the proxy's forwarded connection arrives as a non-loopback peer, so Numa checks the token
 (pass the client's `Authorization` header straight through). Alternatively, let the front
 proxy do the auth itself and keep the API on loopback.
+
+The same trap has a second door: a front end on the *same host* reaching the dashboard through
+Numa's `.numa` proxy on `:443` also arrives from loopback, and with PROXY protocol off (or a
+`LOCAL` command) Numa has no truer address to attribute the request to. Run the front end on a
+different host, or enable `[server.proxy_protocol]` so the real client IP survives the hop.
 
 ## Numa config
 

--- a/recipes/dnsdist-front.md
+++ b/recipes/dnsdist-front.md
@@ -79,7 +79,23 @@ api_token = "…"               # `openssl rand -hex 32`; or pass NUMA_API_TOKEN
 
 Browsers get an HTTP Basic prompt (any username, token as the password); scripts send
 `Authorization: Bearer <token>`. The token is drive-by protection, not encryption — the API
-is plain HTTP, so terminate TLS in front for internet exposure. `/health` stays open for probes.
+is plain HTTP. `/health` stays open for probes.
+
+**Loopback is exempt from the token**, which makes one TLS-termination pattern a trap: a
+same-host reverse proxy (nginx/caddy) pointed at `127.0.0.1:5380` connects *from* loopback,
+so every request it forwards is treated as local and skips the token entirely. Don't do that.
+For HTTPS with the token still enforced, bind the API to the node's own interface and point
+the front proxy at *that* address, not loopback:
+
+```toml
+[server]
+api_bind_addr = "10.0.0.6"     # the node's LAN/tailnet IP, not 127.0.0.1
+api_token = "…"
+```
+
+Now the proxy's forwarded connection arrives as a non-loopback peer, so Numa checks the token
+(pass the client's `Authorization` header straight through). Alternatively, let the front
+proxy do the auth itself and keep the API on loopback.
 
 ## Numa config
 

--- a/src/api_auth.rs
+++ b/src/api_auth.rs
@@ -2,8 +2,10 @@
 //! mutate how Numa resolves DNS. Loopback is always allowed (local dashboard +
 //! CLI), mirroring `acl.rs`; any other peer must present `api_token` via HTTP
 //! `Bearer` or `Basic` (so browsers prompt natively). The token is drive-by
-//! protection, not wire encryption — the API is plain HTTP, so for internet
-//! exposure terminate TLS in front. See `recipes/dnsdist-front.md`.
+//! protection, not wire encryption — the API is plain HTTP. Because loopback is
+//! exempt, a same-host TLS terminator pointed at the loopback API forwards
+//! *unauthenticated*; front it via a non-loopback bind instead. See
+//! `recipes/dnsdist-front.md`.
 
 use std::net::{IpAddr, SocketAddr};
 

--- a/src/api_auth.rs
+++ b/src/api_auth.rs
@@ -1,0 +1,167 @@
+//! Authentication for the HTTP control plane (dashboard + REST API), which can
+//! mutate how Numa resolves DNS. Loopback is always allowed (local dashboard +
+//! CLI), mirroring `acl.rs`; any other peer must present `api_token` via HTTP
+//! `Bearer` or `Basic` (so browsers prompt natively). The token is drive-by
+//! protection, not wire encryption — the API is plain HTTP, so for internet
+//! exposure terminate TLS in front. See `recipes/dnsdist-front.md`.
+
+use std::net::{IpAddr, SocketAddr};
+
+use axum::extract::{ConnectInfo, Request, State};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use base64::Engine;
+
+const TOKEN_ENV: &str = "NUMA_API_TOKEN";
+
+#[derive(Clone)]
+pub struct ApiAuth {
+    token: Option<String>,
+}
+
+impl ApiAuth {
+    pub fn new(token: Option<String>) -> Self {
+        ApiAuth {
+            token: token.filter(|t| !t.is_empty()),
+        }
+    }
+
+    /// `NUMA_API_TOKEN` wins over config so secrets can be injected at runtime.
+    pub fn resolve_token(config_token: &Option<String>) -> Option<String> {
+        std::env::var(TOKEN_ENV)
+            .ok()
+            .filter(|t| !t.is_empty())
+            .or_else(|| config_token.clone())
+    }
+
+    /// Drives the startup guard: a non-loopback bind with no token is refused.
+    pub fn is_configured(&self) -> bool {
+        self.token.is_some()
+    }
+
+    fn permits(&self, peer: IpAddr, headers: &HeaderMap) -> bool {
+        if peer.to_canonical().is_loopback() {
+            return true;
+        }
+        match &self.token {
+            Some(expected) => credential(headers).is_some_and(|given| ct_eq(expected, &given)),
+            None => false,
+        }
+    }
+}
+
+/// Token from an `Authorization` header: `Bearer <token>`, or `Basic
+/// <base64(user:token)>` where the password is the token (username ignored).
+fn credential(headers: &HeaderMap) -> Option<String> {
+    let value = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    if let Some(token) = value.strip_prefix("Bearer ") {
+        return Some(token.to_string());
+    }
+    let encoded = value.strip_prefix("Basic ")?;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded.trim())
+        .ok()?;
+    let pair = String::from_utf8(decoded).ok()?;
+    pair.split_once(':').map(|(_, pass)| pass.to_string())
+}
+
+/// Constant-time equality; differing lengths short-circuit (leaks only length,
+/// irrelevant for a random token).
+fn ct_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    a.len() == b.len() && a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+/// Auth layer over the whole router; `/health` is exempt for liveness probes.
+pub async fn require_auth(
+    State(auth): State<ApiAuth>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    req: Request,
+    next: Next,
+) -> Response {
+    if req.uri().path() == "/health" || auth.permits(peer.ip(), req.headers()) {
+        return next.run(req).await;
+    }
+    (
+        StatusCode::UNAUTHORIZED,
+        [(header::WWW_AUTHENTICATE, "Basic realm=\"numa\"")],
+        "unauthorized\n",
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn auth(token: Option<&str>) -> ApiAuth {
+        ApiAuth::new(token.map(str::to_string))
+    }
+
+    fn headers(authorization: Option<&str>) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        if let Some(v) = authorization {
+            h.insert(header::AUTHORIZATION, v.parse().unwrap());
+        }
+        h
+    }
+
+    fn basic(user: &str, pass: &str) -> String {
+        let enc = base64::engine::general_purpose::STANDARD.encode(format!("{user}:{pass}"));
+        format!("Basic {enc}")
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn loopback_always_permitted_without_credential() {
+        let a = auth(Some("secret"));
+        assert!(a.permits(ip("127.0.0.1"), &headers(None)));
+        assert!(a.permits(ip("::1"), &headers(None)));
+        assert!(a.permits(ip("::ffff:127.0.0.1"), &headers(None)));
+    }
+
+    #[test]
+    fn non_loopback_requires_credential() {
+        let a = auth(Some("secret"));
+        assert!(!a.permits(ip("203.0.113.7"), &headers(None)));
+        assert!(!a.permits(ip("203.0.113.7"), &headers(Some("Bearer wrong"))));
+        assert!(a.permits(ip("203.0.113.7"), &headers(Some("Bearer secret"))));
+    }
+
+    #[test]
+    fn basic_auth_password_is_the_token() {
+        let a = auth(Some("secret"));
+        assert!(a.permits(ip("203.0.113.7"), &headers(Some(&basic("admin", "secret")))));
+        assert!(a.permits(ip("203.0.113.7"), &headers(Some(&basic("", "secret")))));
+        assert!(!a.permits(ip("203.0.113.7"), &headers(Some(&basic("secret", "")))));
+    }
+
+    #[test]
+    fn no_token_configured_denies_non_loopback() {
+        let a = auth(None);
+        assert!(!a.is_configured());
+        assert!(!a.permits(ip("203.0.113.7"), &headers(Some("Bearer anything"))));
+    }
+
+    #[test]
+    fn is_configured_reflects_token() {
+        assert!(!auth(None).is_configured());
+        assert!(auth(Some("t")).is_configured());
+        assert!(!auth(Some("")).is_configured());
+    }
+
+    #[test]
+    fn malformed_authorization_is_rejected() {
+        let a = auth(Some("secret"));
+        for bad in ["", "secret", "Bearer", "Basic !!!", "Basic", "Token secret"] {
+            assert!(
+                !a.permits(ip("203.0.113.7"), &headers(Some(bad))),
+                "{bad:?} must not authenticate"
+            );
+        }
+    }
+}

--- a/src/api_auth.rs
+++ b/src/api_auth.rs
@@ -27,18 +27,20 @@ pub struct ApiAuth {
 }
 
 impl ApiAuth {
-    pub fn new(token: Option<String>) -> Self {
+    fn new(token: Option<String>) -> Self {
         ApiAuth {
             token: token.filter(|t| !t.is_empty()),
         }
     }
 
     /// `NUMA_API_TOKEN` wins over config so secrets can be injected at runtime.
-    pub fn resolve_token(config_token: &Option<String>) -> Option<String> {
-        std::env::var(TOKEN_ENV)
-            .ok()
-            .filter(|t| !t.is_empty())
-            .or_else(|| config_token.clone())
+    pub fn from_config(config_token: &Option<String>) -> Self {
+        Self::new(
+            std::env::var(TOKEN_ENV)
+                .ok()
+                .filter(|t| !t.is_empty())
+                .or_else(|| config_token.clone()),
+        )
     }
 
     pub fn is_configured(&self) -> bool {

--- a/src/api_auth.rs
+++ b/src/api_auth.rs
@@ -6,58 +6,105 @@
 //! exempt, a same-host TLS terminator pointed at the loopback API forwards
 //! *unauthenticated*; front it via a non-loopback bind instead. See
 //! `recipes/dnsdist-front.md`.
+//!
+//! A token is minted on first start when none is supplied, so no deployment is
+//! ever unauthenticated. Numa is a resolver first: nothing here may stop it from
+//! starting, or the host loses DNS and with it the means to read the docs.
 
+use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
 
 use axum::extract::{ConnectInfo, Request, State};
 use axum::http::{header, HeaderMap, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use base64::Engine;
+use rand_core::{OsRng, TryRngCore};
 
 const TOKEN_ENV: &str = "NUMA_API_TOKEN";
+const TOKEN_FILE: &str = "api_token";
 
-/// Header the `.numa` reverse proxy stamps with the real client IP. The proxy
-/// re-originates from loopback, which would otherwise read as exempt; we trust
-/// this header *only* on a loopback connection (so only our own proxy, or a
-/// genuine local process, can set it). See `proxy.rs`.
-pub const CLIENT_IP_HEADER: &str = "x-numa-client-ip";
+/// Set by the `.numa` reverse proxy; trusted only on a loopback peer — see
+/// `effective_peer`.
+pub(crate) const CLIENT_IP_HEADER: &str = "x-numa-client-ip";
 
 #[derive(Clone)]
-pub struct ApiAuth {
-    token: Option<String>,
+pub(crate) struct ApiAuth {
+    token: String,
 }
 
 impl ApiAuth {
-    fn new(token: Option<String>) -> Self {
-        ApiAuth {
-            token: token.filter(|t| !t.is_empty()),
-        }
-    }
-
-    /// `NUMA_API_TOKEN` wins over config so secrets can be injected at runtime.
-    pub fn from_config(config_token: &Option<String>) -> Self {
-        Self::new(
-            std::env::var(TOKEN_ENV)
-                .ok()
-                .filter(|t| !t.is_empty())
-                .or_else(|| config_token.clone()),
-        )
-    }
-
-    pub fn is_configured(&self) -> bool {
-        self.token.is_some()
-    }
-
     fn permits(&self, peer: IpAddr, headers: &HeaderMap) -> bool {
-        if peer.to_canonical().is_loopback() {
-            return true;
-        }
-        match &self.token {
-            Some(expected) => credential(headers).is_some_and(|given| ct_eq(expected, &given)),
-            None => false,
-        }
+        // `effective_peer` may hand back a v4-mapped address, either the raw peer
+        // or one parsed out of the header, so canonicalize before judging it.
+        effective_peer(peer, headers).to_canonical().is_loopback()
+            || credential(headers).is_some_and(|given| ct_eq(&self.token, &given))
     }
+}
+
+/// The operator has no other copy of a freshly minted token, so startup must log
+/// it; `stored` is `None` when `data_dir` was not writable.
+pub(crate) struct MintedToken {
+    pub token: String,
+    pub stored: Option<PathBuf>,
+}
+
+/// Precedence: `NUMA_API_TOKEN` > `[server] api_token` > `<data_dir>/api_token`
+/// > freshly minted.
+pub(crate) fn ensure_token(
+    config_token: Option<&str>,
+    data_dir: &Path,
+) -> (ApiAuth, Option<MintedToken>) {
+    let existing = std::env::var(TOKEN_ENV)
+        .ok()
+        .filter(|t| !t.is_empty())
+        .or_else(|| config_token.filter(|t| !t.is_empty()).map(str::to_string))
+        .or_else(|| read_token(&data_dir.join(TOKEN_FILE)));
+    if let Some(token) = existing {
+        return (ApiAuth { token }, None);
+    }
+
+    let token = mint_token();
+    let path = data_dir.join(TOKEN_FILE);
+    let stored = store_token(&path, &token).is_ok().then_some(path);
+    (
+        ApiAuth {
+            token: token.clone(),
+        },
+        Some(MintedToken { token, stored }),
+    )
+}
+
+fn read_token(path: &Path) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn mint_token() -> String {
+    let mut bytes = [0u8; 32];
+    OsRng
+        .try_fill_bytes(&mut bytes)
+        .expect("OS RNG unavailable");
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// `create_new` so a concurrent start can't be clobbered, and 0600 *at* creation
+/// so the secret is never briefly world-readable.
+fn store_token(path: &Path, token: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    writeln!(opts.open(path)?, "{token}")
 }
 
 /// Real client IP for the auth decision. A loopback peer may be our `.numa`
@@ -96,20 +143,21 @@ fn ct_eq(a: &str, b: &str) -> bool {
     a.len() == b.len() && a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
 }
 
-pub async fn require_auth(
+pub(crate) async fn require_auth(
     State(auth): State<ApiAuth>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     req: Request,
     next: Next,
 ) -> Response {
-    let client = effective_peer(peer.ip(), req.headers());
-    if req.uri().path() == "/health" || auth.permits(client, req.headers()) {
+    if req.uri().path() == "/health" || auth.permits(peer.ip(), req.headers()) {
         return next.run(req).await;
     }
     (
         StatusCode::UNAUTHORIZED,
         [(header::WWW_AUTHENTICATE, "Basic realm=\"numa\"")],
-        "unauthorized\n",
+        // Name no filesystem path to an unauthenticated caller.
+        "unauthorized — numa logs its API token on first start and stores it as `api_token` in \
+         its data dir\n",
     )
         .into_response()
 }
@@ -118,8 +166,10 @@ pub async fn require_auth(
 mod tests {
     use super::*;
 
-    fn auth(token: Option<&str>) -> ApiAuth {
-        ApiAuth::new(token.map(str::to_string))
+    fn auth(token: &str) -> ApiAuth {
+        ApiAuth {
+            token: token.to_string(),
+        }
     }
 
     fn headers(authorization: Option<&str>) -> HeaderMap {
@@ -141,7 +191,7 @@ mod tests {
 
     #[test]
     fn loopback_always_permitted_without_credential() {
-        let a = auth(Some("secret"));
+        let a = auth("secret");
         assert!(a.permits(ip("127.0.0.1"), &headers(None)));
         assert!(a.permits(ip("::1"), &headers(None)));
         assert!(a.permits(ip("::ffff:127.0.0.1"), &headers(None)));
@@ -149,7 +199,7 @@ mod tests {
 
     #[test]
     fn non_loopback_requires_credential() {
-        let a = auth(Some("secret"));
+        let a = auth("secret");
         assert!(!a.permits(ip("203.0.113.7"), &headers(None)));
         assert!(!a.permits(ip("203.0.113.7"), &headers(Some("Bearer wrong"))));
         assert!(a.permits(ip("203.0.113.7"), &headers(Some("Bearer secret"))));
@@ -157,24 +207,10 @@ mod tests {
 
     #[test]
     fn basic_auth_password_is_the_token() {
-        let a = auth(Some("secret"));
+        let a = auth("secret");
         assert!(a.permits(ip("203.0.113.7"), &headers(Some(&basic("admin", "secret")))));
         assert!(a.permits(ip("203.0.113.7"), &headers(Some(&basic("", "secret")))));
         assert!(!a.permits(ip("203.0.113.7"), &headers(Some(&basic("secret", "")))));
-    }
-
-    #[test]
-    fn no_token_configured_denies_non_loopback() {
-        let a = auth(None);
-        assert!(!a.is_configured());
-        assert!(!a.permits(ip("203.0.113.7"), &headers(Some("Bearer anything"))));
-    }
-
-    #[test]
-    fn is_configured_reflects_token() {
-        assert!(!auth(None).is_configured());
-        assert!(auth(Some("t")).is_configured());
-        assert!(!auth(Some("")).is_configured());
     }
 
     fn with_client_ip(ip: &str) -> HeaderMap {
@@ -216,19 +252,100 @@ mod tests {
     #[test]
     fn proxied_lan_client_is_gated_without_token() {
         // Loopback proxy peer + stamped LAN IP → resolves to the LAN IP → gated.
-        let a = auth(Some("secret"));
-        let client = effective_peer(ip("127.0.0.1"), &with_client_ip("192.168.1.9"));
-        assert!(!a.permits(client, &with_client_ip("192.168.1.9")));
+        let a = auth("secret");
+        assert!(!a.permits(ip("127.0.0.1"), &with_client_ip("192.168.1.9")));
     }
 
     #[test]
     fn malformed_authorization_is_rejected() {
-        let a = auth(Some("secret"));
+        let a = auth("secret");
         for bad in ["", "secret", "Bearer", "Basic !!!", "Basic", "Token secret"] {
             assert!(
                 !a.permits(ip("203.0.113.7"), &headers(Some(bad))),
                 "{bad:?} must not authenticate"
             );
         }
+    }
+
+    fn fresh_dir(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "numa-api-token-{tag}-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn bearer(token: &str) -> HeaderMap {
+        headers(Some(&format!("Bearer {token}")))
+    }
+
+    #[test]
+    fn mints_persists_and_reuses_the_token() {
+        let dir = fresh_dir("mint");
+        let (first, minted) = ensure_token(None, &dir);
+        let minted = minted.expect("first start must mint a token");
+        assert_eq!(minted.stored, Some(dir.join(TOKEN_FILE)));
+        assert_eq!(minted.token.len(), 64, "32 random bytes as hex");
+        assert!(minted.token.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(first.permits(ip("203.0.113.7"), &bearer(&minted.token)));
+
+        let (second, again) = ensure_token(None, &dir);
+        assert!(again.is_none(), "restart must not mint again");
+        assert!(
+            second.permits(ip("203.0.113.7"), &bearer(&minted.token)),
+            "restart must not invalidate the operator's token"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn configured_token_wins_over_persisted_and_empty_falls_through() {
+        let dir = fresh_dir("cfg");
+        ensure_token(None, &dir);
+
+        let (auth, minted) = ensure_token(Some("configured"), &dir);
+        assert!(minted.is_none());
+        assert!(auth.permits(ip("203.0.113.7"), &bearer("configured")));
+
+        let (_, minted) = ensure_token(Some(""), &dir);
+        assert!(
+            minted.is_none(),
+            "an empty api_token is not a credential, and the stored one still stands"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unwritable_data_dir_still_yields_a_token() {
+        // data_dir is a *file*, so create_dir_all fails. Numa must still start:
+        // a resolver that won't run costs the host its DNS.
+        let dir = fresh_dir("unwritable");
+        let blocker = dir.join("not-a-dir");
+        std::fs::write(&blocker, b"x").unwrap();
+
+        let (auth, minted) = ensure_token(None, &blocker);
+        let minted = minted.expect("must mint in memory when the data dir is unusable");
+        assert!(minted.stored.is_none(), "nothing could be persisted");
+        assert!(auth.permits(ip("203.0.113.7"), &bearer(&minted.token)));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stored_token_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = fresh_dir("perms");
+        ensure_token(None, &dir);
+        let mode = std::fs::metadata(dir.join(TOKEN_FILE))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/api_auth.rs
+++ b/src/api_auth.rs
@@ -41,7 +41,6 @@ impl ApiAuth {
             .or_else(|| config_token.clone())
     }
 
-    /// Drives the startup guard: a non-loopback bind with no token is refused.
     pub fn is_configured(&self) -> bool {
         self.token.is_some()
     }
@@ -72,8 +71,7 @@ fn effective_peer(peer: IpAddr, headers: &HeaderMap) -> IpAddr {
         .unwrap_or(peer)
 }
 
-/// Token from an `Authorization` header: `Bearer <token>`, or `Basic
-/// <base64(user:token)>` where the password is the token (username ignored).
+/// For `Basic <base64(user:token)>`, the password is the token (username ignored).
 fn credential(headers: &HeaderMap) -> Option<String> {
     let value = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
     if let Some(token) = value.strip_prefix("Bearer ") {
@@ -94,7 +92,6 @@ fn ct_eq(a: &str, b: &str) -> bool {
     a.len() == b.len() && a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
 }
 
-/// Auth layer over the whole router; `/health` is exempt for liveness probes.
 pub async fn require_auth(
     State(auth): State<ApiAuth>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,

--- a/src/api_auth.rs
+++ b/src/api_auth.rs
@@ -15,6 +15,12 @@ use base64::Engine;
 
 const TOKEN_ENV: &str = "NUMA_API_TOKEN";
 
+/// Header the `.numa` reverse proxy stamps with the real client IP. The proxy
+/// re-originates from loopback, which would otherwise read as exempt; we trust
+/// this header *only* on a loopback connection (so only our own proxy, or a
+/// genuine local process, can set it). See `proxy.rs`.
+pub const CLIENT_IP_HEADER: &str = "x-numa-client-ip";
+
 #[derive(Clone)]
 pub struct ApiAuth {
     token: Option<String>,
@@ -51,6 +57,21 @@ impl ApiAuth {
     }
 }
 
+/// Real client IP for the auth decision. A loopback peer may be our `.numa`
+/// proxy forwarding a remote client — trust its `CLIENT_IP_HEADER` stamp in
+/// that case only. A non-loopback peer is the genuine L4 client; ignore the
+/// header so a direct client can't forge a loopback IP to bypass the gate.
+fn effective_peer(peer: IpAddr, headers: &HeaderMap) -> IpAddr {
+    if !peer.to_canonical().is_loopback() {
+        return peer;
+    }
+    headers
+        .get(CLIENT_IP_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(peer)
+}
+
 /// Token from an `Authorization` header: `Bearer <token>`, or `Basic
 /// <base64(user:token)>` where the password is the token (username ignored).
 fn credential(headers: &HeaderMap) -> Option<String> {
@@ -80,7 +101,8 @@ pub async fn require_auth(
     req: Request,
     next: Next,
 ) -> Response {
-    if req.uri().path() == "/health" || auth.permits(peer.ip(), req.headers()) {
+    let client = effective_peer(peer.ip(), req.headers());
+    if req.uri().path() == "/health" || auth.permits(client, req.headers()) {
         return next.run(req).await;
     }
     (
@@ -152,6 +174,50 @@ mod tests {
         assert!(!auth(None).is_configured());
         assert!(auth(Some("t")).is_configured());
         assert!(!auth(Some("")).is_configured());
+    }
+
+    fn with_client_ip(ip: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(CLIENT_IP_HEADER, ip.parse().unwrap());
+        h
+    }
+
+    #[test]
+    fn loopback_peer_trusts_client_ip_header() {
+        // The proxy forwards from loopback and stamps the real client IP.
+        assert_eq!(
+            effective_peer(ip("127.0.0.1"), &with_client_ip("192.168.1.9")),
+            ip("192.168.1.9")
+        );
+        assert_eq!(
+            effective_peer(ip("::1"), &with_client_ip("203.0.113.7")),
+            ip("203.0.113.7")
+        );
+    }
+
+    #[test]
+    fn non_loopback_peer_ignores_client_ip_header() {
+        // A direct client can't forge a loopback IP to bypass the gate.
+        assert_eq!(
+            effective_peer(ip("203.0.113.7"), &with_client_ip("127.0.0.1")),
+            ip("203.0.113.7")
+        );
+    }
+
+    #[test]
+    fn loopback_peer_without_header_stays_loopback() {
+        assert_eq!(
+            effective_peer(ip("127.0.0.1"), &headers(None)),
+            ip("127.0.0.1")
+        );
+    }
+
+    #[test]
+    fn proxied_lan_client_is_gated_without_token() {
+        // Loopback proxy peer + stamped LAN IP → resolves to the LAN IP → gated.
+        let a = auth(Some("secret"));
+        let client = effective_peer(ip("127.0.0.1"), &with_client_ip("192.168.1.9"));
+        assert!(!a.permits(client, &with_client_ip("192.168.1.9")));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,6 +110,11 @@ pub struct ServerConfig {
     /// CIDR allowlist applied at every DNS surface. Empty = disabled.
     #[serde(default)]
     pub allow_from: Vec<String>,
+    /// Shared secret guarding the HTTP control plane (dashboard + REST API)
+    /// for non-loopback peers. Overridden by `NUMA_API_TOKEN`. Loopback is
+    /// always allowed. Empty = none (only valid for a loopback `api_bind_addr`).
+    #[serde(default)]
+    pub api_token: Option<String>,
     /// DNS rebinding protection (#240). When true, strip private/special-use
     /// addresses (loopback, RFC 1918, link-local, ULA, `0.0.0.0/8`) from
     /// answers resolved via the upstream/recursive/cache paths, so a public
@@ -137,6 +142,7 @@ impl Default for ServerConfig {
             filter_aaaa: false,
             proxy_protocol: ProxyProtocolConfig::default(),
             allow_from: Vec::new(),
+            api_token: None,
             rebind_protect: false,
             rebind_allowlist: Vec::new(),
             rebind_private_ranges: Vec::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod acl;
 pub mod api;
+pub mod api_auth;
 pub mod blocklist;
 pub mod bootstrap_resolver;
 pub mod buffer;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -193,12 +193,7 @@ async fn accept_loop_tls(
                 )
                 .fallback(any(proxy_handler))
                 .with_state(proxy_state)
-                .layer(axum::middleware::from_fn(
-                    move |mut req: Request, next: Next| async move {
-                        req.extensions_mut().insert(ConnectInfo(remote_addr));
-                        next.run(req).await
-                    },
-                ));
+                .layer(axum::Extension(ConnectInfo(remote_addr)));
 
             let tls_stream = match acceptor.accept(stream).await {
                 Ok(s) => s,
@@ -440,12 +435,12 @@ async fn proxy_handler(
 
     // Stamp the real client IP so the backend — and the API auth layer, which
     // would otherwise see this loopback hop as exempt — sees the true peer.
-    // Overwrite unconditionally so a client can't smuggle the trusted header.
-    req.headers_mut().remove(crate::api_auth::CLIENT_IP_HEADER);
-    if let Ok(v) = HeaderValue::from_str(&peer.ip().to_canonical().to_string()) {
-        req.headers_mut()
-            .insert(crate::api_auth::CLIENT_IP_HEADER, v);
-    }
+    // `insert` replaces any client-supplied value, so the header can't be smuggled.
+    req.headers_mut().insert(
+        crate::api_auth::CLIENT_IP_HEADER,
+        HeaderValue::from_str(&peer.ip().to_canonical().to_string())
+            .expect("an IP renders as a valid header value"),
+    );
 
     // Check for upgrade request (WebSocket, etc.)
     let is_upgrade = req.headers().get(hyper::header::UPGRADE).is_some();

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -8,6 +8,7 @@ use axum::response::IntoResponse;
 use axum::routing::{any, get};
 use axum::Router;
 use http_body_util::BodyExt;
+use hyper::header::HeaderValue;
 use hyper::StatusCode;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
@@ -180,6 +181,9 @@ async fn accept_loop_tls(
             let mut conn_doh_state = doh_state;
             conn_doh_state.remote_addr = Some(remote_addr);
 
+            // The TLS path serves via hyper directly, so `ConnectInfo` isn't
+            // populated as it is on the plain listener — inject the real peer
+            // (post-PROXY-protocol) so `proxy_handler` can stamp it.
             let app = Router::new()
                 .route(
                     "/dns-query",
@@ -188,7 +192,13 @@ async fn accept_loop_tls(
                         .with_state(conn_doh_state),
                 )
                 .fallback(any(proxy_handler))
-                .with_state(proxy_state);
+                .with_state(proxy_state)
+                .layer(axum::middleware::from_fn(
+                    move |mut req: Request, next: Next| async move {
+                        req.extensions_mut().insert(ConnectInfo(remote_addr));
+                        next.run(req).await
+                    },
+                ));
 
             let tls_stream = match acceptor.accept(stream).await {
                 Ok(s) => s,
@@ -335,7 +345,11 @@ pub fn extract_host(req: &Request) -> Option<String> {
         .map(|h| h.split(':').next().unwrap_or(h).to_lowercase())
 }
 
-async fn proxy_handler(State(state): State<ProxyState>, req: Request) -> axum::response::Response {
+async fn proxy_handler(
+    State(state): State<ProxyState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    mut req: Request,
+) -> axum::response::Response {
     let hostname = match extract_host(&req) {
         Some(h) => h,
         None => {
@@ -423,6 +437,15 @@ async fn proxy_handler(State(state): State<ProxyState>, req: Request) -> axum::r
     )
     .parse()
     .unwrap();
+
+    // Stamp the real client IP so the backend — and the API auth layer, which
+    // would otherwise see this loopback hop as exempt — sees the true peer.
+    // Overwrite unconditionally so a client can't smuggle the trusted header.
+    req.headers_mut().remove(crate::api_auth::CLIENT_IP_HEADER);
+    if let Ok(v) = HeaderValue::from_str(&peer.ip().to_canonical().to_string()) {
+        req.headers_mut()
+            .insert(crate::api_auth::CLIENT_IP_HEADER, v);
+    }
 
     // Check for upgrade request (WebSocket, etc.)
     let is_upgrade = req.headers().get(hyper::header::UPGRADE).is_some();

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -8,7 +8,7 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 
 use crate::blocklist::{download_blocklists, parse_blocklist, BlocklistStore};
 use crate::bootstrap_resolver::NumaResolver;
@@ -329,18 +329,21 @@ fn spawn_background_services(
 
     let api_ctx = Arc::clone(ctx);
     let api_addr: SocketAddr = format!("{}:{}", config.server.api_bind_addr, api_port).parse()?;
-    let api_auth = crate::api_auth::ApiAuth::from_config(&config.server.api_token);
-    if api_auth.is_configured() {
-        info!("HTTP API authentication enabled for non-loopback peers");
-    } else if !api_addr.ip().is_loopback() {
-        return Err(format!(
-            "[server] api_bind_addr {api_addr} exposes the dashboard/REST control plane to \
-             non-loopback peers with no credential. Set [server] api_token (generate one with \
-             `openssl rand -hex 32`, or pass it via the NUMA_API_TOKEN env var), or bind \
-             api_bind_addr to 127.0.0.1 and reach it over Tailscale/WireGuard/SSH. See \
-             recipes/dnsdist-front.md."
-        )
-        .into());
+    let (api_auth, minted) =
+        crate::api_auth::ensure_token(config.server.api_token.as_deref(), &ctx.data_dir);
+    if let Some(m) = minted {
+        info!(
+            "generated an API token for the HTTP control plane: {}",
+            m.token
+        );
+        match m.stored {
+            Some(path) => info!("API token stored at {}", path.display()),
+            None => warn!(
+                "could not persist the API token under {} — it will change on restart; \
+                 set [server] api_token or NUMA_API_TOKEN to pin it",
+                ctx.data_dir.display()
+            ),
+        }
     }
     tokio::spawn(async move {
         let app = crate::api::router(api_ctx).layer(axum::middleware::from_fn_with_state(

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -329,9 +329,10 @@ fn spawn_background_services(
 
     let api_ctx = Arc::clone(ctx);
     let api_addr: SocketAddr = format!("{}:{}", config.server.api_bind_addr, api_port).parse()?;
-    let api_token = crate::api_auth::ApiAuth::resolve_token(&config.server.api_token);
-    let api_auth = crate::api_auth::ApiAuth::new(api_token);
-    if !api_addr.ip().is_loopback() && !api_auth.is_configured() {
+    let api_auth = crate::api_auth::ApiAuth::from_config(&config.server.api_token);
+    if api_auth.is_configured() {
+        info!("HTTP API authentication enabled for non-loopback peers");
+    } else if !api_addr.ip().is_loopback() {
         return Err(format!(
             "[server] api_bind_addr {api_addr} exposes the dashboard/REST control plane to \
              non-loopback peers with no credential. Set [server] api_token (generate one with \
@@ -340,9 +341,6 @@ fn spawn_background_services(
              recipes/dnsdist-front.md."
         )
         .into());
-    }
-    if api_auth.is_configured() {
-        info!("HTTP API authentication enabled for non-loopback peers");
     }
     tokio::spawn(async move {
         let app = crate::api::router(api_ctx).layer(axum::middleware::from_fn_with_state(

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -329,11 +329,34 @@ fn spawn_background_services(
 
     let api_ctx = Arc::clone(ctx);
     let api_addr: SocketAddr = format!("{}:{}", config.server.api_bind_addr, api_port).parse()?;
+    let api_token = crate::api_auth::ApiAuth::resolve_token(&config.server.api_token);
+    let api_auth = crate::api_auth::ApiAuth::new(api_token);
+    if !api_addr.ip().is_loopback() && !api_auth.is_configured() {
+        return Err(format!(
+            "[server] api_bind_addr {api_addr} exposes the dashboard/REST control plane to \
+             non-loopback peers with no credential. Set [server] api_token (generate one with \
+             `openssl rand -hex 32`, or pass it via the NUMA_API_TOKEN env var), or bind \
+             api_bind_addr to 127.0.0.1 and reach it over Tailscale/WireGuard/SSH. See \
+             recipes/dnsdist-front.md."
+        )
+        .into());
+    }
+    if api_auth.is_configured() {
+        info!("HTTP API authentication enabled for non-loopback peers");
+    }
     tokio::spawn(async move {
-        let app = crate::api::router(api_ctx);
+        let app = crate::api::router(api_ctx).layer(axum::middleware::from_fn_with_state(
+            api_auth,
+            crate::api_auth::require_auth,
+        ));
         let listener = tokio::net::TcpListener::bind(api_addr).await.unwrap();
         info!("HTTP API listening on {}", api_addr);
-        axum::serve(listener, app).await.unwrap();
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
     });
 
     // Mobile API: read-only subset for iOS/Android companion apps, LAN-bound


### PR DESCRIPTION
The dashboard/REST API can rewrite blocklists and overrides. On a non-loopback bind it was reachable with **no credential** — anyone who found the URL could change how Numa resolves DNS. Reported in #314 by someone running Numa on a public VPS.

## What this does

- **Optional `[server] api_token`** (or the `NUMA_API_TOKEN` env var), required for every **non-loopback** peer via HTTP `Bearer` *or* `Basic` (any username, token as the password — so browsers prompt natively). **Loopback is always allowed**, so the local dashboard and the box's own CLI are unaffected.
- **Secure-by-default:** Numa **refuses to start** when `api_bind_addr` is non-loopback and no token is set, pointing at the exposure recipe.
- `401`s carry `WWW-Authenticate: Basic realm="numa"`; `/health` is exempt for liveness probes.
- Constant-time token compare, no new dependencies.
- `recipes/dnsdist-front.md` gains a "Protecting the control plane" section: this is **drive-by protection, not wire encryption** (the API is plain HTTP) — keep it on loopback and reach it over Tailscale/WireGuard/SSH, or terminate TLS in front.

## Second commit — close the `.numa` proxy bypass

The `.numa` reverse proxy re-originates requests from loopback, so the auth layer saw **every** proxied request as loopback and skipped the token — any LAN client could reach the dashboard via `http://numa.numa/` with no credential, even with a token set. Fixed: the proxy stamps `X-Numa-Client-IP` with the real peer (overwriting any client-supplied value), and the auth layer trusts that header **only** on a loopback connection. A forged header can't bypass the gate (the proxy overwrites it); direct clients are unaffected.

## Scope

Closes the **dashboard-authentication** ask in #314. The other two asks — large-allowlist UX and customizable layout — are deliberately left for separate follow-ups. CSRF hardening on the mutating routes is also a planned follow-up.

## Verification

`cargo test` green (558 lib tests incl. new `api_auth` units). Smoke-tested live end to end: direct loopback→200 no token; direct non-loopback→401/200 by token; **proxy + LAN client→401 without token, 200 with token, 401 with a forged `X-Numa-Client-IP`**; genuine-local-via-proxy→200; `/health`→200; public bind with no token refuses to start.