### PR TITLE
fix(dnssec): verify rrsets of types without a DnsRecord variant

### DIFF
--- a/src/dnssec.rs
+++ b/src/dnssec.rs
@@ -970,8 +970,45 @@ fn record_rdata_canonical(record: &DnsRecord) -> Vec<u8> {
             rdata.extend(&minimum.to_be_bytes());
             rdata
         }
-        DnsRecord::UNKNOWN { data, .. } => data.clone(),
+        DnsRecord::UNKNOWN { qtype, data, .. } => canonical_unknown_rdata(*qtype, data),
         DnsRecord::RRSIG { .. } => Vec::new(),
+    }
+}
+
+// RFC 4034 §6.2: SRV and NAPTR embed a domain name that is downcased in
+// canonical form; every other type carried as UNKNOWN (TXT, HTTPS, SVCB, LOC)
+// signs its rdata verbatim.
+fn canonical_unknown_rdata(qtype: u16, data: &[u8]) -> Vec<u8> {
+    let name_offset = match QueryType::from_num(qtype) {
+        QueryType::SRV => Some(6), // priority + weight + port
+        QueryType::NAPTR => naptr_replacement_offset(data),
+        _ => None,
+    };
+    let mut rdata = data.to_vec();
+    if let Some(off) = name_offset {
+        downcase_wire_name(&mut rdata, off);
+    }
+    rdata
+}
+
+// order + preference (4 bytes), then three character-strings (flags, services,
+// regexp), then the replacement name.
+fn naptr_replacement_offset(data: &[u8]) -> Option<usize> {
+    let mut off = 4usize;
+    for _ in 0..3 {
+        off += 1 + *data.get(off)? as usize;
+    }
+    Some(off)
+}
+
+fn downcase_wire_name(buf: &mut [u8], mut off: usize) {
+    while let Some(&len) = buf.get(off) {
+        if len == 0 || len > 63 {
+            return; // root, compression pointer, or malformed — stop
+        }
+        let end = (off + 1 + len as usize).min(buf.len());
+        buf[off + 1..end].make_ascii_lowercase();
+        off = end;
     }
 }
 
@@ -2128,5 +2165,141 @@ mod tests {
             DnssecStatus::Secure,
             "child set signed by a KSK the DS does not commit to must not validate"
         );
