### PR TITLE
fix(forward): resolve undetectable system DNS to DoH on rescan (#169)

### DIFF
--- a/src/forward.rs
+++ b/src/forward.rs
@@ -278,18 +278,41 @@ impl UpstreamPool {
         self.primary = primary;
     }
 
+    /// Replace the primary with `new` if it differs from the current preferred.
+    /// Returns `true` if the pool changed.
+    ///
+    /// Keeps the TCP sibling in step with the primary. The sibling exists so
+    /// Forward mode survives carriers that drop outbound UDP:53, but failover
+    /// chains `fallback` *after* the primaries, so a sibling left over from the
+    /// previous network is retried before anything reachable (#169).
+    pub fn maybe_replace_primary(&mut self, new: Upstream) -> bool {
+        if self.preferred() == Some(&new) {
+            return false;
+        }
+        let stale_sibling = match self.primary.first() {
+            Some(Upstream::Udp(addr)) => Some(Upstream::Tcp(*addr)),
+            _ => None,
+        };
+        if let Some(stale) = stale_sibling {
+            self.fallback.retain(|u| *u != stale);
+        }
+        if let Upstream::Udp(addr) = new {
+            let sibling = Upstream::Tcp(addr);
+            if !self.fallback.contains(&sibling) {
+                self.fallback.push(sibling);
+            }
+        }
+        self.primary = vec![new];
+        true
+    }
+
     /// Update the primary upstream if `new_addr` (parsed with `port`) differs
     /// from the current preferred upstream. Returns `true` if the pool changed.
     pub fn maybe_update_primary(&mut self, new_addr: &str, port: u16) -> bool {
         let Ok(new_sock) = format!("{}:{}", new_addr, port).parse::<SocketAddr>() else {
             return false;
         };
-        let new_upstream = Upstream::Udp(new_sock);
-        if self.preferred() == Some(&new_upstream) {
-            return false;
-        }
-        self.primary = vec![new_upstream];
-        true
+        self.maybe_replace_primary(Upstream::Udp(new_sock))
     }
 
     pub fn label(&self) -> String {
@@ -983,6 +1006,59 @@ mod tests {
             UpstreamPool::new(vec![Upstream::Udp("1.2.3.4:53".parse().unwrap())], vec![]);
         assert!(!pool.maybe_update_primary("not-an-ip", 53));
         assert_eq!(pool.preferred().unwrap().to_string(), "1.2.3.4:53");
+    }
+
+    // #169: on undetectable system DNS the rescan adopts the same Quad9 DoH
+    // startup uses, instead of a bare UDP Quad9 that dies wherever outbound
+    // UDP:53 is blocked.
+    #[test]
+    fn maybe_replace_primary_adopts_doh_over_udp() {
+        let mut pool = UpstreamPool::new(
+            vec![Upstream::Udp("192.168.1.1:53".parse().unwrap())],
+            vec![],
+        );
+        let doh = Upstream::Doh {
+            url: "https://9.9.9.9/dns-query".to_string(),
+            client: crate::forward::default_client(),
+        };
+        assert!(pool.maybe_replace_primary(doh.clone()));
+        assert_eq!(
+            pool.preferred().unwrap().to_string(),
+            "https://9.9.9.9/dns-query"
+        );
+        assert!(!pool.maybe_replace_primary(doh), "already on the fallback");
+    }
+
+    // Failover chains fallback after the primaries, so a sibling left behind by
+    // the previous network would be retried before the reachable one (#169).
+    #[test]
+    fn maybe_update_primary_retargets_the_tcp_sibling() {
+        let mut pool = UpstreamPool::new(
+            vec![Upstream::Udp("1.2.3.4:53".parse().unwrap())],
+            vec![Upstream::Tcp("1.2.3.4:53".parse().unwrap())],
+        );
+        assert!(pool.maybe_update_primary("5.6.7.8", 53));
+        assert_eq!(
+            pool.fallback,
+            vec![Upstream::Tcp("5.6.7.8:53".parse().unwrap())]
+        );
+    }
+
+    // Swapping away from DoH leaves no UDP sibling to strip.
+    #[test]
+    fn maybe_replace_primary_from_doh_keeps_fallback_clean() {
+        let mut pool = UpstreamPool::new(
+            vec![Upstream::Doh {
+                url: "https://9.9.9.9/dns-query".to_string(),
+                client: crate::forward::default_client(),
+            }],
+            vec![],
+        );
+        assert!(pool.maybe_update_primary("192.168.1.1", 53));
+        assert_eq!(
+            pool.fallback,
+            vec![Upstream::Tcp("192.168.1.1:53".parse().unwrap())]
+        );
     }
 
     fn tcp_closed_port() -> SocketAddr {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -27,7 +27,6 @@ use crate::stats::{ServerStats, Transport};
 use crate::system_dns::discover_system_dns;
 use crate::udp_listener::UdpListener;
 
-const QUAD9_IP: &str = "9.9.9.9";
 const DOH_FALLBACK: &str = "https://9.9.9.9/dns-query";
 
 /// Boot the DNS server and run until the UDP listener errors out.
@@ -717,6 +716,13 @@ async fn resolve_upstream_pool(
 async fn network_watch_loop(ctx: Arc<ServerCtx>) {
     let mut tick: u64 = 0;
 
+    // Built once. The URL is an IP literal, so it needs no resolver and can't
+    // loop back through numa.
+    let doh_fallback = Upstream::Doh {
+        url: DOH_FALLBACK.to_string(),
+        client: build_https_client_with_resolver(1, None),
+    };
+
     let mut interval = tokio::time::interval(Duration::from_secs(5));
     interval.tick().await; // skip immediate tick
 
@@ -739,12 +745,19 @@ async fn network_watch_loop(ctx: Arc<ServerCtx>) {
         // Re-detect upstream every 30s or on LAN IP change (auto-detect only)
         if ctx.upstream_auto && (changed || tick.is_multiple_of(6)) {
             let dns_info = crate::system_dns::discover_system_dns();
-            let new_addr = dns_info
+            let detected = dns_info
                 .default_upstream
-                .or_else(crate::system_dns::detect_dhcp_dns)
-                .unwrap_or_else(|| QUAD9_IP.to_string());
+                .or_else(crate::system_dns::detect_dhcp_dns);
             let mut pool = ctx.upstream_pool.lock().unwrap();
-            if pool.maybe_update_primary(&new_addr, ctx.upstream_port) {
+            // Undetectable system DNS resolves to Quad9 DoH here exactly as it
+            // does at startup. Synthesising a bare UDP Quad9 instead silently
+            // downgraded the transport 30s in, stranding every client where
+            // outbound UDP:53 is blocked (#169).
+            let updated = match detected {
+                Some(addr) => pool.maybe_update_primary(&addr, ctx.upstream_port),
+                None => pool.maybe_replace_primary(doh_fallback.clone()),
+            };
+            if updated {
                 info!("upstream changed → {}", pool.label());
                 changed = true;
             }

--- a/tests/docker/issue-169-repro.sh
+++ b/tests/docker/issue-169-repro.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Regression for issue #169: the 30s auto-detect rescan must never demote an
+# encrypted upstream to plain UDP:53.
+#
+# serve.rs keeps two fallbacks for the same "can't detect system DNS" state:
+#
+#   const QUAD9_IP     = "9.9.9.9"                    → used by the rescan
+#   const DOH_FALLBACK = "https://9.9.9.9/dns-query"  → used at startup
+#
+# So a box where detection fails starts on DoH and, 30s later, gets silently
+# moved to plain UDP against the same IP. Where outbound UDP:53 is blocked
+# (corporate, ISP-restricted, hostile Wi-Fi) every query then SERVFAILs for the
+# rest of the process lifetime.
+#
+# Reproducing needs detection to fail, which is what `nameserver 127.0.0.1`
+# gives us — is_loopback_or_stub() filters it, resolvectl is absent from the
+# slim image, and detect_dhcp_dns() is a no-op off macOS. That is also exactly
+# what a real box looks like after `numa install` makes numa the system
+# resolver. Note Docker's own 127.0.0.11 is NOT filtered, so the entrypoint has
+# to overwrite resolv.conf or detection succeeds and nothing reproduces.
+#
+# The demotion is the bug; the SERVFAIL is only its consequence on a hostile
+# network, so this asserts the transport rather than blocking UDP.
+#
+#   PASS → upstream is still DoH after the rescan window
+#   FAIL → upstream became 9.9.9.9:53 (the #169 demotion)
+#
+# Usage:
+#   tests/docker/issue-169-repro.sh
+#   WINDOW=70 tests/docker/issue-169-repro.sh   # wait longer for the rescan
+
+set -euo pipefail
+
+WINDOW="${WINDOW:-45}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+IMAGE="numa-169-repro"
+NAME="numa-169-$$"
+CTX="$(mktemp -d)"
+
+# Pin build + run to the host arch so the multi-arch base images don't
+# resolve build and run stages to different platforms.
+case "$(uname -m)" in
+    arm64|aarch64) PLATFORM="linux/arm64" ;;
+    x86_64|amd64)  PLATFORM="linux/amd64" ;;
+    *)             PLATFORM="" ;;
+esac
+PLAT_ARG=${PLATFORM:+--platform=$PLATFORM}
+
+GREEN="\033[32m"; RED="\033[31m"; DIM="\033[90m"; RESET="\033[0m"
+
+cleanup() {
+    docker rm -f "$NAME" >/dev/null 2>&1 || true
+    rm -rf "$CTX"
+}
+trap cleanup EXIT
+
+# ---- Build context: tracked files (no target/, no .git) ----
+# `stash create` snapshots uncommitted edits to a throwaway commit without
+# touching the worktree or the stash list, so a fix can be verified before it's
+# committed. Empty when the tree is clean, hence the HEAD fallback.
+TREE="$(git -C "$REPO_ROOT" stash create)"
+git -C "$REPO_ROOT" archive "${TREE:-HEAD}" | tar -x -C "$CTX"
+
+# `address` is deliberately absent: upstream_auto is address.is_empty(), and
+# only the auto path runs the rescan.
+cat > "$CTX/numa.toml" <<'EOF'
+[server]
+bind_addr = "127.0.0.1:5353"
+api_port = 5381
+data_dir = "/tmp/numa"
+
+[upstream]
+mode = "forward"
+EOF
+
+cat > "$CTX/entrypoint.sh" <<'EOF'
+#!/bin/sh
+set -e
+mkdir -p /tmp/numa
+# Bind-mounted by Docker, but writable — overwrite the contents in place.
+echo "nameserver 127.0.0.1" > /etc/resolv.conf
+exec numa /numa.toml
+EOF
+
+cat > "$CTX/Dockerfile" <<'EOF'
+FROM rust:1-bookworm AS build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake clang libclang-dev perl && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY . .
+RUN cargo build --bin numa
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/target/debug/numa /usr/local/bin/numa
+COPY numa.toml /numa.toml
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+EOF
+
+# Force-pull bases at the target platform first: `docker run/build` reuses a
+# locally-tagged image regardless of --platform, so a stale wrong-arch base
+# would otherwise be silently inherited.
+for base in rust:1-bookworm debian:bookworm-slim; do
+    docker pull $PLAT_ARG -q "$base" >/dev/null
+done
+
+echo "${DIM}Building numa image (first run compiles the crate — a few min)...${RESET}"
+docker build $PLAT_ARG -q -t "$IMAGE" "$CTX" >/dev/null
+
+echo "${DIM}Starting numa with undetectable system DNS...${RESET}"
+docker run $PLAT_ARG -d --name "$NAME" "$IMAGE" >/dev/null
+
+upstream_now() {
+    docker exec "$NAME" curl -s --max-time 3 http://127.0.0.1:5381/stats \
+        | grep -o '"upstream": *"[^"]*"' | cut -d'"' -f4
+}
+
+for _ in $(seq 1 40); do
+    U="$(upstream_now || true)"
+    [ -n "${U:-}" ] && break
+    sleep 0.5
+done
+[ -n "${U:-}" ] || { echo "${RED}✗${RESET} numa API never came up"; docker logs "$NAME" 2>&1 | tail -20; exit 2; }
+
+BEFORE="$U"
+echo "${DIM}startup upstream = ${BEFORE}${RESET}"
+
+# Guard the precondition: if detection did NOT fail, startup picked a plain
+# upstream and there is no demotion to observe — the run proves nothing.
+case "$BEFORE" in
+    https://*) echo "${GREEN}✓${RESET} startup fell back to DoH — precondition met" ;;
+    *) echo "${RED}✗${RESET} expected a DoH startup upstream, got '${BEFORE}' — system DNS was detected, repro invalid"
+       docker logs "$NAME" 2>&1 | tail -20; exit 2 ;;
+esac
+
+echo "${DIM}waiting ${WINDOW}s for the 30s rescan...${RESET}"
+sleep "$WINDOW"
+# `|| true`: a dead container makes grep exit 1, which under `set -e` would
+# abort here and be indistinguishable from the #169 demotion below.
+AFTER="$(upstream_now || true)"
+
+echo "${DIM}upstream after rescan = ${AFTER:-<unreachable>}${RESET}"
+
+case "${AFTER:-}" in
+    https://*)
+        echo "${GREEN}✓ PASS${RESET} encrypted upstream survived the rescan (${AFTER})"
+        exit 0 ;;
+    "")
+        echo "${RED}✗${RESET} numa API stopped answering — result inconclusive"
+        docker logs "$NAME" 2>&1 | tail -20
+        exit 2 ;;
+    *)
+        echo "${RED}✗ FAIL${RESET} rescan demoted DoH → '${AFTER}' — #169"
+        docker logs "$NAME" 2>&1 | grep -E 'falling back|upstream changed' || true
+        exit 1 ;;
+esac


### PR DESCRIPTION
## Summary

- `serve.rs` kept two fallbacks for the same "can't detect system DNS" state: startup used `DOH_FALLBACK` (`https://9.9.9.9/dns-query`), the 30s auto-detect rescan used a bare `QUAD9_IP` (`9.9.9.9`). A box where detection fails started on DoH and was silently moved to plain UDP:53 thirty seconds later.
- Wherever outbound UDP:53 is blocked (corporate, ISP-restricted, hostile Wi-Fi) every query then SERVFAILs for the rest of the process lifetime. Only the no-`numa.toml` path is affected, since `upstream_auto` is `address.is_empty()` — which is exactly the fresh-install path.
- The rescan now resolves that state to the same Quad9 DoH startup uses, so the two paths agree. `QUAD9_IP` is gone.
- **A detected address is still adopted.** Refusing to leave an encrypted upstream would freeze any box whose detection loses the boot race with the network stack (systemd starting `numa.service` before NetworkManager writes `resolv.conf`), permanently losing router and split-horizon zones. In the auto path DoH is only ever the synthetic fallback, never user intent: an explicit encrypted upstream sets `address`, which makes `upstream_auto` false and stops the rescan entirely.
- Adopting again makes the stale TCP sibling load-bearing, so `maybe_replace_primary` retargets it. Failover chains `fallback` after the primaries (`forward.rs:541`), so a sibling left over from the previous network was retried before anything reachable.

Closes #169.

## Test plan

- `maybe_replace_primary_adopts_doh_over_udp`, `maybe_update_primary_retargets_the_tcp_sibling`, `maybe_replace_primary_from_doh_keeps_fallback_clean`.
- `tests/docker/issue-169-repro.sh` reproduces it end to end. `resolv.conf` is pinned to a filtered loopback so detection fails (Docker's own `127.0.0.11` is *not* in `is_loopback_or_stub`, so it would be accepted as a real upstream and nothing would reproduce). The DoH startup state is asserted as a precondition so a meaningless run can't report green, and an unreachable API exits 2 rather than masquerading as a regression.

  ```
  before:  startup https://9.9.9.9/dns-query  →  after rescan 9.9.9.9:53                 ✗ FAIL
  after:   startup https://9.9.9.9/dns-query  →  after rescan https://9.9.9.9/dns-query  ✓ PASS
  ```

  Container logs on the failing run match the reporter's evidence, thirty seconds apart:

  ```
  06:24:01  could not detect system DNS, falling back to Quad9 DoH
  06:24:31  upstream changed → 9.9.9.9:53
  ```

- `make all` green (552 lib tests + integration + doc-tests).