### PR TITLE
feat(blocking): keep a last-known-good copy of every remote list

### DIFF
--- a/numa.toml
+++ b/numa.toml
@@ -115,7 +115,11 @@ api_port = 5380
 
 # [blocking]
 # enabled = true               # set to false to disable ad blocking
-# refresh_hours = 24
+# refresh_hours = 24           # a refresh that leaves nothing loaded retries in
+#                              # an hour instead of waiting the full cycle.
+# The last good copy of each remote list is kept under <data_dir>/blocklists so
+# a restart while the upstream is down still blocks. It never expires: age is
+# reported in the dashboard, but an old list always beats no list.
 # Every entry blocks the domain and all its subdomains, whatever the list
 # format — hosts lines, bare domains, adblock syntax, remote or local.
 # lists = [

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1487,19 +1487,39 @@ function shortenUrl(url) {
   } catch { return url; }
 }
 
+// Copy carries the truth, colour only carries urgency — a state must never be
+// distinguishable by colour alone.
+// One missed 24h cycle is a blip; two is a pattern; a week is real drift. The
+// wording never changes with age, only the colour — a stale list is still
+// blocking, so the copy must not start claiming otherwise.
+const STALE_AMBER_SECS = 48 * 3600;
+const STALE_ROSE_SECS = 7 * 86400;
+
+function oldestStaleAge(info) {
+  const ages = ((info && info.list_sources) || [])
+    .filter(s => s.status === 'stale' && s.last_ok_secs_ago != null)
+    .map(s => s.last_ok_secs_ago);
+  return ages.length ? Math.max(...ages) : null;
+}
+
 // A source that has not been fetched yet is not a broken one — saying so was
 // the same mistake as rendering a dead list as "loading".
 function sourceNote(s) {
   if (s.status === 'ok') return '';
+  const age = s.last_ok_secs_ago != null ? `${formatUptime(s.last_ok_secs_ago)} ago` : null;
   if (s.status === 'pending') {
     return '<span style="color:var(--text-dim);margin-left:0.5rem;">not fetched yet</span>';
   }
-  const when = s.last_ok_secs_ago != null ? `last ok ${formatUptime(s.last_ok_secs_ago)} ago` : 'never loaded';
-  return `<span style="color:var(--rose);margin-left:0.5rem;">${h(s.error || 'failed')} &middot; ${when}</span>`;
+  const colour = s.status === 'stale' ? 'var(--amber)' : 'var(--rose)';
+  const when = age ? `${s.status === 'stale' ? 'cached' : 'last ok'} ${age}` : 'never loaded';
+  return `<span style="color:${colour};margin-left:0.5rem;">${h(s.error || 'failed')} &middot; ${when}</span>`;
 }
 
-// Copy carries the truth, colour only carries urgency — a state must never be
-// distinguishable by colour alone.
+function formatStaleAge(secs) {
+  if (secs == null) return 'unknown age';
+  return secs < STALE_AMBER_SECS ? `${Math.round(secs / 3600)}h` : `${Math.round(secs / 86400)}d`;
+}
+
 function blockingSubline(bl, info) {
   if (bl.paused) return 'paused';
   if (!bl.enabled) return 'disabled';
@@ -1510,6 +1530,7 @@ function blockingSubline(bl, info) {
     case 'loading': return 'loading…';
     case 'failed': return 'all lists failed · not blocking';
     case 'degraded': return `${loaded} · ${sources.filter(s => s.status === 'failed').length} of ${sources.length} lists failing`;
+    case 'stale': return `${loaded} · stale ${formatStaleAge(oldestStaleAge(info))}`;
     default: return loaded;
   }
 }