+    }
+
+    fn tamper_signature(rrsig: &mut DnsRecord) {
+        if let DnsRecord::RRSIG { signature, .. } = rrsig {
+            signature[0] ^= 0xFF;
+        }
+    }
+
+    // Issue #324: TXT has no DnsRecord variant, so group_rrsets keys the rrset
+    // UNKNOWN(16) while matching_rrsigs_for compares against from_num(16) = TXT.
+    // No RRSIG ever matches, the rrset is skipped, and a tampered answer
+    // falls through to Secure.
+    #[tokio::test]
+    async fn issue_324_tampered_txt_must_not_report_secure() {
+        let (cache, srtt, _stats) = empty_ctx();
+
+        let zsk = mk_signer(256);
+        cache.write().unwrap().insert(
+            "test",
+            QueryType::DNSKEY,
+            &mk_pkt(vec![mk_dnskey("test", &zsk)]),
+        );
+
+        let txt = DnsRecord::UNKNOWN {
+            domain: "www.test".into(),
+            qtype: QueryType::TXT.to_num(),
+            data: b"\x10v=spf1 -all TAMPERED".to_vec(),
+            ttl: 3600,
+        };
+        let txt_refs = [&txt];
+        let mut rrsig = mk_rrsig(&zsk, "test", QueryType::TXT, &txt_refs);
+        tamper_signature(&mut rrsig);
+
+        let response = mk_pkt(vec![txt, rrsig]);
+        let (status, _) = validate_response(&response, &cache, &[], &srtt).await;
+        assert_eq!(
+            status,
+            DnssecStatus::Bogus,
+            "TXT rrset with an unverifiable signature must not report Secure"
+        );
+    }
+
+    // Control: the identical tamper on a type WITH a DnsRecord variant is caught.
+    #[tokio::test]
+    async fn issue_324_control_tampered_a_is_bogus() {
+        let (cache, srtt, _stats) = empty_ctx();
+
+        let zsk = mk_signer(256);
+        cache.write().unwrap().insert(
+            "test",
+            QueryType::DNSKEY,
+            &mk_pkt(vec![mk_dnskey("test", &zsk)]),
+        );
+
+        let a = DnsRecord::A {
+            domain: "www.test".into(),
+            addr: "6.6.6.6".parse().unwrap(),
+            ttl: 3600,
+        };
+        let a_refs = [&a];
+        let mut rrsig = mk_rrsig(&zsk, "test", QueryType::A, &a_refs);
+        tamper_signature(&mut rrsig);
+
+        let response = mk_pkt(vec![a, rrsig]);
+        let (status, _) = validate_response(&response, &cache, &[], &srtt).await;
+        assert_eq!(status, DnssecStatus::Bogus);
+    }
+
+    fn mk_unknown(domain: &str, qtype: QueryType, data: &[u8]) -> DnsRecord {
+        DnsRecord::UNKNOWN {
+            domain: domain.into(),
+            qtype: qtype.to_num(),
+            data: data.to_vec(),
+            ttl: 3600,
+        }
+    }
+
+    #[test]
+    fn genuine_txt_and_https_signatures_verify() {
+        let zsk = mk_signer(256);
+        let dk = mk_dnskey("test", &zsk);
+
+        for (qtype, rdata) in [
+            (QueryType::TXT, &b"\x0bv=spf1 -all"[..]),
+            // HTTPS: priority=1, target=root, alpn="h2"
+            (QueryType::HTTPS, &b"\x00\x01\x00\x00\x01\x00\x03\x02h2"[..]),
+        ] {
+            let rr = mk_unknown("www.test", qtype, rdata);
+            let refs = [&rr];
+            let rrsig = mk_rrsig(&zsk, "test", qtype, &refs);
+            assert!(
+                rrsig_verified_by(&rrsig, &dk, &refs),
+                "genuine {qtype:?} signature must verify"
+            );
+
+            let tampered = mk_unknown("www.test", qtype, b"\x08TAMPERED");
+            assert!(
+                !rrsig_verified_by(&rrsig, &dk, &[&tampered]),
+                "tampered {qtype:?} rdata must not verify"
+            );
+        }
+    }
+
+    // RFC 4034 §6.2: the signer canonicalizes the SRV target to lowercase, so a
+    // response carrying the target with its original casing must still verify.
+    #[test]
+    fn srv_with_uppercase_target_verifies_against_canonical_signature() {
+        let zsk = mk_signer(256);
+        let dk = mk_dnskey("test", &zsk);
+
+        let srv_rdata = |target_case: &[u8]| {
+            let mut d = vec![0, 10, 0, 5, 0x13, 0xc4]; // prio=10 weight=5 port=5060
+            d.push(3);
+            d.extend(target_case);
+            d.extend(b"\x04test\x00");
+            d
+        };
+        let canonical = mk_unknown("_sip._udp.test", QueryType::SRV, &srv_rdata(b"sip"));
+        let as_served = mk_unknown("_sip._udp.test", QueryType::SRV, &srv_rdata(b"SIP"));
+
+        let rrsig = mk_rrsig(&zsk, "test", QueryType::SRV, &[&canonical]);
+        assert!(rrsig_verified_by(&rrsig, &dk, &[&as_served]));
+    }
+
+    #[test]
+    fn naptr_canonical_downcases_only_the_replacement_name() {
+        // order=100 pref=10, flags="S", services="SIP+D2U", regexp="", replacement=Sip.Test.
+        let mut rdata = vec![0, 100, 0, 10];
+        rdata.extend(b"\x01S\x07SIP+D2U\x00");
+        rdata.extend(b"\x03Sip\x04Test\x00");
+
+        let canon = canonical_unknown_rdata(QueryType::NAPTR.to_num(), &rdata);
+        let mut want = vec![0, 100, 0, 10];
+        want.extend(b"\x01S\x07SIP+D2U\x00"); // character-strings untouched
+        want.extend(b"\x03sip\x04test\x00");
+        assert_eq!(canon, want);
     }
 }

--- a/src/dnssec.rs
+++ b/src/dnssec.rs
@@ -796,19 +796,7 @@ pub fn name_to_wire(name: &str) -> Vec<u8> {
     buf.write_qname(name)
         .expect("name_to_wire: input must parse as a valid DNS name");
     let mut wire = buf.filled().to_vec();
-
-    let mut i = 0;
-    while i < wire.len() {
-        let label_len = wire[i] as usize;
-        if label_len == 0 {
-            break;
-        }
-        i += 1;
-        let end = i + label_len;
-        wire[i..end].make_ascii_lowercase();
-        i = end;
-    }
-
+    downcase_wire_name(&mut wire, 0);
     wire
 }
 
@@ -970,7 +958,7 @@ fn record_rdata_canonical(record: &DnsRecord) -> Vec<u8> {
             rdata.extend(&minimum.to_be_bytes());
             rdata
         }
-        DnsRecord::UNKNOWN { qtype, data, .. } => canonical_unknown_rdata(*qtype, data),
+        DnsRecord::UNKNOWN { data, .. } => canonical_unknown_rdata(record.query_type(), data),
         DnsRecord::RRSIG { .. } => Vec::new(),
     }
 }
