### PR TITLE
fix(ctx): stop duplicating CNAME chain links in chased answers

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -277,48 +277,31 @@ async fn resolve_with_cname_chase(
     let mut current_qname = qname.to_string();
 
     loop {
-        // Compare wire numbers: types without a DnsRecord variant (HTTPS,
-        // TXT, …) parse as UNKNOWN(n), which never `==` the question's qtype.
-        if resp
-            .answers
-            .iter()
-            .any(|r| r.query_type().to_num() == qtype.to_num())
-            || resp.header.rescode != ResultCode::NOERROR
-        {
+        if resp.has_answer_of_type(qtype) || resp.header.rescode != ResultCode::NOERROR {
             return (resp, path, dnssec, ut);
         }
-        // Follow every link already present before sub-querying: upstreams
-        // return multiple chain links per response, and re-querying an
-        // intermediate name would append those links a second time (Chrome
-        // rejects responses with duplicate CNAMEs as malformed).
-        let mut advanced = false;
-        while let Some(target) = crate::recursive::extract_cname_target(&resp, &current_qname) {
-            if visited.len() > crate::recursive::MAX_CNAME_DEPTH as usize
-                || !visited.insert(target.to_ascii_lowercase())
-            {
+        match crate::recursive::follow_cname_links(&resp, &current_qname, &mut visited) {
+            Err(()) => {
                 return (
                     DnsPacket::response_from(query, ResultCode::SERVFAIL),
                     path,
                     dnssec,
                     ut,
-                );
+                )
             }
-            current_qname = target;
-            advanced = true;
-        }
-        if !advanced {
-            return (resp, path, dnssec, ut);
+            Ok(None) => return (resp, path, dnssec, ut),
+            Ok(Some(target)) => current_qname = target,
         }
 
         let sub_query = DnsPacket::query(query.header.id, &current_qname, qtype);
-        let mut sub_buf = BytePacketBuffer::new();
-        sub_query
-            .write(&mut sub_buf)
-            .expect("sub-query serialization");
         let (sub_resp, _, _, sub_ut) =
             match resolve_local(&sub_query, src_addr, &current_qname, qtype, ctx) {
                 Some((r, p, d)) => (r, p, d, None),
                 None => {
+                    let mut sub_buf = BytePacketBuffer::new();
+                    sub_query
+                        .write(&mut sub_buf)
+                        .expect("sub-query serialization");
                     resolve_remote(
                         &sub_query,
                         sub_buf.filled(),
@@ -2825,6 +2808,15 @@ mod tests {
         );
     }
 
+    async fn ctx_with_upstream(upstream: SocketAddr) -> Arc<ServerCtx> {
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
+            vec![crate::forward::Upstream::Udp(upstream)],
+            vec![],
+        ));
+        Arc::new(ctx)
+    }
+
     /// Amazon-style NODATA behind a multi-link CNAME chain: the upstream
     /// returns both links in one response, and the sub-query for the
     /// intermediate name re-answers the second link. The chase must not
@@ -2832,46 +2824,24 @@ mod tests {
     /// (eu.primevideo.com regression).
     #[tokio::test]
     async fn cname_chase_multi_link_response_has_no_duplicate_links() {
-        let mut chain = DnsPacket::new();
-        chain.header.response = true;
-        chain.header.rescode = ResultCode::NOERROR;
-        chain.answers.push(crate::testutil::cname_record(
-            "eu.video.test",
-            "tp.video.test",
-            300,
-        ));
-        chain.answers.push(crate::testutil::cname_record(
+        let chain = crate::testutil::noerror_response(vec![
+            crate::testutil::cname_record("eu.video.test", "tp.video.test", 300),
+            crate::testutil::cname_record("tp.video.test", "cdn.example.net", 300),
+        ]);
+        let tail = crate::testutil::noerror_response(vec![crate::testutil::cname_record(
             "tp.video.test",
             "cdn.example.net",
             300,
-        ));
-
-        let mut tail = DnsPacket::new();
-        tail.header.response = true;
-        tail.header.rescode = ResultCode::NOERROR;
-        tail.answers.push(crate::testutil::cname_record(
-            "tp.video.test",
-            "cdn.example.net",
-            300,
-        ));
-
-        let mut nodata = DnsPacket::new();
-        nodata.header.response = true;
-        nodata.header.rescode = ResultCode::NOERROR;
+        )]);
+        let nodata = crate::testutil::noerror_response(vec![]);
 
         let upstream = crate::testutil::mock_upstream_by_qname(vec![
-            ("eu.video.test".to_string(), chain),
-            ("tp.video.test".to_string(), tail),
-            ("cdn.example.net".to_string(), nodata),
+            ("eu.video.test", chain),
+            ("tp.video.test", tail),
+            ("cdn.example.net", nodata),
         ])
         .await;
-
-        let mut ctx = crate::testutil::test_ctx().await;
-        ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
-            vec![crate::forward::Upstream::Udp(upstream)],
-            vec![],
-        ));
-        let ctx = Arc::new(ctx);
+        let ctx = ctx_with_upstream(upstream).await;
 
         let (resp, _) = resolve_in_test(&ctx, "eu.video.test", QueryType::AAAA).await;
         assert_eq!(resp.header.rescode, ResultCode::NOERROR);
@@ -2896,38 +2866,19 @@ mod tests {
             data: vec![0, 1, 0, 0],
             ttl: 300,
         };
-        let mut chain = DnsPacket::new();
-        chain.header.response = true;
-        chain.header.rescode = ResultCode::NOERROR;
-        chain.answers.push(crate::testutil::cname_record(
-            "eu.video.test",
-            "tp.video.test",
-            300,
-        ));
-        chain.answers.push(crate::testutil::cname_record(
-            "tp.video.test",
-            "cdn.example.net",
-            300,
-        ));
-        chain.answers.push(https_terminal.clone());
-
-        let mut tail = DnsPacket::new();
-        tail.header.response = true;
-        tail.header.rescode = ResultCode::NOERROR;
-        tail.answers.push(https_terminal);
+        let chain = crate::testutil::noerror_response(vec![
+            crate::testutil::cname_record("eu.video.test", "tp.video.test", 300),
+            crate::testutil::cname_record("tp.video.test", "cdn.example.net", 300),
+            https_terminal.clone(),
+        ]);
+        let tail = crate::testutil::noerror_response(vec![https_terminal]);
 
         let upstream = crate::testutil::mock_upstream_by_qname(vec![
-            ("eu.video.test".to_string(), chain),
-            ("cdn.example.net".to_string(), tail),
+            ("eu.video.test", chain),
+            ("cdn.example.net", tail),
         ])
         .await;
-
-        let mut ctx = crate::testutil::test_ctx().await;
-        ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
-            vec![crate::forward::Upstream::Udp(upstream)],
-            vec![],
-        ));
-        let ctx = Arc::new(ctx);
+        let ctx = ctx_with_upstream(upstream).await;
 
         let (resp, _) = resolve_in_test(&ctx, "eu.video.test", QueryType::HTTPS).await;
         assert_eq!(resp.header.rescode, ResultCode::NOERROR);

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -277,7 +277,12 @@ async fn resolve_with_cname_chase(
     let mut current_qname = qname.to_string();
 
     loop {
-        if resp.answers.iter().any(|r| r.query_type() == qtype)
+        // Compare wire numbers: types without a DnsRecord variant (HTTPS,
+        // TXT, …) parse as UNKNOWN(n), which never `==` the question's qtype.
+        if resp
+            .answers
+            .iter()
+            .any(|r| r.query_type().to_num() == qtype.to_num())
             || resp.header.rescode != ResultCode::NOERROR
         {
             return (resp, path, dnssec, ut);
@@ -2874,6 +2879,62 @@ mod tests {
             resp.answers.len(),
             2,
             "chain must appear exactly once: {:?}",
+            resp.answers
+        );
+    }
+
+    /// HTTPS (type 65) answers parse as `DnsRecord::UNKNOWN`, so the chase's
+    /// termination check must compare wire type numbers — `UNKNOWN(65)` never
+    /// `==` `QueryType::HTTPS`, which kept the chase running past a complete
+    /// answer and re-appended the terminal record (eu.primevideo.com
+    /// regression, second half).
+    #[tokio::test]
+    async fn cname_chase_terminates_on_unknown_variant_record_type() {
+        let https_terminal = DnsRecord::UNKNOWN {
+            domain: "cdn.example.net".to_string(),
+            qtype: 65,
+            data: vec![0, 1, 0, 0],
+            ttl: 300,
+        };
+        let mut chain = DnsPacket::new();
+        chain.header.response = true;
+        chain.header.rescode = ResultCode::NOERROR;
+        chain.answers.push(crate::testutil::cname_record(
+            "eu.video.test",
+            "tp.video.test",
+            300,
+        ));
+        chain.answers.push(crate::testutil::cname_record(
+            "tp.video.test",
+            "cdn.example.net",
+            300,
+        ));
+        chain.answers.push(https_terminal.clone());
+
+        let mut tail = DnsPacket::new();
+        tail.header.response = true;
+        tail.header.rescode = ResultCode::NOERROR;
+        tail.answers.push(https_terminal);
+
+        let upstream = crate::testutil::mock_upstream_by_qname(vec![
+            ("eu.video.test".to_string(), chain),
+            ("cdn.example.net".to_string(), tail),
+        ])
+        .await;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
+            vec![crate::forward::Upstream::Udp(upstream)],
+            vec![],
+        ));
+        let ctx = Arc::new(ctx);
+
+        let (resp, _) = resolve_in_test(&ctx, "eu.video.test", QueryType::HTTPS).await;
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert_eq!(
+            resp.answers.len(),
+            3,
+            "complete answer must not be chased: {:?}",
             resp.answers
         );
     }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -282,38 +282,53 @@ async fn resolve_with_cname_chase(
         {
             return (resp, path, dnssec, ut);
         }
-        let Some(target) = crate::recursive::extract_cname_target(&resp, &current_qname) else {
+        // Follow every link already present before sub-querying: upstreams
+        // return multiple chain links per response, and re-querying an
+        // intermediate name would append those links a second time (Chrome
+        // rejects responses with duplicate CNAMEs as malformed).
+        let mut advanced = false;
+        while let Some(target) = crate::recursive::extract_cname_target(&resp, &current_qname) {
+            if visited.len() > crate::recursive::MAX_CNAME_DEPTH as usize
+                || !visited.insert(target.to_ascii_lowercase())
+            {
+                return (
+                    DnsPacket::response_from(query, ResultCode::SERVFAIL),
+                    path,
+                    dnssec,
+                    ut,
+                );
+            }
+            current_qname = target;
+            advanced = true;
+        }
+        if !advanced {
             return (resp, path, dnssec, ut);
-        };
-        if visited.len() > crate::recursive::MAX_CNAME_DEPTH as usize
-            || !visited.insert(target.to_ascii_lowercase())
-        {
-            return (
-                DnsPacket::response_from(query, ResultCode::SERVFAIL),
-                path,
-                dnssec,
-                ut,
-            );
         }
 
-        let sub_query = DnsPacket::query(query.header.id, &target, qtype);
+        let sub_query = DnsPacket::query(query.header.id, &current_qname, qtype);
         let mut sub_buf = BytePacketBuffer::new();
         sub_query
             .write(&mut sub_buf)
             .expect("sub-query serialization");
         let (sub_resp, _, _, sub_ut) =
-            match resolve_local(&sub_query, src_addr, &target, qtype, ctx) {
+            match resolve_local(&sub_query, src_addr, &current_qname, qtype, ctx) {
                 Some((r, p, d)) => (r, p, d, None),
                 None => {
-                    resolve_remote(&sub_query, sub_buf.filled(), src_addr, &target, qtype, ctx)
-                        .await
+                    resolve_remote(
+                        &sub_query,
+                        sub_buf.filled(),
+                        src_addr,
+                        &current_qname,
+                        qtype,
+                        ctx,
+                    )
+                    .await
                 }
             };
 
         resp.answers.extend(sub_resp.answers);
         resp.header.rescode = sub_resp.header.rescode;
         ut = ut.or(sub_ut);
-        current_qname = target;
     }
 }
 
@@ -2802,6 +2817,64 @@ mod tests {
         );
         assert!(
             matches!(&resp.answers[1], DnsRecord::A { addr, .. } if *addr == Ipv4Addr::new(93, 184, 216, 34))
+        );
+    }
+
+    /// Amazon-style NODATA behind a multi-link CNAME chain: the upstream
+    /// returns both links in one response, and the sub-query for the
+    /// intermediate name re-answers the second link. The chase must not
+    /// append it twice — Chrome rejects duplicate CNAMEs as malformed
+    /// (eu.primevideo.com regression).
+    #[tokio::test]
+    async fn cname_chase_multi_link_response_has_no_duplicate_links() {
+        let mut chain = DnsPacket::new();
+        chain.header.response = true;
+        chain.header.rescode = ResultCode::NOERROR;
+        chain.answers.push(crate::testutil::cname_record(
+            "eu.video.test",
+            "tp.video.test",
+            300,
+        ));
+        chain.answers.push(crate::testutil::cname_record(
+            "tp.video.test",
+            "cdn.example.net",
+            300,
+        ));
+
+        let mut tail = DnsPacket::new();
+        tail.header.response = true;
+        tail.header.rescode = ResultCode::NOERROR;
+        tail.answers.push(crate::testutil::cname_record(
+            "tp.video.test",
+            "cdn.example.net",
+            300,
+        ));
+
+        let mut nodata = DnsPacket::new();
+        nodata.header.response = true;
+        nodata.header.rescode = ResultCode::NOERROR;
+
+        let upstream = crate::testutil::mock_upstream_by_qname(vec![
+            ("eu.video.test".to_string(), chain),
+            ("tp.video.test".to_string(), tail),
+            ("cdn.example.net".to_string(), nodata),
+        ])
+        .await;
+
+        let mut ctx = crate::testutil::test_ctx().await;
+        ctx.upstream_pool = Mutex::new(crate::forward::UpstreamPool::new(
+            vec![crate::forward::Upstream::Udp(upstream)],
+            vec![],
+        ));
+        let ctx = Arc::new(ctx);
+
+        let (resp, _) = resolve_in_test(&ctx, "eu.video.test", QueryType::AAAA).await;
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert_eq!(
+            resp.answers.len(),
+            2,
+            "chain must appear exactly once: {:?}",
+            resp.answers
         );
     }
 }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -267,8 +267,7 @@ async fn resolve_with_cname_chase(
     DnssecStatus,
     Option<crate::stats::UpstreamTransport>,
 ) {
-    let mut visited = HashSet::new();
-    visited.insert(qname.to_ascii_lowercase());
+    let mut visited = HashSet::from([qname.to_ascii_lowercase()]);
 
     let (mut resp, path, dnssec, mut ut) = match resolve_local(query, src_addr, qname, qtype, ctx) {
         Some((r, p, d)) => (r, p, d, None),

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -93,6 +93,14 @@ impl DnsPacket {
         self.resources.iter_mut().for_each(&mut f);
     }
 
+    /// Compares wire numbers: types without a DnsRecord variant (HTTPS,
+    /// TXT, …) parse as UNKNOWN(n), which never `==` a named QueryType.
+    pub fn has_answer_of_type(&self, qtype: crate::question::QueryType) -> bool {
+        self.answers
+            .iter()
+            .any(|r| r.query_type().to_num() == qtype.to_num())
+    }
+
     pub fn response_from(query: &DnsPacket, rescode: crate::header::ResultCode) -> DnsPacket {
         let mut resp = DnsPacket::new();
         resp.header.id = query.header.id;

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -250,7 +250,12 @@ pub(crate) fn resolve_iterative<'a>(
             }
 
             if !response.answers.is_empty() {
-                let has_target = response.answers.iter().any(|r| r.query_type() == qtype);
+                // Wire-number comparison: HTTPS/TXT/… parse as UNKNOWN(n),
+                // which never `==` the question's qtype.
+                let has_target = response
+                    .answers
+                    .iter()
+                    .any(|r| r.query_type().to_num() == qtype.to_num());
 
                 if has_target || qtype == QueryType::CNAME {
                     cache.write().unwrap().insert(qname, qtype, &response);

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -16,7 +16,7 @@ use crate::srtt::SrttCache;
 use crate::stats::UpstreamTransport;
 
 const MAX_REFERRAL_DEPTH: u8 = 10;
-pub(crate) const MAX_CNAME_DEPTH: u8 = 8;
+const MAX_CNAME_DEPTH: u8 = 8;
 const NS_QUERY_TIMEOUT: Duration = Duration::from_millis(400);
 const TCP_TIMEOUT: Duration = Duration::from_millis(400);
 const UDP_FAIL_THRESHOLD: u8 = 3;
@@ -796,7 +796,6 @@ async fn send_query(
 /// hop in `visited`. Upstreams return multiple chain links per response;
 /// re-querying an intermediate name would append those links a second time
 /// (Chrome rejects responses with duplicate CNAMEs as malformed).
-/// `Ok(None)` = no link; `Err(())` = loop or depth cap exceeded.
 pub(crate) fn follow_cname_links(
     response: &DnsPacket,
     start: &str,
@@ -812,7 +811,7 @@ pub(crate) fn follow_cname_links(
     Ok(current)
 }
 
-pub(crate) fn extract_cname_target(response: &DnsPacket, qname: &str) -> Option<String> {
+fn extract_cname_target(response: &DnsPacket, qname: &str) -> Option<String> {
     response.answers.iter().find_map(|r| match r {
         DnsRecord::CNAME { domain, host, .. } if domain.eq_ignore_ascii_case(qname) => {
             Some(host.clone())

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::RwLock;
@@ -250,19 +251,15 @@ pub(crate) fn resolve_iterative<'a>(
             }
 
             if !response.answers.is_empty() {
-                // Wire-number comparison: HTTPS/TXT/… parse as UNKNOWN(n),
-                // which never `==` the question's qtype.
-                let has_target = response
-                    .answers
-                    .iter()
-                    .any(|r| r.query_type().to_num() == qtype.to_num());
-
-                if has_target || qtype == QueryType::CNAME {
+                if response.has_answer_of_type(qtype) || qtype == QueryType::CNAME {
                     cache.write().unwrap().insert(qname, qtype, &response);
                     return Ok(response);
                 }
 
-                if let Some(cname_target) = extract_cname_target(&response, qname) {
+                let mut visited = HashSet::from([qname.to_ascii_lowercase()]);
+                if let Some(cname_target) = follow_cname_links(&response, qname, &mut visited)
+                    .map_err(|()| "CNAME loop in response")?
+                {
                     if cname_depth >= MAX_CNAME_DEPTH {
                         return Err("max CNAME depth exceeded".into());
                     }
@@ -793,6 +790,26 @@ async fn send_query(
             Err(e)
         }
     }
+}
+
+/// Follow every CNAME link for `start` present in `response`, recording each
+/// hop in `visited`. Upstreams return multiple chain links per response;
+/// re-querying an intermediate name would append those links a second time
+/// (Chrome rejects responses with duplicate CNAMEs as malformed).
+/// `Ok(None)` = no link; `Err(())` = loop or depth cap exceeded.
+pub(crate) fn follow_cname_links(
+    response: &DnsPacket,
+    start: &str,
+    visited: &mut HashSet<String>,
+) -> Result<Option<String>, ()> {
+    let mut current = None;
+    while let Some(next) = extract_cname_target(response, current.as_deref().unwrap_or(start)) {
+        if visited.len() > MAX_CNAME_DEPTH as usize || !visited.insert(next.to_ascii_lowercase()) {
+            return Err(());
+        }
+        current = Some(next);
+    }
+    Ok(current)
 }
 
 pub(crate) fn extract_cname_target(response: &DnsPacket, qname: &str) -> Option<String> {

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -149,6 +149,41 @@ pub async fn mock_upstream_raw(mut bytes: Vec<u8>) -> SocketAddr {
     addr
 }
 
+/// Spawn a UDP socket that answers every query by qname from the given table
+/// (patching the query ID) — for chase tests where follow-up sub-queries hit
+/// the same upstream.
+pub async fn mock_upstream_by_qname(responses: Vec<(String, DnsPacket)>) -> SocketAddr {
+    let table: Vec<(String, Vec<u8>)> = responses
+        .into_iter()
+        .map(|(name, pkt)| {
+            let mut out = BytePacketBuffer::new();
+            pkt.write(&mut out).unwrap();
+            (name, out.filled().to_vec())
+        })
+        .collect();
+    let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = sock.local_addr().unwrap();
+    tokio::spawn(async move {
+        let mut buf = [0u8; 512];
+        while let Ok((n, src)) = sock.recv_from(&mut buf).await {
+            let mut query_buf = BytePacketBuffer::from_bytes(&buf[..n]);
+            let Ok(query) = DnsPacket::from_buffer(&mut query_buf) else {
+                continue;
+            };
+            let Some(qname) = query.questions.first().map(|q| q.name.clone()) else {
+                continue;
+            };
+            if let Some((_, bytes)) = table.iter().find(|(name, _)| *name == qname) {
+                let mut reply = bytes.clone();
+                reply[0] = buf[0];
+                reply[1] = buf[1];
+                let _ = sock.send_to(&reply, src).await;
+            }
+        }
+    });
+    addr
+}
+
 /// UDP socket that accepts connections but never replies.
 /// Useful as an upstream that triggers timeouts.
 pub fn blackhole_upstream() -> SocketAddr {

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -99,31 +99,28 @@ pub fn cname_record(domain: &str, host: &str, ttl: u32) -> DnsRecord {
     }
 }
 
-/// Build a NOERROR response containing a single A record — the shape used
-/// repeatedly by pipeline/forwarding tests to seed `mock_upstream`.
-pub fn a_record_response(domain: &str, addr: Ipv4Addr, ttl: u32) -> DnsPacket {
+/// Build a NOERROR response with the given answer records.
+pub fn noerror_response(answers: Vec<DnsRecord>) -> DnsPacket {
     let mut pkt = DnsPacket::new();
     pkt.header.response = true;
     pkt.header.rescode = ResultCode::NOERROR;
-    pkt.answers.push(DnsRecord::A {
-        domain: domain.to_string(),
-        addr,
-        ttl,
-    });
+    pkt.answers = answers;
     pkt
+}
+
+/// Build a NOERROR response containing a single A record — the shape used
+/// repeatedly by pipeline/forwarding tests to seed `mock_upstream`.
+pub fn a_record_response(domain: &str, addr: Ipv4Addr, ttl: u32) -> DnsPacket {
+    noerror_response(vec![a_record(domain, addr, ttl)])
 }
 
 /// AAAA counterpart of `a_record_response`, for filter_aaaa pipeline tests.
 pub fn aaaa_record_response(domain: &str, addr: std::net::Ipv6Addr, ttl: u32) -> DnsPacket {
-    let mut pkt = DnsPacket::new();
-    pkt.header.response = true;
-    pkt.header.rescode = ResultCode::NOERROR;
-    pkt.answers.push(DnsRecord::AAAA {
+    noerror_response(vec![DnsRecord::AAAA {
         domain: domain.to_string(),
         addr,
         ttl,
-    });
-    pkt
+    }])
 }
 
 /// Spawn a UDP socket that replies to the first DNS query with the given
@@ -152,13 +149,13 @@ pub async fn mock_upstream_raw(mut bytes: Vec<u8>) -> SocketAddr {
 /// Spawn a UDP socket that answers every query by qname from the given table
 /// (patching the query ID) — for chase tests where follow-up sub-queries hit
 /// the same upstream.
-pub async fn mock_upstream_by_qname(responses: Vec<(String, DnsPacket)>) -> SocketAddr {
+pub async fn mock_upstream_by_qname(responses: Vec<(&str, DnsPacket)>) -> SocketAddr {
     let table: Vec<(String, Vec<u8>)> = responses
         .into_iter()
         .map(|(name, pkt)| {
             let mut out = BytePacketBuffer::new();
             pkt.write(&mut out).unwrap();
-            (name, out.filled().to_vec())
+            (name.to_string(), out.filled().to_vec())
         })
         .collect();
     let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -170,10 +167,10 @@ pub async fn mock_upstream_by_qname(responses: Vec<(String, DnsPacket)>) -> Sock
             let Ok(query) = DnsPacket::from_buffer(&mut query_buf) else {
                 continue;
             };
-            let Some(qname) = query.questions.first().map(|q| q.name.clone()) else {
+            let Some(question) = query.questions.first() else {
                 continue;
             };
-            if let Some((_, bytes)) = table.iter().find(|(name, _)| *name == qname) {
+            if let Some((_, bytes)) = table.iter().find(|(name, _)| *name == question.name) {
                 let mut reply = bytes.clone();
                 reply[0] = buf[0];
                 reply[1] = buf[1];


### PR DESCRIPTION
## Symptom

`https://eu.primevideo.com/` failed to load in Chrome with `DNS_PROBE_FINISHED_NXDOMAIN` while `curl` and `dig` for the same name worked. Reproduced on a live resolver and fixed here.

## Root cause

Two independent defects, both in the CNAME chase, both hit by Amazon's rotating multi-link chains (`eu.primevideo.com` → `tp.d348e87f6-frontier.primevideo.com` → `d2gpkz5aub6hsk.cloudfront.net`).

**1. Duplicate chain links.** `resolve_with_cname_chase` advanced one link at a time, but upstreams return the whole chain in a single response. Chasing from the first link re-queried an intermediate name, whose answer repeated the later links, and `answers.extend(...)` appended them a second time. Chrome rejects a response with duplicate CNAMEs at the same owner name as malformed and fails the whole resolution. `curl` only asks for A, which happened to be clean, so the failure looked browser-specific.

**2. Chase never terminated for HTTPS/SVCB.** `DnsRecord::query_type()` returns `QueryType::UNKNOWN(n)` for types without a dedicated variant, which never `==` the question's `QueryType::HTTPS`. The chase treated a complete answer as incomplete, re-queried, and re-appended the terminal record. `resolve_iterative` had the identical comparison.

Chrome resolves A, AAAA and HTTPS in parallel, so a malformed answer on any one of them sinks the navigation.

## Changes

- `follow_cname_links` (beside `extract_cname_target`) walks every link already present in a response before any sub-query. Applied to both chases: `resolve_with_cname_chase` and `resolve_iterative`, which had the same defect and additionally cached the duplicated answer with a full TTL.
- `DnsPacket::has_answer_of_type` compares wire numbers, replacing the two `query_type() == qtype` sites.
- Sub-query serialization moved into the remote-resolution branch so it is skipped when the target resolves locally.

Net effect on the hot path is one upstream round trip per chain instead of one per link.

## Tests

Two regression tests, each reproducing the exact corruption observed live before the fix:

- `cname_chase_multi_link_response_has_no_duplicate_links` — 3 answers instead of 2 on unfixed code.
- `cname_chase_terminates_on_unknown_variant_record_type` — 4 answers instead of 3 on unfixed code.

New `testutil` helpers: `mock_upstream_by_qname` (table-driven mock, needed because the chase issues follow-up queries to the same upstream) and `noerror_response`.

## Verification

Built and deployed to a live resolver. A, AAAA and HTTPS for `eu.primevideo.com` all return clean two-link chains with no duplicates; the page loads. Full suite green, `fmt` and `clippy` clean.

## Follow-up

The `UNKNOWN(n)` mismatch in defect 2 has a root cause at `record.rs:139` with a separate, more serious consequence in DNSSEC validation. Filed separately; deliberately not fixed here because it needs its own tests and a decision on SRV/NAPTR canonicalization.