@@ -1518,6 +1539,11 @@ function blockingAlarm(info) {
   if (!info) return '';
   if (info.health === 'failed') return 'var(--rose)';
   if (info.health === 'degraded') return 'var(--amber)';
+  if (info.health === 'stale') {
+    const age = oldestStaleAge(info);
+    if (age > STALE_ROSE_SECS) return 'var(--rose)';
+    if (age > STALE_AMBER_SECS) return 'var(--amber)';
+  }
   return '';
 }
 

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -20,6 +20,9 @@ pub struct BlocklistStore {
 enum SourceOutcome {
     Pending,
     Ok,
+    /// Live fetch failed, but a cached copy is being served. The string is why
+    /// the fetch failed, which is still worth showing.
+    Stale(String),
     Failed(String),
 }
 
@@ -29,14 +32,23 @@ enum SourceOutcome {
 struct SourceState {
     url: String,
     outcome: SourceOutcome,
-    last_ok: Option<Instant>,
+    /// Wall clock, not `Instant`, because it has to survive a restart to say
+    /// anything useful about a cached copy.
+    last_ok_unix: Option<u64>,
+}
+
+/// What a single source did on the last refresh.
+pub enum SourceResult {
+    Loaded,
+    Cached { error: String, fetched_unix: u64 },
+    Failed(String),
 }
 
 #[derive(serde::Serialize)]
 pub struct SourceStatus {
     pub url: String,
-    /// `pending` | `ok` | `failed`. One field rather than a pair of booleans,
-    /// so a not-yet-fetched source cannot read as a failed one.
+    /// `pending` | `ok` | `stale` | `failed`. One field rather than a pair of
+    /// booleans, so a not-yet-fetched source cannot read as a failed one.
     pub status: &'static str,
     pub error: Option<String>,
     pub last_ok_secs_ago: Option<u64>,
@@ -178,26 +190,31 @@ impl BlocklistStore {
             .map(|url| SourceState {
                 url: url.clone(),
                 outcome: SourceOutcome::Pending,
-                last_ok: None,
+                last_ok_unix: None,
             })
             .collect();
     }
 
-    /// `None` means the source loaded. Recorded whether or not the domains were
-    /// swapped in, because a refresh that keeps the live list still has to say
-    /// why it kept it.
-    pub fn record_outcomes(&mut self, outcomes: &[(String, Option<String>)]) {
-        let now = Instant::now();
-        for (url, error) in outcomes {
+    /// Recorded whether or not the domains were swapped in, because a refresh
+    /// that keeps the live list still has to say why it kept it.
+    pub fn record_outcomes(&mut self, outcomes: &[(String, SourceResult)]) {
+        for (url, result) in outcomes {
             let Some(state) = self.sources.iter_mut().find(|s| &s.url == url) else {
                 continue;
             };
-            match error {
-                None => {
+            match result {
+                SourceResult::Loaded => {
                     state.outcome = SourceOutcome::Ok;
-                    state.last_ok = Some(now);
+                    state.last_ok_unix = Some(crate::blocklist_cache::now_unix());
                 }
-                Some(e) => state.outcome = SourceOutcome::Failed(e.clone()),
+                SourceResult::Cached {
+                    error,
+                    fetched_unix,
+                } => {
+                    state.outcome = SourceOutcome::Stale(error.clone());
+                    state.last_ok_unix = Some(*fetched_unix);
+                }
+                SourceResult::Failed(e) => state.outcome = SourceOutcome::Failed(e.clone()),
             }
         }
     }
@@ -219,20 +236,29 @@ impl BlocklistStore {
         {
             return "loading";
         }
-        let failed = self
+        if self
             .sources
             .iter()
-            .any(|s| matches!(s.outcome, SourceOutcome::Failed(_)));
-        if !failed {
-            return "ok";
+            .any(|s| matches!(s.outcome, SourceOutcome::Failed(_)))
+        {
+            // Domains present means something is still being blocked, from the
+            // sources that did load or from a list a failed refresh left alone.
+            return if self.domains.is_empty() {
+                "failed"
+            } else {
+                "degraded"
+            };
         }
-        // Domains present means something is still being blocked, from the
-        // sources that did load or from a list a failed refresh left alone.
-        if self.domains.is_empty() {
-            "failed"
-        } else {
-            "degraded"
+        // A cached copy still blocks, so this ranks below a source contributing
+        // nothing at all. Age is reported, never a reason to refuse the copy.
+        if self
+            .sources
+            .iter()
+            .any(|s| matches!(s.outcome, SourceOutcome::Stale(_)))
+        {
+            return "stale";
         }
+        "ok"
     }
 
     pub fn domains_loaded(&self) -> usize {
@@ -311,13 +337,16 @@ impl BlocklistStore {
                     status: match s.outcome {
                         SourceOutcome::Pending => "pending",
                         SourceOutcome::Ok => "ok",
+                        SourceOutcome::Stale(_) => "stale",
                         SourceOutcome::Failed(_) => "failed",
                     },
                     error: match &s.outcome {
-                        SourceOutcome::Failed(e) => Some(e.clone()),
+                        SourceOutcome::Failed(e) | SourceOutcome::Stale(e) => Some(e.clone()),
                         _ => None,
                     },
-                    last_ok_secs_ago: s.last_ok.map(|t| t.elapsed().as_secs()),
+                    last_ok_secs_ago: s
+                        .last_ok_unix
+                        .map(|t| crate::blocklist_cache::now_unix().saturating_sub(t)),
                 })
                 .collect(),
             last_refresh_secs_ago: self.last_refresh.map(|t| t.elapsed().as_secs()),
@@ -692,7 +721,10 @@ mod tests {
             "not yet fetched is not the same as failed"
         );
 
-        store.record_outcomes(&[(a.to_string(), None), (b.to_string(), None)]);
+        store.record_outcomes(&[
+            (a.to_string(), SourceResult::Loaded),
+            (b.to_string(), SourceResult::Loaded),
+        ]);
         assert_eq!(
             store.health(),
             "ok",
@@ -700,7 +732,7 @@ mod tests {
         );
 
         store.swap_domains(["ads.example.com".to_string()].into_iter().collect());
-        store.record_outcomes(&[(b.to_string(), Some("HTTP 404".to_string()))]);
+        store.record_outcomes(&[(b.to_string(), SourceResult::Failed("HTTP 404".to_string()))]);
         assert_eq!(
             store.health(),
             "degraded",
@@ -720,7 +752,7 @@ mod tests {
         store.set_sources(&[a.to_string(), a.to_string()]);
         assert_eq!(store.stats().list_sources.len(), 1, "deduplicated");
 
-        store.record_outcomes(&[(a.to_string(), None)]);
+        store.record_outcomes(&[(a.to_string(), SourceResult::Loaded)]);
         assert_eq!(store.health(), "ok");
     }
 
@@ -745,8 +777,8 @@ mod tests {
         let (a, b) = ("https://a.example/l.txt", "https://b.example/l.txt");
         store.set_sources(&[a.to_string(), b.to_string()]);
         store.record_outcomes(&[
-            (a.to_string(), None),
-            (b.to_string(), Some("HTTP 404".to_string())),
+            (a.to_string(), SourceResult::Loaded),
+            (b.to_string(), SourceResult::Failed("HTTP 404".to_string())),
         ]);
 
         let stats = store.stats();
@@ -761,14 +793,57 @@ mod tests {
         assert!(bad.last_ok_secs_ago.is_none(), "it never loaded");
     }
 
+    /// Serving a cached copy is not a failure — it is still blocking, and the
+    /// cache is never refused for being old.
+    #[test]
+    fn a_cached_copy_reports_stale_and_still_counts_as_blocking() {
+        let mut store = empty_store();
+        let a = "https://a.example/l.txt";
+        store.set_sources(&[a.to_string()]);
+        store.swap_domains(["ads.example.com".to_string()].into_iter().collect());
+        store.record_outcomes(&[(
+            a.to_string(),
+            SourceResult::Cached {
+                error: "HTTP 404".to_string(),
+                fetched_unix: crate::blocklist_cache::now_unix() - 3 * 86400,
+            },
+        )]);
+
+        assert_eq!(store.health(), "stale");
+        let s = &store.stats().list_sources[0];
+        assert_eq!(s.status, "stale", "a served cache is still blocking");
+        assert_eq!(s.error.as_deref(), Some("HTTP 404"), "why it went stale");
+        assert!(s.last_ok_secs_ago.unwrap() >= 3 * 86400, "age survives");
+    }
+
+    /// A source contributing nothing is worse news than an old copy.
+    #[test]
+    fn a_dead_source_outranks_a_stale_one() {
+        let mut store = empty_store();
+        let (a, b) = ("https://a.example/l.txt", "https://b.example/l.txt");
+        store.set_sources(&[a.to_string(), b.to_string()]);
+        store.swap_domains(["ads.example.com".to_string()].into_iter().collect());
+        store.record_outcomes(&[
+            (
+                a.to_string(),
+                SourceResult::Cached {
+                    error: "timeout".to_string(),
+                    fetched_unix: crate::blocklist_cache::now_unix(),
+                },
+            ),
+            (b.to_string(), SourceResult::Failed("HTTP 404".to_string())),
+        ]);
+        assert_eq!(store.health(), "degraded");
+    }
+
     /// A source that recovers must stop reporting the old error.
     #[test]
     fn a_recovered_source_clears_its_error() {
         let mut store = empty_store();
         let a = "https://a.example/l.txt";
         store.set_sources(&[a.to_string()]);
-        store.record_outcomes(&[(a.to_string(), Some("timeout".to_string()))]);
-        store.record_outcomes(&[(a.to_string(), None)]);
+        store.record_outcomes(&[(a.to_string(), SourceResult::Failed("timeout".to_string()))]);
+        store.record_outcomes(&[(a.to_string(), SourceResult::Loaded)]);
 
         let stats = store.stats();
         assert_eq!(stats.list_sources[0].status, "ok");

--- a/src/blocklist_cache.rs
+++ b/src/blocklist_cache.rs
@@ -86,13 +86,11 @@ impl BlocklistCache {
         };
         for entry in entries.flatten() {
             let name = entry.file_name();
-            match name.to_str() {
-                Some(name) if !keep.contains(name) => {
-                    if std::fs::remove_file(entry.path()).is_ok() {
-                        info!("dropped unused blocklist cache file {name}");
-                    }
-                }
-                _ => {}
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            if !keep.contains(name) && std::fs::remove_file(entry.path()).is_ok() {
+                info!("dropped unused blocklist cache file {name}");
             }
         }
     }

--- a/src/blocklist_cache.rs
+++ b/src/blocklist_cache.rs
@@ -1,0 +1,233 @@
+//! Last-known-good copy of every remote blocklist.
+//!
+//! A box that restarts while its upstream is down otherwise blocks nothing at
+//! all, and no amount of in-memory care survives a process that is not running
+//! yet (issue #336). The cache never expires: age is reported, but it is never
+//! a reason to refuse a copy, because the only alternative to an old list is
+//! no list.
+//!
+//! One file per remote source, named for a hash of the URL rather than the URL
+//! itself. A readable name has to be sanitised and truncated, and two long URLs
+//! that truncate alike would then share a file — which costs the loser exactly
+//! the fallback the cache exists to provide. Age is the file's mtime, so there
+//! is no second file to keep in step with the body.
+//!
+//! Local file sources are not cached — the file *is* the user's copy, and
+//! duplicating it into the data dir would be surprising.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use log::info;
+use ring::digest::{digest, SHA256};
+
+pub struct BlocklistCache {
+    dir: PathBuf,
+}
+
+pub struct CachedList {
+    pub text: String,
+    pub fetched_unix: u64,
+}
+
+impl BlocklistCache {
+    pub fn new(data_dir: &Path) -> Self {
+        BlocklistCache {
+            dir: data_dir.join("blocklists"),
+        }
+    }
+
+    /// SHA-256 of the URL, truncated. Not `DefaultHasher`, whose output is not
+    /// promised to be stable across Rust releases — a toolchain bump would
+    /// rename every file and silently discard every last-known-good copy.
+    fn key(url: &str) -> String {
+        digest(&SHA256, url.as_bytes()).as_ref()[..16]
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect()
+    }
+
+    fn path(&self, url: &str) -> PathBuf {
+        self.dir.join(format!("{}.txt", Self::key(url)))
+    }
+
+    pub fn store(&self, url: &str, text: &str) {
+        if !is_remote(url) {
+            return;
+        }
+        crate::persist::save_text(&self.path(url), text);
+    }
+
+    pub fn load(&self, url: &str) -> Option<CachedList> {
+        if !is_remote(url) {
+            return None;
+        }
+        let path = self.path(url);
+        let text = std::fs::read_to_string(&path).ok()?;
+        let fetched_unix = mtime_unix(&path)?;
+        info!(
+            "serving {url} from cache ({})",
+            format_age(now_unix().saturating_sub(fetched_unix))
+        );
+        Some(CachedList { text, fetched_unix })
+    }
+
+    /// Drop everything that is not a copy of a currently configured source.
+    /// Editing a list URL would otherwise leave its copy in the data dir
+    /// forever, and this sweeps a `.tmp` left by a crashed write too.
+    pub fn prune(&self, urls: &[String]) {
+        let keep: HashSet<String> = urls
+            .iter()
+            .filter(|u| is_remote(u))
+            .map(|u| format!("{}.txt", Self::key(u)))
+            .collect();
+        let Ok(entries) = std::fs::read_dir(&self.dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            match name.to_str() {
+                Some(name) if !keep.contains(name) => {
+                    if std::fs::remove_file(entry.path()).is_ok() {
+                        info!("dropped unused blocklist cache file {name}");
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Only remote lists are cached; a local path is already the user's own copy.
+fn is_remote(source: &str) -> bool {
+    source.starts_with("http://") || source.starts_with("https://")
+}
+
+fn mtime_unix(path: &Path) -> Option<u64> {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
+}
+
+pub fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn format_age(secs: u64) -> String {
+    match secs {
+        s if s < 3600 => format!("{}m ago", s / 60),
+        s if s < 86400 => format!("{}h ago", s / 3600),
+        s => format!("{}d ago", s / 86400),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("numa_blcache_{name}_{nanos}"))
+    }
+
+    #[test]
+    fn round_trips_a_list() {
+        let dir = temp_dir("roundtrip");
+        let cache = BlocklistCache::new(&dir);
+        let url = "https://example.com/list.txt";
+        cache.store(url, "ads.example.com\n");
+
+        let got = cache.load(url).expect("cached copy");
+        assert_eq!(got.text, "ads.example.com\n");
+        assert!(got.fetched_unix > 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_url_never_stored_is_a_miss() {
+        let dir = temp_dir("miss");
+        let cache = BlocklistCache::new(&dir);
+        assert!(cache.load("https://example.com/absent.txt").is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_local_source_is_not_cached() {
+        let dir = temp_dir("local");
+        let cache = BlocklistCache::new(&dir);
+        let url = "file:///etc/hosts";
+        cache.store(url, "ads.example.com\n");
+        assert!(cache.load(url).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Two long URLs sharing a prefix would truncate alike under a readable
+    /// name. Each must still keep its own copy, or the loser has no fallback
+    /// when its upstream goes down.
+    #[test]
+    fn urls_that_share_a_long_prefix_keep_separate_copies() {
+        let dir = temp_dir("collide");
+        let cache = BlocklistCache::new(&dir);
+        let long = "https://example.com/".to_string() + &"a".repeat(200);
+        let other = long.clone() + "-different";
+
+        cache.store(&long, "one.example\n");
+        cache.store(&other, "two.example\n");
+        assert_eq!(cache.load(&long).unwrap().text, "one.example\n");
+        assert_eq!(cache.load(&other).unwrap().text, "two.example\n");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Editing a list URL must not leave its copy behind forever.
+    #[test]
+    fn prune_drops_copies_of_sources_no_longer_configured() {
+        let dir = temp_dir("prune");
+        let cache = BlocklistCache::new(&dir);
+        let (kept, dropped) = ("https://a.example/l.txt", "https://b.example/l.txt");
+        cache.store(kept, "one.example\n");
+        cache.store(dropped, "two.example\n");
+
+        cache.prune(&[kept.to_string()]);
+        assert!(cache.load(kept).is_some(), "still configured");
+        assert!(cache.load(dropped).is_none(), "no longer configured");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A local source contributes no key, so pruning must not read it as an
+    /// instruction to drop every remote copy.
+    #[test]
+    fn prune_keeps_remote_copies_alongside_a_local_source() {
+        let dir = temp_dir("prune_local");
+        let cache = BlocklistCache::new(&dir);
+        let url = "https://a.example/l.txt";
+        cache.store(url, "one.example\n");
+
+        cache.prune(&[url.to_string(), "file:///etc/hosts".to_string()]);
+        assert!(cache.load(url).is_some());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn prune_sweeps_a_tmp_file_left_by_a_crashed_write() {
+        let dir = temp_dir("prune_tmp");
+        let cache = BlocklistCache::new(&dir);
+        let url = "https://a.example/l.txt";
+        cache.store(url, "one.example\n");
+        let orphan = dir.join("blocklists").join("deadbeef.txt.tmp");
+        std::fs::write(&orphan, "half written").unwrap();
+
+        cache.prune(&[url.to_string()]);
+        assert!(!orphan.exists());
+        assert!(cache.load(url).is_some());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod acl;
 pub mod api;
 pub mod api_auth;
 pub mod blocklist;
+pub mod blocklist_cache;
 pub mod bootstrap_resolver;
 pub mod buffer;
 pub mod cache;

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -45,8 +45,22 @@ pub fn save_json<T: Serialize>(path: &Path, value: &T) {
     }
 }
 
+/// Same durability as `save_json`, for payloads that are not JSON.
+pub fn save_text(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Err(e) = write_atomic(path, contents) {
+        warn!("failed to write {path:?}: {e}");
+    }
+}
+
 fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
-    let tmp = path.with_extension("json.tmp");
+    // Appended, not `with_extension`, so a non-JSON payload keeps its own
+    // extension and two files in the same dir cannot collide on the temp name.
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".tmp");
+    let tmp = std::path::PathBuf::from(tmp);
     let mut file = std::fs::File::create(&tmp)?;
     file.write_all(contents.as_bytes())?;
     file.sync_all()?;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -10,7 +10,10 @@ use std::time::Duration;
 
 use log::{debug, error, info, warn};
 
-use crate::blocklist::{download_blocklists, parse_blocklist, source_defect, BlocklistStore};
+use crate::blocklist::{
+    download_blocklists, parse_blocklist, source_defect, BlocklistStore, SourceResult,
+};
+use crate::blocklist_cache::BlocklistCache;
 use crate::bootstrap_resolver::NumaResolver;
 use crate::buffer::BytePacketBuffer;
 use crate::cache::DnsCache;
@@ -826,26 +829,49 @@ async fn load_blocklists(
     let mut all_domains = std::collections::HashSet::new();
     let mut outcomes = Vec::with_capacity(downloaded.len());
     let mut failed = 0;
+    let mut stale = 0;
+    let cache = BlocklistCache::new(&ctx.data_dir);
     for (source, fetched) in &downloaded {
-        let text = match fetched {
-            Ok(text) => text,
-            Err(why) => {
-                failed += 1;
-                outcomes.push((source.clone(), Some(why.clone())));
-                continue;
+        let live_error = match fetched {
+            Err(why) => why.clone(),
+            Ok(text) => {
+                let domains = parse_blocklist(text);
+                match source_defect(source, text, &domains) {
+                    Some(why) => {
+                        error!("blocklist source failed: {source} — {why}");
+                        "not a domain list".to_string()
+                    }
+                    None => {
+                        info!("blocklist: {} domains from {}", domains.len(), source);
+                        cache.store(source, text);
+                        all_domains.extend(domains);
+                        outcomes.push((source.clone(), SourceResult::Loaded));
+                        continue;
+                    }
+                }
             }
         };
-        let domains = parse_blocklist(text);
-        if let Some(why) = source_defect(source, text, &domains) {
-            error!("blocklist source failed: {source} — {why}");
-            failed += 1;
-            outcomes.push((source.clone(), Some("not a domain list".to_string())));
-            continue;
+        // A stale list still blocks; nothing at all does not. The cached copy
+        // is never refused for being old (issue #336).
+        match cache.load(source) {
+            Some(cached) => {
+                stale += 1;
+                all_domains.extend(parse_blocklist(&cached.text));
+                outcomes.push((
+                    source.clone(),
+                    SourceResult::Cached {
+                        error: live_error,
+                        fetched_unix: cached.fetched_unix,
+                    },
+                ));
+            }
+            None => {
+                failed += 1;
+                outcomes.push((source.clone(), SourceResult::Failed(live_error)));
+            }
         }
-        info!("blocklist: {} domains from {}", domains.len(), source);
-        all_domains.extend(domains);
-        outcomes.push((source.clone(), None));
     }
+    cache.prune(lists);
     let total = all_domains.len();
 
     // Nothing to swap in is a failure only if something broke (issue #336);
@@ -863,15 +889,25 @@ async fn load_blocklists(
         return kept > 0;
     }
 
-    let loaded = outcomes.len() - failed;
+    // Live only. A cached source is contributing domains but is not evidence
+    // its upstream works, and counting it as loaded is the overstatement this
+    // reporting exists to remove.
+    let loaded = outcomes.len() - failed - stale;
     // Swap under lock — sub-microsecond
     let mut store = ctx.blocklist.write().unwrap();
     store.record_outcomes(&outcomes);
     store.swap_domains(all_domains);
     drop(store);
     if failed > 0 {
+        // Spells out stale too — the degraded branch wins the `if`, so a box
+        // that is both would otherwise never mention its cached lists.
         warn!(
-            "blocking degraded: {total} unique domains from {loaded} of {} lists",
+            "blocking degraded: {total} unique domains, {loaded} of {} lists live, {stale} from cache, {failed} failed",
+            lists.len()
+        );
+    } else if stale > 0 {
+        warn!(
+            "blocking stale: {total} unique domains, {stale} of {} lists served from cache",
             lists.len()
         );
     } else {


### PR DESCRIPTION
Stacked on #339, which carries the reporting half. **Review #339 first**; this PR's diff is the cache only.

Closes the part of #336 that reporting cannot reach: a box that restarts while its upstream is down blocks nothing at all and cannot recover until the upstream does. No amount of in-memory care survives a process that is not running yet.

Scope note: this does **not** help a genuinely fresh install — there is no cached copy on a box that has never fetched. What it covers is a box that has run before and restarts during an outage, which is the common shape (a laptop restarts daily; #336's outage was permanent).

Every remote list that loads and validates is written to `<data_dir>/blocklists` via the existing atomic temp-and-rename. When a live fetch fails, the cached copy is served and the source reports `stale` with why the fetch failed and how old the copy is.

The cache **never expires**. Age is reported; it is never a reason to refuse a copy, because the only alternative to an old list is no list. `degraded` outranks `stale` — a source contributing nothing is worse news than one contributing an old copy.

## on the file layout

One file per source, named for a truncated SHA-256 of the URL, and nothing else.

The readable-filename version of this cost more than it returned. A readable name has to be sanitised and truncated, two long URLs that truncate alike then share a file, and the loser of that collision is left with no fallback during its outage — which is the entire point of the cache. That needed a hash suffix to avoid, a stored URL to detect what the hash missed, a mismatch branch, and two tests. Hashing the whole URL removes the case instead of detecting it. `ls` no longer tells you which list is which; `grep -l` in the directory does.

SHA-256 rather than `DefaultHasher`, whose output is not promised to be stable across releases — a toolchain bump would rename every file and silently discard every last-known-good copy. `ring` is already a dependency (`health.rs` uses it for the CA fingerprint).

Age is the file's mtime, so there is no sidecar to keep in step with the body and no crash window between writing the two.

Copies are pruned against the configured sources on every refresh, so editing a list URL no longer leaves its copy in the data dir forever. The sweep takes a `.tmp` from a crashed write with it.

Local file sources are not cached: the file is already the user's copy, and duplicating it into the data dir would be surprising. `last_ok` became wall clock rather than `Instant`, because "cached 3d ago" has to mean something across the restart that motivates the cache.

## logging

The degraded line counts live lists only and spells out the cached and failed tallies beside them. It previously reported cached sources as loaded, and since the degraded branch wins the `if`, a box that was both degraded and stale never mentioned its cached lists at all.

## Dashboard

Stale sources show the cache age. Stale escalates amber at 48h (two missed cycles) and rose at 7d — **colour only, the copy never changes**, because a stale list is still blocking and must never be described as if it weren't.

## Verified end to end

`make all` green. Unit tests cover store/load, prune dropping an unconfigured source, prune keeping remotes when a local source is configured, and prune sweeping an orphaned `.tmp`.

The round trip was then run against a binary on this layout: a list served over local HTTP, the cache file backdated three days, the server killed, and numa restarted as a **fresh process**.

```
run 1  health "ok"     3 domains   blocked query -> 0.0.0.0
       one hash-named file in <data_dir>/blocklists, no sidecar
run 2  health "stale"  3 domains   blocked query -> 0.0.0.0
       error "connection failed", status "stale", last_ok_secs_ago 266420
       log: serving http://127.0.0.1:8899/list.txt from cache (3d ago)
            blocking stale: 3 unique domains, 1 of 1 lists served from cache
```

`last_ok_secs_ago` is 3d 2h, matching the backdated mtime, so the age is read from the file rather than stamped at load and it survives the restart. Run 2 is the case that had no answer before this PR.

Prune was verified separately by pointing the config at a different URL and restarting, with an orphaned `.tmp` planted first:

```
before  dbc80fe9c07f8ffeb5c878d30c7a61be.txt  (old URL) + deadbeef.txt.tmp
after   374afc86ebcc2f0f51d39377c71729bb.txt  (configured URL) only
log     dropped unused blocklist cache file dbc80fe9c07f8ffeb5c878d30c7a61be.txt
        dropped unused blocklist cache file deadbeef.txt.tmp
```

## Still deferred

Shrink detection and its acceptance path. Nothing about #336 required it, and the auto-accept-after-N-repeats policy deserves its own review.

