### PR TITLE
fix(cli): centralize terminal colors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod mobileconfig;
 pub mod odoh;
 pub mod override_store;
 pub mod packet;
+pub mod palette;
 pub mod persist;
 pub mod pp2;
 pub mod pp2_udp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use numa::system_dns::{
 const NO_SYSTEM_DNS_FLAG: &str = "--no-system-dns";
 
 fn main() -> numa::Result<()> {
+    let palette = numa::palette::get();
     // Handle CLI subcommands
     let arg1 = std::env::args().nth(1).unwrap_or_default();
 
@@ -35,16 +36,22 @@ fn main() -> numa::Result<()> {
 
     match arg1.as_str() {
         "install" => {
-            eprintln!("\x1b[1;38;2;192;98;58mNuma\x1b[0m — installing\n");
+            eprintln!("{}Numa{} — installing\n", palette.brand_bold, palette.reset);
             return install_service(skip_system_dns).map_err(|e| e.into());
         }
         "uninstall" => {
-            eprintln!("\x1b[1;38;2;192;98;58mNuma\x1b[0m — uninstalling\n");
+            eprintln!(
+                "{}Numa{} — uninstalling\n",
+                palette.brand_bold, palette.reset
+            );
             return uninstall_service().map_err(|e| e.into());
         }
         "service" => {
             let sub = std::env::args().nth(2).unwrap_or_default();
-            eprintln!("\x1b[1;38;2;192;98;58mNuma\x1b[0m — service management\n");
+            eprintln!(
+                "{}Numa{} — service management\n",
+                palette.brand_bold, palette.reset
+            );
             return match sub.as_str() {
                 "start" => start_service(skip_system_dns).map_err(|e| e.into()),
                 "stop" => stop_service().map_err(|e| e.into()),
@@ -82,8 +89,8 @@ fn main() -> numa::Result<()> {
                 .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
             let addr = std::net::SocketAddr::new(bind, port);
             eprintln!(
-                "\x1b[1;38;2;192;98;58mNuma\x1b[0m — ODoH relay on {}\n",
-                addr
+                "{}Numa{} — ODoH relay on {}\n",
+                palette.brand_bold, palette.reset, addr
             );
             let runtime = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -153,10 +160,13 @@ fn main() -> numa::Result<()> {
                 && !arg1.ends_with(".toml")
             {
                 eprintln!(
-                    "\x1b[1;38;2;192;98;58mNuma\x1b[0m — unknown command: \x1b[1m{}\x1b[0m\n",
-                    arg1
+                    "{}Numa{} — unknown command: {}{}{}\n",
+                    palette.brand_bold, palette.reset, palette.bold, arg1, palette.reset
                 );
-                eprintln!("Run \x1b[1mnuma help\x1b[0m for a list of commands.");
+                eprintln!(
+                    "Run {}numa help{} for a list of commands.",
+                    palette.bold, palette.reset
+                );
                 std::process::exit(1);
             }
         }
@@ -250,10 +260,15 @@ fn update_config_content(contents: &str, section: &str, key: &str, value: bool) 
 
 fn print_toggle_status(feature: &str, enabled: bool, path: &str) {
     let label = if enabled { "enabled" } else { "disabled" };
-    let color = if enabled { "32" } else { "33" };
+    let palette = numa::palette::get();
+    let color = if enabled {
+        palette.green
+    } else {
+        palette.warning
+    };
     eprintln!(
-        "\x1b[1;38;2;192;98;58mNuma\x1b[0m — {} \x1b[{}m{}\x1b[0m",
-        feature, color, label
+        "{}Numa{} — {} {}{}{}",
+        palette.brand_bold, palette.reset, feature, color, label, palette.reset
     );
     eprintln!("  Wrote {}", path);
     if enabled {

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,0 +1,136 @@
+use std::io::IsTerminal;
+use std::sync::LazyLock;
+
+pub struct Palette {
+    pub brand: &'static str,
+    pub brand_bold: &'static str,
+    pub olive: &'static str,
+    pub dim: &'static str,
+    pub dim_italic: &'static str,
+    pub warning: &'static str,
+    pub cyan: &'static str,
+    pub green: &'static str,
+    pub bold: &'static str,
+    pub reset: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ColorLevel {
+    None,
+    Ansi256,
+    Truecolor,
+}
+
+static PALETTE: LazyLock<Palette> = LazyLock::new(|| {
+    let no_color = std::env::var_os("NO_COLOR");
+    let colorterm = std::env::var("COLORTERM").ok();
+    Palette::for_level(select_level(
+        no_color_enabled(no_color.as_deref()),
+        std::io::stderr().is_terminal(),
+        colorterm.as_deref(),
+    ))
+});
+
+pub fn get() -> &'static Palette {
+    &PALETTE
+}
+
+fn no_color_enabled(value: Option<&std::ffi::OsStr>) -> bool {
+    value.is_some_and(|value| !value.is_empty())
+}
+
+fn select_level(no_color: bool, is_terminal: bool, colorterm: Option<&str>) -> ColorLevel {
+    if no_color || !is_terminal {
+        ColorLevel::None
+    } else if colorterm.is_some_and(|value| {
+        value.eq_ignore_ascii_case("truecolor") || value.eq_ignore_ascii_case("24bit")
+    }) {
+        ColorLevel::Truecolor
+    } else {
+        ColorLevel::Ansi256
+    }
+}
+
+impl Palette {
+    fn for_level(level: ColorLevel) -> Self {
+        match level {
+            ColorLevel::None => Self {
+                brand: "",
+                brand_bold: "",
+                olive: "",
+                dim: "",
+                dim_italic: "",
+                warning: "",
+                cyan: "",
+                green: "",
+                bold: "",
+                reset: "",
+            },
+            ColorLevel::Ansi256 => Self {
+                brand: "\x1b[38;5;131m",
+                brand_bold: "\x1b[1;38;5;131m",
+                olive: "\x1b[38;5;65m",
+                dim: "\x1b[38;5;246m",
+                dim_italic: "\x1b[3;38;5;246m",
+                warning: "\x1b[38;5;179m",
+                cyan: "\x1b[38;5;44m",
+                green: "\x1b[38;5;40m",
+                bold: "\x1b[1m",
+                reset: "\x1b[0m",
+            },
+            ColorLevel::Truecolor => Self {
+                brand: "\x1b[38;2;192;98;58m",
+                brand_bold: "\x1b[1;38;2;192;98;58m",
+                olive: "\x1b[38;2;107;124;78m",
+                dim: "\x1b[38;2;163;152;136m",
+                dim_italic: "\x1b[3;38;2;163;152;136m",
+                warning: "\x1b[38;2;204;176;59m",
+                cyan: "\x1b[36m",
+                green: "\x1b[32m",
+                bold: "\x1b[1m",
+                reset: "\x1b[0m",
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_color_requires_a_non_empty_value() {
+        assert!(!no_color_enabled(None));
+        assert!(!no_color_enabled(Some(std::ffi::OsStr::new(""))));
+        assert!(no_color_enabled(Some(std::ffi::OsStr::new("1"))));
+    }
+
+    #[test]
+    fn color_level_respects_output_and_environment() {
+        assert_eq!(
+            select_level(true, true, Some("truecolor")),
+            ColorLevel::None
+        );
+        assert_eq!(
+            select_level(false, false, Some("truecolor")),
+            ColorLevel::None
+        );
+        assert_eq!(select_level(false, true, None), ColorLevel::Ansi256);
+        assert_eq!(
+            select_level(false, true, Some("24bit")),
+            ColorLevel::Truecolor
+        );
+        assert_eq!(
+            select_level(false, true, Some("TRUECOLOR")),
+            ColorLevel::Truecolor
+        );
+    }
+
+    #[test]
+    fn disabled_palette_has_no_escape_codes() {
+        let palette = Palette::for_level(ColorLevel::None);
+        assert!(palette.brand.is_empty());
+        assert!(palette.bold.is_empty());
+        assert!(palette.reset.is_empty());
+    }
+}

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -535,12 +535,13 @@ fn print_banner(
     .unwrap_or(30);
     let w = (val_w + 12).max(42).max(1 + title_plain.chars().count());
 
-    let o = "\x1b[38;2;192;98;58m";
-    let g = "\x1b[38;2;107;124;78m";
-    let d = "\x1b[38;2;163;152;136m";
-    let r = "\x1b[0m";
-    let b = "\x1b[1;38;2;192;98;58m";
-    let it = "\x1b[3;38;2;163;152;136m";
+    let palette = crate::palette::get();
+    let o = palette.brand;
+    let g = palette.olive;
+    let d = palette.dim;
+    let r = palette.reset;
+    let b = palette.brand_bold;
+    let it = palette.dim_italic;
 
     let bar_top = "═".repeat(w);
     let bar_mid = "─".repeat(w);
@@ -592,10 +593,9 @@ fn print_banner(
     if let Some(ref label) = proxy_label {
         row("Proxy", g, label);
         if config.proxy.bind_addr == "127.0.0.1" {
-            let y = "\x1b[38;2;204;176;59m";
             row(
                 "",
-                y,
+                palette.warning,
                 &format!(
                     "⚠ proxy on 127.0.0.1 — .{} not LAN reachable",
                     config.proxy.tld

--- a/src/setup_phone.rs
+++ b/src/setup_phone.rs
@@ -45,6 +45,7 @@ fn render_qr(url: &str) -> Result<String, String> {
 
 /// Run the `numa setup-phone` flow.
 pub async fn run() -> Result<(), String> {
+    let palette = crate::palette::get();
     let lan_ip = crate::lan::detect_lan_ip()
         .ok_or("could not detect LAN IP — are you connected to a network?")?;
 
@@ -60,8 +61,8 @@ pub async fn run() -> Result<(), String> {
     if !api_reachable {
         eprintln!();
         eprintln!(
-            "  \x1b[1;38;2;192;98;58mNuma\x1b[0m — mobile API is not reachable on port {}.",
-            SETUP_PORT
+            "  {}Numa{} — mobile API is not reachable on port {}.",
+            palette.brand_bold, palette.reset, SETUP_PORT
         );
         eprintln!();
         eprintln!("  The phone won't be able to download the profile until the mobile");
@@ -77,36 +78,45 @@ pub async fn run() -> Result<(), String> {
     let qr = render_qr(&url)?;
 
     eprintln!();
-    eprintln!("  \x1b[1;38;2;192;98;58mNuma Phone Setup\x1b[0m");
+    eprintln!("  {}Numa Phone Setup{}", palette.brand_bold, palette.reset);
     eprintln!();
-    eprintln!("  Profile URL: \x1b[36m{}\x1b[0m", url);
+    eprintln!("  Profile URL: {}{}{}", palette.cyan, url, palette.reset);
     eprintln!();
     for line in qr.lines() {
         eprintln!("  {}", line);
     }
     eprintln!();
-    eprintln!("  \x1b[1mOn your iPhone:\x1b[0m");
+    eprintln!("  {}On your iPhone:{}", palette.bold, palette.reset);
     eprintln!("    1. Open Camera, point at the QR code, tap the yellow banner");
     eprintln!("    2. Allow the download when Safari asks");
     eprintln!("    3. Open Settings — tap \"Profile Downloaded\" near the top");
     eprintln!("       (or: Settings → General → VPN & Device Management → Numa DNS)");
     eprintln!("    4. Tap Install (top right), enter passcode, Install again");
-    eprintln!("    5. \x1b[1mSettings → General → About → Certificate Trust Settings\x1b[0m");
+    eprintln!(
+        "    5. {}Settings → General → About → Certificate Trust Settings{}",
+        palette.bold, palette.reset
+    );
     eprintln!("       Toggle ON \"Numa Local CA\" — required for DoT to work");
     eprintln!();
     eprintln!(
-        "  \x1b[33mNote:\x1b[0m profile uses your laptop's current IP ({}). If your",
-        lan_ip
+        "  {}Note:{} profile uses your laptop's current IP ({}). If your",
+        palette.warning, palette.reset, lan_ip
     );
     eprintln!("  laptop changes networks, re-scan this QR — iOS will replace the");
     eprintln!("  existing profile automatically (fixed UUID).");
     eprintln!();
     eprintln!(
-        "  \x1b[90mThe profile is served by Numa's persistent mobile API on port {}.\x1b[0m",
-        SETUP_PORT
+        "  {}The profile is served by Numa's persistent mobile API on port {}.{}",
+        palette.dim, SETUP_PORT, palette.reset
     );
-    eprintln!("  \x1b[90mMake sure `numa` is running before scanning. If it's not,\x1b[0m");
-    eprintln!("  \x1b[90mstart it with `sudo numa install` or run it interactively.\x1b[0m");
+    eprintln!(
+        "  {}Make sure `numa` is running before scanning. If it's not,{}",
+        palette.dim, palette.reset
+    );
+    eprintln!(
+        "  {}start it with `sudo numa install` or run it interactively.{}",
+        palette.dim, palette.reset
+    );
     eprintln!();
 
     Ok(())

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -111,8 +111,9 @@ pub fn try_port53_advisory(bind_addr: &str, err: &std::io::Error) -> Option<Stri
         ),
         _ => return None,
     };
-    let o = "\x1b[1;38;2;192;98;58m"; // bold orange
-    let r = "\x1b[0m";
+    let palette = crate::palette::get();
+    let o = palette.brand_bold;
+    let r = palette.reset;
     Some(format!(
         "
 {o}Numa{r} — cannot bind to {bind_addr}: {title}.

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -137,8 +137,9 @@ pub fn try_data_dir_advisory(err: &crate::Error, data_dir: &Path) -> Option<Stri
     if io_err.kind() != std::io::ErrorKind::PermissionDenied {
         return None;
     }
-    let o = "\x1b[1;38;2;192;98;58m";
-    let r = "\x1b[0m";
+    let palette = crate::palette::get();
+    let o = palette.brand_bold;
+    let r = palette.reset;
     Some(format!(
         "
 {o}Numa{r} — HTTPS proxy disabled: cannot write TLS CA to {}.


### PR DESCRIPTION
## Summary

- I centralized the CLI's terminal styling in a single palette module.
- I disable ANSI output when `NO_COLOR` is non-empty or stderr is not a terminal.
- I preserve the existing truecolor palette when `COLORTERM` advertises `truecolor`/`24bit`, with xterm-256 fallbacks otherwise.
- I routed the startup banner, command status, phone setup, port advisory, and TLS advisory through the shared palette without adding dependencies.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -j 2 palette::tests --lib` (3 passed)
- `cargo test -j 2 --bin numa` (2 passed)
- `cargo clippy -j 2 -- -D warnings`
- Runtime probes for piped stderr, `NO_COLOR`, 256-color, and truecolor output
- `git diff --check main...HEAD`

The full cross-platform and integration test matrix is deferred to CI.

Fixes #320