@@ -978,8 +966,8 @@ fn record_rdata_canonical(record: &DnsRecord) -> Vec<u8> {
 // RFC 4034 §6.2: SRV and NAPTR embed a domain name that is downcased in
 // canonical form; every other type carried as UNKNOWN (TXT, HTTPS, SVCB, LOC)
 // signs its rdata verbatim.
-fn canonical_unknown_rdata(qtype: u16, data: &[u8]) -> Vec<u8> {
-    let name_offset = match QueryType::from_num(qtype) {
+fn canonical_unknown_rdata(qtype: QueryType, data: &[u8]) -> Vec<u8> {
+    let name_offset = match qtype {
         QueryType::SRV => Some(6), // priority + weight + port
         QueryType::NAPTR => naptr_replacement_offset(data),
         _ => None,
@@ -2167,20 +2155,10 @@ mod tests {
         );
     }
 
-    fn tamper_signature(rrsig: &mut DnsRecord) {
-        if let DnsRecord::RRSIG { signature, .. } = rrsig {
-            signature[0] ^= 0xFF;
-        }
-    }
-
-    // Issue #324: TXT has no DnsRecord variant, so group_rrsets keys the rrset
-    // UNKNOWN(16) while matching_rrsigs_for compares against from_num(16) = TXT.
-    // No RRSIG ever matches, the rrset is skipped, and a tampered answer
-    // falls through to Secure.
-    #[tokio::test]
-    async fn issue_324_tampered_txt_must_not_report_secure() {
+    // Sign `record` in zone "test" (DNSKEY pre-seeded in cache), corrupt the
+    // signature, and validate the full response.
+    async fn tampered_rrset_status(record: DnsRecord) -> DnssecStatus {
         let (cache, srtt, _stats) = empty_ctx();
-
         let zsk = mk_signer(256);
         cache.write().unwrap().insert(
             "test",
@@ -2188,20 +2166,24 @@ mod tests {
             &mk_pkt(vec![mk_dnskey("test", &zsk)]),
         );
 
-        let txt = DnsRecord::UNKNOWN {
-            domain: "www.test".into(),
-            qtype: QueryType::TXT.to_num(),
-            data: b"\x10v=spf1 -all TAMPERED".to_vec(),
-            ttl: 3600,
-        };
-        let txt_refs = [&txt];
-        let mut rrsig = mk_rrsig(&zsk, "test", QueryType::TXT, &txt_refs);
-        tamper_signature(&mut rrsig);
+        let mut rrsig = mk_rrsig(&zsk, "test", record.query_type(), &[&record]);
+        if let DnsRecord::RRSIG { signature, .. } = &mut rrsig {
+            signature[0] ^= 0xFF;
+        }
 
-        let response = mk_pkt(vec![txt, rrsig]);
-        let (status, _) = validate_response(&response, &cache, &[], &srtt).await;
+        let response = mk_pkt(vec![record, rrsig]);
+        validate_response(&response, &cache, &[], &srtt).await.0
+    }
+
+    // Issue #324: TXT has no DnsRecord variant, so group_rrsets keyed the rrset
+    // UNKNOWN(16) while matching_rrsigs_for compares against from_num(16) = TXT.
+    // No RRSIG ever matched, the rrset was skipped, and a tampered answer
+    // fell through to Secure.
+    #[tokio::test]
+    async fn issue_324_tampered_txt_must_not_report_secure() {
+        let txt = mk_unknown("www.test", QueryType::TXT, b"\x10v=spf1 -all TAMPERED");
         assert_eq!(
-            status,
+            tampered_rrset_status(txt).await,
             DnssecStatus::Bogus,
             "TXT rrset with an unverifiable signature must not report Secure"
         );
@@ -2210,27 +2192,12 @@ mod tests {
     // Control: the identical tamper on a type WITH a DnsRecord variant is caught.
     #[tokio::test]
     async fn issue_324_control_tampered_a_is_bogus() {
-        let (cache, srtt, _stats) = empty_ctx();
-
-        let zsk = mk_signer(256);
-        cache.write().unwrap().insert(
-            "test",
-            QueryType::DNSKEY,
-            &mk_pkt(vec![mk_dnskey("test", &zsk)]),
-        );
-
         let a = DnsRecord::A {
             domain: "www.test".into(),
             addr: "6.6.6.6".parse().unwrap(),
             ttl: 3600,
         };
-        let a_refs = [&a];
-        let mut rrsig = mk_rrsig(&zsk, "test", QueryType::A, &a_refs);
-        tamper_signature(&mut rrsig);
-
-        let response = mk_pkt(vec![a, rrsig]);
-        let (status, _) = validate_response(&response, &cache, &[], &srtt).await;
-        assert_eq!(status, DnssecStatus::Bogus);
+        assert_eq!(tampered_rrset_status(a).await, DnssecStatus::Bogus);
     }
 
     fn mk_unknown(domain: &str, qtype: QueryType, data: &[u8]) -> DnsRecord {
@@ -2296,7 +2263,7 @@ mod tests {
         rdata.extend(b"\x01S\x07SIP+D2U\x00");
         rdata.extend(b"\x03Sip\x04Test\x00");
 
-        let canon = canonical_unknown_rdata(QueryType::NAPTR.to_num(), &rdata);
+        let canon = canonical_unknown_rdata(QueryType::NAPTR, &rdata);
         let mut want = vec![0, 100, 0, 10];
         want.extend(b"\x01S\x07SIP+D2U\x00"); // character-strings untouched
         want.extend(b"\x03sip\x04test\x00");

--- a/src/record.rs
+++ b/src/record.rs
@@ -136,7 +136,7 @@ impl DnsRecord {
             DnsRecord::RRSIG { .. } => QueryType::RRSIG,
             DnsRecord::NSEC { .. } => QueryType::NSEC,
             DnsRecord::NSEC3 { .. } => QueryType::NSEC3,
-            DnsRecord::UNKNOWN { qtype, .. } => QueryType::UNKNOWN(*qtype),
+            DnsRecord::UNKNOWN { qtype, .. } => QueryType::from_num(*qtype),
         }
     }
 
@@ -795,6 +795,17 @@ mod tests {
             .query_type(),
             QueryType::DS
         );
+        // Types without a variant normalize to their named QueryType (issue #324):
+        // DNSSEC rrset grouping and qtype comparisons rely on this.
+        let unknown = |qtype| DnsRecord::UNKNOWN {
+            domain: String::new(),
+            qtype,
+            data: vec![],
+            ttl: 0,
+        };
+        assert_eq!(unknown(16).query_type(), QueryType::TXT);
+        assert_eq!(unknown(65).query_type(), QueryType::HTTPS);
+        assert_eq!(unknown(999).query_type(), QueryType::UNKNOWN(999));
     }
 
     #[test]


### PR DESCRIPTION
Closes #324.

With `[dnssec] enabled = true`, a signed TXT / HTTPS / SVCB / SRV / NAPTR / LOC answer was reported `Secure` (ad bit set) without any signature verification running. These types parse as `DnsRecord::UNKNOWN`, and `query_type()` returned `QueryType::UNKNOWN(n)` rather than normalizing through `from_num`, so `group_rrsets` keyed the rrset `UNKNOWN(16)` while `matching_rrsigs_for` compared against `from_num(16)` = `TXT`. No RRSIG ever matched, the rrset was skipped as unsigned, and `validate_response` fell through to `Secure`. Tampered rdata validated as cleanly as genuine rdata.

### The fix

`record.rs`: `query_type()` for `UNKNOWN` now normalizes through `QueryType::from_num`. The `DnsRecord` variant itself is unchanged, so `matches!(r, DnsRecord::UNKNOWN { .. })` sites are unaffected.

Call-site audit of `query_type()` (per the issue):

| Site | Effect |
|---|---|
| `dnssec.rs` group_rrsets / rrset filters | the fix — rrsets now match their RRSIGs |
| `dnssec.rs:862` build_signed_data | round-trips through `to_num`, byte-identical |
| `ctx.rs:280`, `recursive.rs:253` CNAME-chase target checks | false mismatch removed; belt-and-braces after #323 |
| `ctx.rs` `is_dnssec_record` | matches named variants only, unaffected |
| `config.rs:1721` `from_exact` | test-only helper, keys now consistent with question qtypes |

### Canonical form for SRV/NAPTR

Verification now actually runs for these types, so canonical form matters. Per RFC 4034 §6.2, SRV and NAPTR embed a domain name that the signer downcases; verifying raw rdata would flag legitimately-signed records with uppercase targets as Bogus. `record_rdata_canonical` now downcases the embedded name (SRV target after the 6-byte fixed prefix; NAPTR replacement after the three character-strings, which stay verbatim). TXT/HTTPS/SVCB/LOC correctly sign rdata verbatim.

### Tests

- `issue_324_tampered_txt_must_not_report_secure` — the repro: corrupted RRSIG over a TXT rrset returned `Secure` before this change, now `Bogus`
- `issue_324_control_tampered_a_is_bogus` — control showing types with a variant were always caught
- `genuine_txt_and_https_signatures_verify` — positive path plus tamper-rejection for TXT and HTTPS
- `srv_with_uppercase_target_verifies_against_canonical_signature` — signer-downcased SRV verifies against mixed-case served rdata
- `naptr_canonical_downcases_only_the_replacement_name`
- `query_type_method` extended with the normalization contract

`cargo test --lib`: 557 passed. fmt/clippy clean on touched files (bench criterion deprecations are pre-existing toolchain drift).