### PR TITLE
fix(blocklist): replace dead hagezi default, reject non-2xx

### DIFF
--- a/.github/workflows/blocklist-canary.yml
+++ b/.github/workflows/blocklist-canary.yml
@@ -1,0 +1,22 @@
+name: Blocklist canary
+
+# HaGeZi discontinued the hosts/ format on 2026-08-01 and the shipped default
+# 404'd for days without anyone noticing (issue #336). This fetches the URL
+# actually compiled into the binary and parses it with Numa's own parser, so a
+# discontinued format or a changed layout fails here instead of in the field.
+
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # No name filter: a filter that matches nothing exits 0, which would make
+      # this canary silently pass forever if the test were renamed.
+      - run: cargo test --lib -- --ignored --nocapture

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Add path-based routing (`app.numa/api → :5001`), share services across machine
 
 ## Ad Blocking & Privacy
 
-385K+ domains blocked via [Hagezi Pro](https://github.com/hagezi/dns-blocklists). Works on any network — coffee shops, hotels, airports. Travels with your laptop.
+Ad and tracker blocking via [Hagezi Pro](https://github.com/hagezi/dns-blocklists), refreshed daily. Works on any network — coffee shops, hotels, airports. Travels with your laptop.
 
 Three resolution modes:
 
@@ -141,7 +141,7 @@ Turnkey compose recipes:
 | Developer overrides (REST API) | — | — | — | Auto-revert, scriptable |
 | Recursive resolver | — | — | Yes | Yes, with SRTT selection |
 | DNSSEC validation | — | — | Yes | Yes (RSA, ECDSA, Ed25519) |
-| Ad blocking | Yes | Yes | — | 385K+ domains |
+| Ad blocking | Yes | Yes | — | Hagezi Pro |
 | Web admin UI | Full | Full | — | Dashboard |
 | Encrypted upstream (DoH/DoT) | Needs cloudflared | DoH only | DoT only | DoH + DoT (`tls://`) |
 | Encrypted clients (DoT listener) | Needs stunnel sidecar | Yes | Yes | Native (RFC 7858) |

--- a/numa.toml
+++ b/numa.toml
@@ -116,12 +116,16 @@ api_port = 5380
 # [blocking]
 # enabled = true               # set to false to disable ad blocking
 # refresh_hours = 24
+# Every entry blocks the domain and all its subdomains, whatever the list
+# format — hosts lines, bare domains, adblock syntax, remote or local.
 # lists = [
-#     "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/hosts/pro.txt",
-#     "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/nsfw-onlydomains.txt",  # adult-content (opt-in; hagezi ships nsfw only as wildcard/adblock, not hosts/)
-#     "file:///etc/numa/local-blocklist.txt",  # local hosts-style file
+#     "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro-onlydomains.txt",
+#     "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/nsfw-onlydomains.txt",  # adult-content (opt-in)
+#     "file:///etc/numa/local-blocklist.txt",  # local file: hosts lines or bare domains
 #     "/etc/numa/extra-blocks.txt",            # bare absolute path also works
 # ]
+# Where raw.githubusercontent.com is unreachable, the jsDelivr mirror of the
+# same file works: https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/pro-onlydomains.txt
 # allowlist = ["example.com"]  # domains to never block
 
 # ── Per-client domain policies ─────────────────────────────────────

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1328,7 +1328,7 @@ async function refresh() {
     document.getElementById('blockedSub').textContent =
       bl.paused ? 'paused' :
       !bl.enabled ? 'disabled' :
-      bl.domains_loaded > 0 ? `${formatNumber(bl.domains_loaded)} in blocklist` : 'loading...';
+      bl.domains_loaded > 0 ? `${formatNumber(bl.domains_loaded)} in blocklist` : 'no domains loaded';
 
     // Blocking controls — single primary button + secondary toggle
     const toggleBtn = document.getElementById('toggleBtn');
@@ -1489,6 +1489,8 @@ function renderBlockingInfo(info) {
   const refreshEl = document.getElementById('blockingRefresh');
   if (info.last_refresh_secs_ago != null) {
     refreshEl.textContent = `refreshed ${formatUptime(info.last_refresh_secs_ago)} ago`;
+  } else {
+    refreshEl.textContent = 'never updated';
   }
   const sources = info.list_sources || [];
   if (!sources.length) {

--- a/site/index.html
+++ b/site/index.html
@@ -1290,7 +1290,7 @@ footer .closing {
         <h3>Resolve &amp; Protect</h3>
         <ul>
           <li>Forward mode by default &mdash; transparent proxy to your existing DNS, with caching</li>
-          <li>Ad &amp; tracker blocking &mdash; 385K+ domains, zero config</li>
+          <li>Ad &amp; tracker blocking &mdash; Hagezi Pro, zero config</li>
           <li>Recursive resolution &mdash; opt-in, resolve from root nameservers, no upstream needed</li>
           <li>DNSSEC validation &mdash; chain-of-trust + NSEC/NSEC3 denial proofs (RSA, ECDSA, Ed25519)</li>
           <li>DNS-over-TLS listener &mdash; encrypted DNS for phones and strict clients (RFC 7858 with ALPN defense)</li>
@@ -1408,7 +1408,7 @@ footer .closing {
             <td class="check">Yes</td>
             <td class="muted">Limited</td>
             <td class="check">Yes</td>
-            <td class="check">385K+ domains</td>
+            <td class="check">Hagezi Pro</td>
           </tr>
           <tr>
             <td>Portable (travels with laptop)</td>
@@ -1688,7 +1688,7 @@ footer .closing {
       </div>
       <div class="roadmap-item done">
         <span class="phase">Phase 2</span>
-        <span class="phase-desc">Ad &amp; tracker blocking &mdash; 385K+ domains, live dashboard, one-click allowlist</span>
+        <span class="phase-desc">Ad &amp; tracker blocking &mdash; Hagezi Pro, live dashboard, one-click allowlist</span>
       </div>
       <div class="roadmap-item done">
         <span class="phase">Phase 3</span>

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -141,6 +141,10 @@ impl BlocklistStore {
         self.last_refresh = Some(Instant::now());
     }
 
+    pub fn domains_loaded(&self) -> usize {
+        self.domains.len()
+    }
+
     pub fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled;
     }
@@ -238,6 +242,38 @@ pub fn parse_blocklist(text: &str) -> HashSet<String> {
         insert_if_valid(&mut domains, d.trim_end_matches('^'));
     }
     domains
+}
+
+/// Share of entry lines that must parse as domains for a body to be a list at
+/// all. Every format Numa parses — hosts lines, bare domains, adblock syntax —
+/// yields a domain from essentially every entry line, so anything under half is
+/// something else wearing a 200.
+const MIN_PARSED_PERCENT: usize = 50;
+
+/// Why this source is not a usable blocklist, or `None` if it is one.
+///
+/// Judges shape, never size: a twelve-domain personal list parses all of its
+/// entry lines and stays valid, while an error page parses almost none. An
+/// empty local file is a deliberate "block nothing"; an empty remote body is a
+/// broken upstream, never an instruction.
+pub(crate) fn source_defect(source: &str, text: &str, domains: &HashSet<String>) -> Option<String> {
+    let entries = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#') && !l.starts_with('!'))
+        .count();
+    if entries == 0 {
+        return local_path(source)
+            .is_none()
+            .then(|| "response body has no entries".to_string());
+    }
+    if domains.len() * 100 < entries * MIN_PARSED_PERCENT {
+        return Some(format!(
+            "only {} of {entries} entry lines parsed as domains",
+            domains.len()
+        ));
+    }
+    None
 }
 
 pub(crate) fn normalize(domain: &str) -> String {
@@ -453,6 +489,52 @@ mod tests {
         assert!(local_path("http://example.com/list.txt").is_none());
     }
 
+    fn defect(source: &str, text: &str) -> Option<String> {
+        source_defect(source, text, &parse_blocklist(text))
+    }
+
+    /// A soft-error page small enough to yield one domain-shaped token still
+    /// must not replace a working list — the count is not the test, the share
+    /// of entry lines that parsed is.
+    #[test]
+    fn small_error_page_with_one_domain_shaped_line_is_rejected() {
+        let body = "<html>\n<head><title>404 Not Found</title></head>\n<body>\n<center><h1>404 Not Found</h1></center>\n<hr><center>nginx/1.18.0</center>\n</body>\n</html>\n";
+        assert!(
+            !parse_blocklist(body).is_empty(),
+            "precondition: parses > 0"
+        );
+        assert!(defect("https://cdn.example/list.txt", body).is_some());
+    }
+
+    /// Size is never the test — a tiny personal list must survive validation
+    /// that an error page fails.
+    #[test]
+    fn tiny_custom_list_is_accepted() {
+        assert!(defect("https://cdn.example/list.txt", "# mine\nads.example.com\n").is_none());
+    }
+
+    #[test]
+    fn real_list_shapes_are_accepted() {
+        assert!(defect("https://cdn.example/l.txt", "a.com\nb.com\nc.com\n").is_none());
+        assert!(defect(
+            "https://cdn.example/l.txt",
+            "0.0.0.0 a.com\n0.0.0.0 b.com\n"
+        )
+        .is_none());
+        assert!(defect("https://cdn.example/l.txt", "||a.com^\n||b.com^\n").is_none());
+    }
+
+    /// Emptying your own list file is an instruction to block nothing; an empty
+    /// remote body is a broken upstream.
+    #[test]
+    fn empty_local_file_is_valid_but_empty_remote_body_is_not() {
+        // temp_dir() rather than a literal: `/etc/...` has no drive prefix, so
+        // Path::is_absolute is false for it on Windows.
+        let local = std::env::temp_dir().join("numa-local.txt");
+        assert!(defect(&local.display().to_string(), "# all clear\n").is_none());
+        assert!(defect("https://cdn.example/list.txt", "").is_some());
+    }
+
     #[test]
     fn heap_bytes_grows_with_domains() {
         let mut store = BlocklistStore::new(
@@ -563,6 +645,8 @@ async fn fetch_once(client: &reqwest::Client, url: &str) -> Result<String, Strin
         .get(url)
         .send()
         .await
+        .map_err(|e| format_error_chain(&e))?
+        .error_for_status()
         .map_err(|e| format_error_chain(&e))?;
     resp.text().await.map_err(|e| format_error_chain(&e))
 }
@@ -584,7 +668,11 @@ mod retry_tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
-    async fn flaky_http_server(drop_first_n: usize, body: &'static str) -> SocketAddr {
+    async fn flaky_http_server(
+        drop_first_n: usize,
+        status: &'static str,
+        body: &'static str,
+    ) -> SocketAddr {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
@@ -601,7 +689,8 @@ mod retry_tests {
                     let mut buf = [0u8; 2048];
                     let _ = sock.read(&mut buf).await;
                     let response = format!(
-                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n{}",
+                        "HTTP/1.1 {}\r\nContent-Length: {}\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n{}",
+                        status,
                         body.len(),
                         body,
                     );
@@ -621,7 +710,7 @@ mod retry_tests {
     async fn retry_succeeds_on_final_attempt() {
         let body = "ads.example.com\ntracker.example.net\n";
         let delays = zero_delays();
-        let addr = flaky_http_server(delays.len(), body).await;
+        let addr = flaky_http_server(delays.len(), "200 OK", body).await;
         let client = crate::forward::default_client();
         let url = format!("http://{addr}/");
         let result = fetch_with_retry_delays(&client, &url, &delays).await;
@@ -682,10 +771,45 @@ mod retry_tests {
     #[tokio::test]
     async fn retry_gives_up_when_all_attempts_fail() {
         let delays = zero_delays();
-        let addr = flaky_http_server(delays.len() + 2, "unreachable").await;
+        let addr = flaky_http_server(delays.len() + 2, "200 OK", "unreachable").await;
         let client = crate::forward::default_client();
         let url = format!("http://{addr}/");
         let result = fetch_with_retry_delays(&client, &url, &delays).await;
         assert_eq!(result, None);
+    }
+
+    /// The issue #336 outage: jsDelivr answered 403 with a plain-text error
+    /// body, which was accepted as a successful download of zero domains.
+    #[tokio::test]
+    async fn non_2xx_is_a_failure_not_an_empty_list() {
+        let addr = flaky_http_server(
+            0,
+            "403 Forbidden",
+            "Package size exceeded the configured limit of 150 MB.",
+        )
+        .await;
+        let client = crate::forward::default_client();
+        let url = format!("http://{addr}/");
+        let result = fetch_with_retry_delays(&client, &url, &[0]).await;
+        assert_eq!(result, None, "403 body must not be taken as a blocklist");
+    }
+
+    /// CI canary. Fetches the URL actually compiled into the binary and parses
+    /// it with Numa's own parser, so a discontinued format fails here rather
+    /// than in the field.
+    #[tokio::test]
+    #[ignore = "network"]
+    async fn shipped_default_blocklist_still_loads() {
+        let lists = crate::config::default_blocklists();
+        let downloaded = download_blocklists(&lists, None).await;
+        assert_eq!(downloaded.len(), lists.len(), "a default source failed");
+        for (source, text) in &downloaded {
+            let domains = parse_blocklist(text);
+            assert!(
+                domains.len() > 100_000,
+                "default blocklist {source} parsed only {} domains",
+                domains.len()
+            );
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -573,8 +573,17 @@ fn default_blocking_enabled() -> bool {
     true
 }
 
-fn default_blocklists() -> Vec<String> {
-    vec!["https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/hosts/pro.txt".to_string()]
+/// HaGeZi discontinued the `hosts/` and `domains/` formats on 2026-08-01; the
+/// wildcard list is the maintained equivalent. Bare domains there rely on
+/// `find_in_set`'s parent-suffix match to cover subdomains, which is what the
+/// hosts format was already getting anyway. The repo is past jsDelivr's 150 MB
+/// package cap — `hosts/` already 403s there — so raw GitHub is the path least
+/// likely to be withdrawn next.
+pub(crate) fn default_blocklists() -> Vec<String> {
+    vec![
+        "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro-onlydomains.txt"
+            .to_string(),
+    ]
 }
 
 fn default_refresh_hours() -> u64 {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use log::{debug, error, info, warn};
 
-use crate::blocklist::{download_blocklists, parse_blocklist, BlocklistStore};
+use crate::blocklist::{download_blocklists, parse_blocklist, source_defect, BlocklistStore};
 use crate::bootstrap_resolver::NumaResolver;
 use crate::buffer::BytePacketBuffer;
 use crate::cache::DnsCache;
@@ -806,24 +806,46 @@ async fn load_blocklists(ctx: &ServerCtx, lists: &[String], resolver: Option<Arc
     // Parse outside the lock to avoid blocking DNS queries during parse (~100ms)
     let mut all_domains = std::collections::HashSet::new();
     let mut sources = Vec::new();
+    let mut failed = lists.len().saturating_sub(downloaded.len());
     for (source, text) in &downloaded {
         let domains = parse_blocklist(text);
+        if let Some(why) = source_defect(source, text, &domains) {
+            error!("blocklist source failed: {source} — {why}");
+            failed += 1;
+            continue;
+        }
         info!("blocklist: {} domains from {}", domains.len(), source);
         all_domains.extend(domains);
         sources.push(source.clone());
     }
     let total = all_domains.len();
 
+    // Nothing to swap in is a failure only if something broke (issue #336);
+    // sources that all loaded and parsed to nothing are a deliberately emptied
+    // list and must be allowed to clear the old one.
+    if total == 0 && failed > 0 {
+        error!(
+            "blocklist refresh failed for {failed} of {} lists — keeping {} domains already loaded",
+            lists.len(),
+            ctx.blocklist.read().unwrap().domains_loaded()
+        );
+        return;
+    }
+
+    let loaded = sources.len();
     // Swap under lock — sub-microsecond
     ctx.blocklist
         .write()
         .unwrap()
         .swap_domains(all_domains, sources);
-    info!(
-        "blocking enabled: {} unique domains from {} lists",
-        total,
-        downloaded.len()
-    );
+    if failed > 0 {
+        warn!(
+            "blocking degraded: {total} unique domains from {loaded} of {} lists",
+            lists.len()
+        );
+    } else {
+        info!("blocking enabled: {total} unique domains from {loaded} lists");
+    }
 }
 
 async fn warm_domain(ctx: &ServerCtx, domain: &str) {
@@ -878,5 +900,63 @@ mod tests {
     async fn bind_udp_listeners_rejects_empty() {
         let err = bind_udp_listeners(&[]).await.unwrap_err();
         assert!(err.to_string().contains("bind_addr is empty"));
+    }
+
+    /// Absolute so `local_path` recognises it on Windows too, where a leading
+    /// `/` is not an absolute path.
+    fn temp_path(name: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("numa_{name}_{nanos}.txt"))
+            .display()
+            .to_string()
+    }
+
+    fn temp_list(name: &str, body: &str) -> String {
+        let path = temp_path(name);
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    async fn ctx_blocking(domains: &[&str]) -> ServerCtx {
+        let ctx = crate::testutil::test_ctx().await;
+        ctx.blocklist.write().unwrap().swap_domains(
+            domains.iter().map(|d| d.to_string()).collect(),
+            vec!["seed".to_string()],
+        );
+        ctx
+    }
+
+    /// A source that cannot be read is not an instruction to stop blocking:
+    /// the working list must survive (issue #336).
+    #[tokio::test]
+    async fn failed_source_keeps_the_live_list() {
+        let ctx = ctx_blocking(&["ads.example.com"]).await;
+        let missing = temp_path("never_written");
+        load_blocklists(&ctx, std::slice::from_ref(&missing), None).await;
+        assert_eq!(ctx.blocklist.read().unwrap().domains_loaded(), 1);
+    }
+
+    /// But deliberately emptying your own list means block nothing, and must
+    /// not be mistaken for a failure.
+    #[tokio::test]
+    async fn emptied_local_list_clears_the_live_list() {
+        let ctx = ctx_blocking(&["ads.example.com"]).await;
+        let source = temp_list("emptied", "# all clear\n");
+        load_blocklists(&ctx, std::slice::from_ref(&source), None).await;
+        let _ = std::fs::remove_file(&source);
+        assert_eq!(ctx.blocklist.read().unwrap().domains_loaded(), 0);
+    }
+
+    #[tokio::test]
+    async fn healthy_local_list_is_swapped_in() {
+        let ctx = ctx_blocking(&["ads.example.com"]).await;
+        let source = temp_list("healthy", "a.com\nb.com\n");
+        load_blocklists(&ctx, std::slice::from_ref(&source), None).await;
+        let _ = std::fs::remove_file(&source);
+        assert_eq!(ctx.blocklist.read().unwrap().domains_loaded(), 2);
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -28,6 +28,7 @@ use crate::system_dns::discover_system_dns;
 use crate::udp_listener::UdpListener;
 
 const DOH_FALLBACK: &str = "https://9.9.9.9/dns-query";
+const BLOCKLIST_RETRY_SECS: u64 = 3600;
 
 /// Boot the DNS server and run until the UDP listener errors out.
 pub async fn run(config_path: String) -> crate::Result<()> {
@@ -286,14 +287,21 @@ fn spawn_background_services(
         let bl_ctx = Arc::clone(ctx);
         let bl_resolver = bootstrap_resolver.clone();
         tokio::spawn(async move {
-            load_blocklists(&bl_ctx, &blocklist_lists, Some(bl_resolver.clone())).await;
-
-            let mut interval = tokio::time::interval(Duration::from_secs(refresh_hours * 3600));
-            interval.tick().await;
-            loop {
-                interval.tick().await;
-                info!("refreshing blocklists...");
+            let mut loaded =
                 load_blocklists(&bl_ctx, &blocklist_lists, Some(bl_resolver.clone())).await;
+            loop {
+                // A refresh that left us with nothing is not blocking at all, so
+                // waiting the full cycle to try again turns a brief upstream
+                // outage into a day without blocking (issue #336).
+                let wait = if loaded {
+                    refresh_hours * 3600
+                } else {
+                    BLOCKLIST_RETRY_SECS.min(refresh_hours * 3600)
+                };
+                tokio::time::sleep(Duration::from_secs(wait)).await;
+                info!("refreshing blocklists...");
+                loaded =
+                    load_blocklists(&bl_ctx, &blocklist_lists, Some(bl_resolver.clone())).await;
             }
         });
     }
@@ -800,7 +808,13 @@ async fn network_watch_loop(ctx: Arc<ServerCtx>) {
     }
 }
 
-async fn load_blocklists(ctx: &ServerCtx, lists: &[String], resolver: Option<Arc<NumaResolver>>) {
+/// Returns `false` only when a failure left nothing loaded at all. An emptied
+/// list is a successful load of nothing, and has nothing to retry.
+async fn load_blocklists(
+    ctx: &ServerCtx,
+    lists: &[String],
+    resolver: Option<Arc<NumaResolver>>,
+) -> bool {
     let downloaded = download_blocklists(lists, resolver).await;
 
     // Parse outside the lock to avoid blocking DNS queries during parse (~100ms)
@@ -824,12 +838,12 @@ async fn load_blocklists(ctx: &ServerCtx, lists: &[String], resolver: Option<Arc
     // sources that all loaded and parsed to nothing are a deliberately emptied
     // list and must be allowed to clear the old one.
     if total == 0 && failed > 0 {
+        let kept = ctx.blocklist.read().unwrap().domains_loaded();
         error!(
-            "blocklist refresh failed for {failed} of {} lists — keeping {} domains already loaded",
-            lists.len(),
-            ctx.blocklist.read().unwrap().domains_loaded()
+            "blocklist refresh failed for {failed} of {} lists — keeping {kept} domains already loaded",
+            lists.len()
         );
-        return;
+        return kept > 0;
     }
 
     let loaded = sources.len();
@@ -846,6 +860,7 @@ async fn load_blocklists(ctx: &ServerCtx, lists: &[String], resolver: Option<Arc
     } else {
         info!("blocking enabled: {total} unique domains from {loaded} lists");
     }
+    true
 }
 
 async fn warm_domain(ctx: &ServerCtx, domain: &str) {
@@ -936,8 +951,23 @@ mod tests {
     async fn failed_source_keeps_the_live_list() {
         let ctx = ctx_blocking(&["ads.example.com"]).await;
         let missing = temp_path("never_written");
-        load_blocklists(&ctx, std::slice::from_ref(&missing), None).await;
+        let loaded = load_blocklists(&ctx, std::slice::from_ref(&missing), None).await;
         assert_eq!(ctx.blocklist.read().unwrap().domains_loaded(), 1);
+        assert!(
+            loaded,
+            "a surviving list is still blocking, so wait a full cycle"
+        );
+    }
+
+    /// The same failure with nothing to fall back on leaves blocking inactive,
+    /// which is the one case that must not wait a full refresh cycle.
+    #[tokio::test]
+    async fn total_failure_with_no_live_list_asks_for_a_retry() {
+        let ctx = ctx_blocking(&[]).await;
+        let missing = temp_path("never_written_either");
+        let loaded = load_blocklists(&ctx, std::slice::from_ref(&missing), None).await;
+        assert_eq!(ctx.blocklist.read().unwrap().domains_loaded(), 0);
+        assert!(!loaded);
     }
 
     /// But deliberately emptying your own list means block nothing, and must
@@ -946,9 +976,13 @@ mod tests {
     async fn emptied_local_list_clears_the_live_list() {
         let ctx = ctx_blocking(&["ads.example.com"]).await;
         let source = temp_list("emptied", "# all clear\n");
-        load_blocklists(&ctx, std::slice::from_ref(&source), None).await;
+        let loaded = load_blocklists(&ctx, std::slice::from_ref(&source), None).await;
         let _ = std::fs::remove_file(&source);
         assert_eq!(ctx.blocklist.read().unwrap().domains_loaded(), 0);
+        assert!(
+            loaded,
+            "an emptied list loaded fine, there is nothing to retry"
+        );
     }
 
     #[tokio::test]

--- a/tests/docker/self-resolver-loop.sh
+++ b/tests/docker/self-resolver-loop.sh
@@ -8,7 +8,7 @@
 #   container /etc/resolv.conf  →  nameserver 127.0.0.1
 #   numa bound on :53           →  upstream DoH by hostname (quad9)
 #   numa boots → spawns blocklist download
-#   reqwest::get → getaddrinfo("cdn.jsdelivr.net")
+#   reqwest::get → getaddrinfo("raw.githubusercontent.com")
 #     → loopback UDP :53 → numa → cache miss → DoH upstream
 #     → getaddrinfo("dns.quad9.net") → same loop → glibc EAI_AGAIN
 #
@@ -81,7 +81,7 @@ timeout_ms = 3000
 
 [blocking]
 enabled = true
-lists = ["https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/hosts/pro.txt"]
+lists = ["https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro-onlydomains.txt"]
 CONF
 
 mkdir -p /tmp/numa-data


### PR DESCRIPTION
Closes #336.

HaGeZi discontinued the `hosts/` and `domains/` formats on 2026-08-01. The compiled-in default 403s behind jsDelivr and 404s on raw GitHub, so every deployment on the default has had no ad blocking since then.

It was silent because `fetch_once` never checked HTTP status. jsDelivr's 145-byte error page came back as a successful download, parsed to zero domains, and logged at INFO like a normal load.

Four changes:

- `error_for_status()` on fetch, so non-2xx is a failure rather than a list. This is the bug.
- Reject bodies that are not list-shaped. `error_for_status` only catches the failures that announce themselves; a soft error served as 200 still parses to a domain or two and would replace a working list. The test is the *share of entry lines that parse as domains*, never the domain count, so a twelve-domain personal list stays valid while a small nginx 404 page does not.
- Keep the live list only when a source actually failed. The old code called `swap_domains` unconditionally, so a total failure at the 24h tick *wiped* a working in-memory list, and a failure at startup stamped `last_refresh` on nothing — which is how this presented on the dashboard as a normal refresh.
- Default becomes `wildcard/pro-onlydomains.txt`, the maintained equivalent.

## the shape check

Threshold is 50%, not something token. Every format `parse_blocklist` handles — hosts lines, bare domains, adblock `||x^` — yields a domain from essentially every entry line, so half is a wide margin against any real list. It has to be that high to work: a small nginx 404 page yields one domain-shaped token from about seven entry lines, and anything under ~15% lets that through.

One asymmetry worth flagging. An **empty** body is valid for a `file://` source and a defect for a remote one. Emptying your own list file is an instruction to block nothing and must be allowed to clear the old set; an empty body from a CDN is a broken upstream and is never an instruction. Without that split, "all sources loaded fine and parsed to nothing" would let an empty 200 wipe a working list.

## on the list swap

The wildcard list is the more honest shape, not just the surviving one. `find_in_set` already does parent-suffix matching, so hosts-format FQDNs were being treated as wildcards regardless — the old default was blocking subdomains `hosts(5)` never implied. 218k wildcard entries cover what 385k enumerated entries did, in less heap, which matters on the Pi Zero.

Served from raw.githubusercontent rather than jsDelivr. The repo is past jsDelivr's 150 MB package cap — `hosts/` already 403s there while `wildcard/` still serves — so raw GitHub is the path least likely to be withdrawn next. `numa.toml` documents the jsDelivr mirror for networks where raw GitHub is unreachable.

## canary

Scheduled workflow fetches the URL actually compiled into `default_blocklists()` and parses it with `parse_blocklist`, so a discontinued format fails in CI instead of in the field. It goes through the real constant and the real parser rather than a URL copied into the workflow.

No name filter on the test run — a filter matching nothing exits 0, which would have made the canary silently pass forever if the test were renamed.

## what i left out

Partial-failure handling. One dead source out of two still swaps the smaller union in, with a `blocking degraded` warning rather than a refusal.

An earlier version of this branch refused the whole refresh if any source failed. That freezes every source forever on a permanently broken one — a `file://` path you deleted, say — and it does nothing after a restart, since the store starts empty and the guard only applies once something is loaded. Deciding whether a shrunken union is real needs to know what each source contributed last time, so it belongs with the on-disk cache, not before it. With the shipped single-source default, partial is total anyway.

## verification

- Red-first on all three guards: removing `error_for_status()` fails `non_2xx_is_a_failure_not_an_empty_list`; stubbing `source_defect` to `None` fails the three shape tests; relaxing the keep condition back to "any empty union" fails `emptied_local_list_clears_the_live_list`.
- Pointing the canary at the old `hosts/pro.txt` URL fails it, so it would have caught this.
- `load_blocklists` itself is now covered via `testutil::test_ctx()` — failed source keeps the list, emptied local list clears it, healthy list swaps in.
- 583 lib tests pass.
- End to end: 218,748 domains load; a list entry and its subdomain both sinkhole to `0.0.0.0`; an unlisted domain resolves normally.

## follow-up

Per-source last-known-good cache, startup restoration, partial-failure handling on top of it, and stale/degraded status in `/stats` and the dashboard. That is what makes a restart survive a dead upstream; this PR does not claim to.
