### PR TITLE
feat(blocking): report per-source health instead of dropping failures

### DIFF
--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1325,10 +1325,13 @@ async function refresh() {
     document.getElementById('overrideCount').textContent = stats.overrides.active;
     document.getElementById('blockedCount').textContent = formatNumber(q.blocked);
     const bl = stats.blocking;
-    document.getElementById('blockedSub').textContent =
-      bl.paused ? 'paused' :
-      !bl.enabled ? 'disabled' :
-      bl.domains_loaded > 0 ? `${formatNumber(bl.domains_loaded)} in blocklist` : 'no domains loaded';
+    const subEl = document.getElementById('blockedSub');
+    subEl.textContent = blockingSubline(bl, blockingInfo);
+    // The big number is a lifetime counter, so it keeps looking healthy while
+    // nothing is being blocked. Colour it, or the card still reads as fine.
+    const alarm = bl.enabled && !bl.paused ? blockingAlarm(blockingInfo) : '';
+    subEl.style.color = alarm;
+    document.getElementById('blockedCount').style.color = alarm;
 
     // Blocking controls — single primary button + secondary toggle
     const toggleBtn = document.getElementById('toggleBtn');
@@ -1484,6 +1487,40 @@ function shortenUrl(url) {
   } catch { return url; }
 }
 
+// A source that has not been fetched yet is not a broken one — saying so was
+// the same mistake as rendering a dead list as "loading".
+function sourceNote(s) {
+  if (s.status === 'ok') return '';
+  if (s.status === 'pending') {
+    return '<span style="color:var(--text-dim);margin-left:0.5rem;">not fetched yet</span>';
+  }
+  const when = s.last_ok_secs_ago != null ? `last ok ${formatUptime(s.last_ok_secs_ago)} ago` : 'never loaded';
+  return `<span style="color:var(--rose);margin-left:0.5rem;">${h(s.error || 'failed')} &middot; ${when}</span>`;
+}
+
+// Copy carries the truth, colour only carries urgency — a state must never be
+// distinguishable by colour alone.
+function blockingSubline(bl, info) {
+  if (bl.paused) return 'paused';
+  if (!bl.enabled) return 'disabled';
+  const loaded = `${formatNumber(bl.domains_loaded)} in blocklist`;
+  const sources = (info && info.list_sources) || [];
+  switch (info && info.health) {
+    case 'unconfigured': return 'no lists configured';
+    case 'loading': return 'loading…';
+    case 'failed': return 'all lists failed · not blocking';
+    case 'degraded': return `${loaded} · ${sources.filter(s => s.status === 'failed').length} of ${sources.length} lists failing`;
+    default: return loaded;
+  }
+}
+
+function blockingAlarm(info) {
+  if (!info) return '';
+  if (info.health === 'failed') return 'var(--rose)';
+  if (info.health === 'degraded') return 'var(--amber)';
+  return '';
+}
+
 function renderBlockingInfo(info) {
   const el = document.getElementById('blockingSources');
   const refreshEl = document.getElementById('blockingRefresh');
@@ -1494,14 +1531,15 @@ function renderBlockingInfo(info) {
   }
   const sources = info.list_sources || [];
   if (!sources.length) {
-    el.innerHTML = '';
+    el.innerHTML = '<div class="empty-state">No blocklists configured</div>';
     return;
   }
   el.innerHTML = `
     <div style="font-size:0.65rem;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-dim);margin-bottom:0.4rem;">Sources &middot; ${formatNumber(info.domains_loaded)} domains</div>
     ${sources.map(s => `
       <div style="padding:0.3rem 0;font-family:var(--font-mono);font-size:0.72rem;">
-        <a href="${s}" target="_blank" rel="noopener" style="color:var(--text-secondary);text-decoration:none;" title="${s}">${shortenUrl(s)}</a>
+        <a href="${h(s.url)}" target="_blank" rel="noopener" style="color:var(--text-secondary);text-decoration:none;" title="${h(s.url)}">${shortenUrl(s.url)}</a>
+        ${sourceNote(s)}
       </div>
     `).join('')}
   `;

--- a/src/api.rs
+++ b/src/api.rs
@@ -709,6 +709,7 @@ async fn blocking_stats(State(ctx): State<Arc<ServerCtx>>) -> Json<serde_json::V
         "paused": stats.paused,
         "domains_loaded": stats.domains_loaded,
         "allowlist_size": stats.allowlist_size,
+        "health": stats.health,
         "list_sources": stats.list_sources,
         "last_refresh_secs_ago": stats.last_refresh_secs_ago,
     }))

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -12,8 +12,34 @@ pub struct BlocklistStore {
     manual: PersistedDomainList, // UI/API-blocked domains; survives list refresh
     enabled: bool,
     paused_until: Option<Instant>,
-    list_sources: Vec<String>,
+    sources: Vec<SourceState>,
     last_refresh: Option<Instant>,
+}
+
+#[derive(Debug, PartialEq)]
+enum SourceOutcome {
+    Pending,
+    Ok,
+    Failed(String),
+}
+
+/// Every *configured* source, loaded or not. A source that fails still belongs
+/// here: dropping it is what let a dead list look like no list at all (#336).
+#[derive(Debug)]
+struct SourceState {
+    url: String,
+    outcome: SourceOutcome,
+    last_ok: Option<Instant>,
+}
+
+#[derive(serde::Serialize)]
+pub struct SourceStatus {
+    pub url: String,
+    /// `pending` | `ok` | `failed`. One field rather than a pair of booleans,
+    /// so a not-yet-fetched source cannot read as a failed one.
+    pub status: &'static str,
+    pub error: Option<String>,
+    pub last_ok_secs_ago: Option<u64>,
 }
 
 #[derive(serde::Serialize)]
@@ -59,7 +85,8 @@ pub struct BlocklistStats {
     pub paused: bool,
     pub domains_loaded: usize,
     pub allowlist_size: usize,
-    pub list_sources: Vec<String>,
+    pub health: &'static str,
+    pub list_sources: Vec<SourceStatus>,
     pub last_refresh_secs_ago: Option<u64>,
 }
 
@@ -73,7 +100,7 @@ impl BlocklistStore {
             manual,
             enabled: true,
             paused_until: None,
-            list_sources: Vec::new(),
+            sources: Vec::new(),
             last_refresh: None,
         }
     }
@@ -135,10 +162,77 @@ impl BlocklistStore {
 
     /// Atomically swap in a new domain set. Build the set outside the lock,
     /// then call this to swap — keeps lock hold time sub-microsecond.
-    pub fn swap_domains(&mut self, domains: HashSet<String>, sources: Vec<String>) {
+    pub fn swap_domains(&mut self, domains: HashSet<String>) {
         self.domains = domains;
-        self.list_sources = sources;
         self.last_refresh = Some(Instant::now());
+    }
+
+    /// Seed the configured sources before the first fetch, so an empty source
+    /// list means "none configured" rather than "none has loaded yet".
+    ///
+    /// Deduplicated: `record_outcomes` matches by URL, so a repeated entry
+    /// would leave a second state stuck `Pending` and health stuck `loading`.
+    pub fn set_sources(&mut self, urls: &[String]) {
+        self.sources = dedup_sources(urls)
+            .iter()
+            .map(|url| SourceState {
+                url: url.clone(),
+                outcome: SourceOutcome::Pending,
+                last_ok: None,
+            })
+            .collect();
+    }
+
+    /// `None` means the source loaded. Recorded whether or not the domains were
+    /// swapped in, because a refresh that keeps the live list still has to say
+    /// why it kept it.
+    pub fn record_outcomes(&mut self, outcomes: &[(String, Option<String>)]) {
+        let now = Instant::now();
+        for (url, error) in outcomes {
+            let Some(state) = self.sources.iter_mut().find(|s| &s.url == url) else {
+                continue;
+            };
+            match error {
+                None => {
+                    state.outcome = SourceOutcome::Ok;
+                    state.last_ok = Some(now);
+                }
+                Some(e) => state.outcome = SourceOutcome::Failed(e.clone()),
+            }
+        }
+    }
+
+    /// Meant to be the one field a monitor reads, so it reports the switch too:
+    /// list state is moot when nothing is being blocked on purpose, and a box
+    /// with blocking off would otherwise report `loading` forever.
+    pub fn health(&self) -> &'static str {
+        if !self.enabled {
+            return "off";
+        }
+        if self.sources.is_empty() {
+            return "unconfigured";
+        }
+        if self
+            .sources
+            .iter()
+            .any(|s| s.outcome == SourceOutcome::Pending)
+        {
+            return "loading";
+        }
+        let failed = self
+            .sources
+            .iter()
+            .any(|s| matches!(s.outcome, SourceOutcome::Failed(_)));
+        if !failed {
+            return "ok";
+        }
+        // Domains present means something is still being blocked, from the
+        // sources that did load or from a list a failed refresh left alone.
+        if self.domains.is_empty() {
+            "failed"
+        } else {
+            "degraded"
+        }
     }
 
     pub fn domains_loaded(&self) -> usize {
@@ -208,10 +302,38 @@ impl BlocklistStore {
             paused: self.is_paused(),
             domains_loaded: self.domains.len(),
             allowlist_size: self.allowlist.len(),
-            list_sources: self.list_sources.clone(),
+            health: self.health(),
+            list_sources: self
+                .sources
+                .iter()
+                .map(|s| SourceStatus {
+                    url: s.url.clone(),
+                    status: match s.outcome {
+                        SourceOutcome::Pending => "pending",
+                        SourceOutcome::Ok => "ok",
+                        SourceOutcome::Failed(_) => "failed",
+                    },
+                    error: match &s.outcome {
+                        SourceOutcome::Failed(e) => Some(e.clone()),
+                        _ => None,
+                    },
+                    last_ok_secs_ago: s.last_ok.map(|t| t.elapsed().as_secs()),
+                })
+                .collect(),
             last_refresh_secs_ago: self.last_refresh.map(|t| t.elapsed().as_secs()),
         }
     }
+}
+
+/// First occurrence of each URL wins, order preserved. Fetching the same list
+/// twice is pure waste, and a repeat also strands a source in `Pending`.
+pub fn dedup_sources(lists: &[String]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    lists
+        .iter()
+        .filter(|url| seen.insert((*url).clone()))
+        .cloned()
+        .collect()
 }
 
 /// Parse a blocklist text file into a set of domains.
@@ -313,7 +435,7 @@ mod tests {
             PersistedDomainList::unpersisted(),
             PersistedDomainList::unpersisted(),
         );
-        store.swap_domains(domains.iter().map(|s| s.to_string()).collect(), vec![]);
+        store.swap_domains(domains.iter().map(|s| s.to_string()).collect());
         for d in allowlist {
             store.add_to_allowlist(d);
         }
@@ -382,7 +504,6 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-            vec![],
         );
         assert!(!store.remove_from_allowlist("safe.example.com"));
         assert!(!store.is_blocked("safe.example.com"));
@@ -403,7 +524,7 @@ mod tests {
         // Allowlist wins over a manual block, same as over list blocks.
         assert!(!store.is_blocked("safe.example.com"));
         // List refresh replaces `domains` wholesale; manual entries survive.
-        store.swap_domains(HashSet::new(), vec![]);
+        store.swap_domains(HashSet::new());
         assert!(store.is_blocked("bad.example.com"));
         assert_eq!(store.check("bad.example.com").reason, "manually blocked");
         assert!(store.remove_from_blocklist("bad.example.com"));
@@ -546,8 +667,113 @@ mod tests {
             .iter()
             .map(|s| s.to_string())
             .collect();
-        store.swap_domains(domains, vec![]);
+        store.swap_domains(domains);
         assert!(store.heap_bytes() > empty);
+    }
+
+    fn empty_store() -> BlocklistStore {
+        BlocklistStore::new(
+            PersistedDomainList::unpersisted(),
+            PersistedDomainList::unpersisted(),
+        )
+    }
+
+    #[test]
+    fn health_walks_from_unconfigured_to_failed() {
+        let mut store = empty_store();
+        assert_eq!(store.health(), "unconfigured");
+
+        let (a, b) = ("https://a.example/l.txt", "https://b.example/l.txt");
+        store.set_sources(&[a.to_string(), b.to_string()]);
+        assert_eq!(store.health(), "loading", "configured but not yet fetched");
+        assert_eq!(
+            store.stats().list_sources[0].status,
+            "pending",
+            "not yet fetched is not the same as failed"
+        );
+
+        store.record_outcomes(&[(a.to_string(), None), (b.to_string(), None)]);
+        assert_eq!(
+            store.health(),
+            "ok",
+            "sources that loaded and parsed to nothing are an emptied list"
+        );
+
+        store.swap_domains(["ads.example.com".to_string()].into_iter().collect());
+        store.record_outcomes(&[(b.to_string(), Some("HTTP 404".to_string()))]);
+        assert_eq!(
+            store.health(),
+            "degraded",
+            "one source down, still blocking"
+        );
+
+        store.swap_domains(HashSet::new());
+        assert_eq!(store.health(), "failed", "nothing left to block with");
+    }
+
+    /// `record_outcomes` matches by URL, so a repeated entry used to strand a
+    /// second state in Pending and pin health at "loading" forever.
+    #[test]
+    fn a_duplicate_source_does_not_pin_health_at_loading() {
+        let mut store = empty_store();
+        let a = "https://a.example/l.txt";
+        store.set_sources(&[a.to_string(), a.to_string()]);
+        assert_eq!(store.stats().list_sources.len(), 1, "deduplicated");
+
+        store.record_outcomes(&[(a.to_string(), None)]);
+        assert_eq!(store.health(), "ok");
+    }
+
+    /// Blocking switched off must not report the same as a box with no lists.
+    #[test]
+    fn a_disabled_store_keeps_its_sources() {
+        let mut store = empty_store();
+        store.set_sources(&["https://a.example/l.txt".to_string()]);
+        store.set_enabled(false);
+
+        assert_eq!(store.health(), "off");
+        let sources = store.stats().list_sources;
+        assert_eq!(sources.len(), 1, "still configured, just not running");
+        assert_eq!(sources[0].status, "pending");
+    }
+
+    /// The #336 shape: a source that failed has to keep its identity, or the
+    /// dashboard cannot tell it apart from a source nobody configured.
+    #[test]
+    fn a_failed_source_keeps_its_url_and_reason() {
+        let mut store = empty_store();
+        let (a, b) = ("https://a.example/l.txt", "https://b.example/l.txt");
+        store.set_sources(&[a.to_string(), b.to_string()]);
+        store.record_outcomes(&[
+            (a.to_string(), None),
+            (b.to_string(), Some("HTTP 404".to_string())),
+        ]);
+
+        let stats = store.stats();
+        assert_eq!(stats.list_sources.len(), 2);
+        let good = stats.list_sources.iter().find(|s| s.url == a).unwrap();
+        assert_eq!(good.status, "ok");
+        assert!(good.error.is_none());
+        assert!(good.last_ok_secs_ago.is_some());
+        let bad = stats.list_sources.iter().find(|s| s.url == b).unwrap();
+        assert_eq!(bad.status, "failed");
+        assert_eq!(bad.error.as_deref(), Some("HTTP 404"));
+        assert!(bad.last_ok_secs_ago.is_none(), "it never loaded");
+    }
+
+    /// A source that recovers must stop reporting the old error.
+    #[test]
+    fn a_recovered_source_clears_its_error() {
+        let mut store = empty_store();
+        let a = "https://a.example/l.txt";
+        store.set_sources(&[a.to_string()]);
+        store.record_outcomes(&[(a.to_string(), Some("timeout".to_string()))]);
+        store.record_outcomes(&[(a.to_string(), None)]);
+
+        let stats = store.stats();
+        assert_eq!(stats.list_sources[0].status, "ok");
+        assert!(stats.list_sources[0].error.is_none());
+        assert_eq!(store.health(), "ok");
     }
 }
 
@@ -556,7 +782,7 @@ const RETRY_DELAYS_SECS: &[u64] = &[2, 10, 30];
 pub async fn download_blocklists(
     lists: &[String],
     resolver: Option<std::sync::Arc<crate::bootstrap_resolver::NumaResolver>>,
-) -> Vec<(String, String)> {
+) -> Vec<(String, Result<String, String>)> {
     let mut builder = crate::forward::numa_tls_builder()
         .timeout(Duration::from_secs(30))
         .gzip(true);
@@ -572,7 +798,7 @@ pub async fn download_blocklists(
                 match tokio::fs::read_to_string(&path).await {
                     Ok(t) => {
                         info!("loaded local blocklist: {} ({} bytes)", source, t.len());
-                        t
+                        Ok(t)
                     }
                     Err(e) => {
                         warn!(
@@ -580,21 +806,24 @@ pub async fn download_blocklists(
                             source,
                             format_error_chain(&e)
                         );
-                        return None;
+                        Err("unreadable".to_string())
                     }
                 }
             } else {
-                let t = fetch_with_retry(client, source).await?;
-                info!("downloaded blocklist: {} ({} bytes)", source, t.len());
-                t
+                match fetch_with_retry(client, source).await {
+                    Ok(t) => {
+                        info!("downloaded blocklist: {} ({} bytes)", source, t.len());
+                        Ok(t)
+                    }
+                    Err(e) => Err(e),
+                }
             };
-            Some((source.clone(), text))
+            (source.clone(), text)
         }
     });
     futures::future::join_all(fetches)
         .await
         .into_iter()
-        .flatten()
         .collect()
 }
 
@@ -608,7 +837,7 @@ fn local_path(source: &str) -> Option<std::path::PathBuf> {
     None
 }
 
-async fn fetch_with_retry(client: &reqwest::Client, url: &str) -> Option<String> {
+async fn fetch_with_retry(client: &reqwest::Client, url: &str) -> Result<String, String> {
     fetch_with_retry_delays(client, url, RETRY_DELAYS_SECS).await
 }
 
@@ -616,39 +845,67 @@ async fn fetch_with_retry_delays(
     client: &reqwest::Client,
     url: &str,
     delays: &[u64],
-) -> Option<String> {
+) -> Result<String, String> {
     let total = delays.len() + 1;
+    let mut last = "fetch failed".to_string();
     for attempt in 1..=total {
         match fetch_once(client, url).await {
-            Ok(text) => return Some(text),
-            Err(msg) if attempt < total => {
+            Ok(text) => return Ok(text),
+            Err(e) if attempt < total => {
                 let delay = delays[attempt - 1];
                 warn!(
                     "blocklist {} attempt {}/{} failed: {} — retrying in {}s",
-                    url, attempt, total, msg, delay
+                    url, attempt, total, e.detail, delay
                 );
+                last = e.short;
                 tokio::time::sleep(Duration::from_secs(delay)).await;
             }
-            Err(msg) => {
+            Err(e) => {
                 warn!(
                     "blocklist {} attempt {}/{} failed: {} — giving up",
-                    url, attempt, total, msg
+                    url, attempt, total, e.detail
                 );
+                last = e.short;
             }
         }
     }
-    None
+    Err(last)
 }
 
-async fn fetch_once(client: &reqwest::Client, url: &str) -> Result<String, String> {
+/// `short` is for the dashboard and must stay a terse token; `detail` is the
+/// full chain the logs already carried.
+struct FetchError {
+    short: String,
+    detail: String,
+}
+
+impl FetchError {
+    fn new(e: reqwest::Error) -> Self {
+        let short = if let Some(status) = e.status() {
+            format!("HTTP {}", status.as_u16())
+        } else if e.is_timeout() {
+            "timeout".to_string()
+        } else if e.is_connect() {
+            "connection failed".to_string()
+        } else {
+            "fetch failed".to_string()
+        };
+        FetchError {
+            short,
+            detail: format_error_chain(&e),
+        }
+    }
+}
+
+async fn fetch_once(client: &reqwest::Client, url: &str) -> Result<String, FetchError> {
     let resp = client
         .get(url)
         .send()
         .await
-        .map_err(|e| format_error_chain(&e))?
+        .map_err(FetchError::new)?
         .error_for_status()
-        .map_err(|e| format_error_chain(&e))?;
-    resp.text().await.map_err(|e| format_error_chain(&e))
+        .map_err(FetchError::new)?;
+    resp.text().await.map_err(FetchError::new)
 }
 
 fn format_error_chain(e: &(dyn std::error::Error + 'static)) -> String {
@@ -714,7 +971,7 @@ mod retry_tests {
         let client = crate::forward::default_client();
         let url = format!("http://{addr}/");
         let result = fetch_with_retry_delays(&client, &url, &delays).await;
-        assert_eq!(result.as_deref(), Some(body));
+        assert_eq!(result.as_deref(), Ok(body));
     }
 
     fn unique_temp_path(prefix: &str) -> std::path::PathBuf {
@@ -738,7 +995,7 @@ mod retry_tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].0, url);
-        let domains = parse_blocklist(&result[0].1);
+        let domains = parse_blocklist(result[0].1.as_ref().unwrap());
         assert!(domains.contains("a.com"));
         assert!(domains.contains("b.com"));
     }
@@ -754,18 +1011,22 @@ mod retry_tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].0, source);
-        assert!(result[0].1.contains("ads.example.com"));
+        assert!(result[0].1.as_ref().unwrap().contains("ads.example.com"));
     }
 
+    /// A missing file is reported as a failed source, not dropped: dropping it
+    /// is what made a dead list indistinguishable from no list (#336).
     #[tokio::test]
-    async fn download_blocklists_skips_missing_local_file() {
+    async fn download_blocklists_reports_missing_local_file() {
         let path = unique_temp_path("numa_blocklist_missing");
         let url = format!(
             "file:///does/not/exist/{}",
             path.file_name().unwrap().to_string_lossy()
         );
-        let result = download_blocklists(&[url], None).await;
-        assert!(result.is_empty());
+        let result = download_blocklists(std::slice::from_ref(&url), None).await;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, url);
+        assert_eq!(result[0].1.as_ref().unwrap_err(), "unreadable");
     }
 
     #[tokio::test]
@@ -775,7 +1036,7 @@ mod retry_tests {
         let client = crate::forward::default_client();
         let url = format!("http://{addr}/");
         let result = fetch_with_retry_delays(&client, &url, &delays).await;
-        assert_eq!(result, None);
+        assert!(result.is_err());
     }
 
     /// The issue #336 outage: jsDelivr answered 403 with a plain-text error
@@ -791,7 +1052,11 @@ mod retry_tests {
         let client = crate::forward::default_client();
         let url = format!("http://{addr}/");
         let result = fetch_with_retry_delays(&client, &url, &[0]).await;
-        assert_eq!(result, None, "403 body must not be taken as a blocklist");
+        assert_eq!(
+            result.unwrap_err(),
+            "HTTP 403",
+            "403 body must not be taken as a blocklist"
+        );
     }
 
     /// CI canary. Fetches the URL actually compiled into the binary and parses
@@ -802,8 +1067,13 @@ mod retry_tests {
     async fn shipped_default_blocklist_still_loads() {
         let lists = crate::config::default_blocklists();
         let downloaded = download_blocklists(&lists, None).await;
-        assert_eq!(downloaded.len(), lists.len(), "a default source failed");
-        for (source, text) in &downloaded {
+        assert_eq!(downloaded.len(), lists.len());
+        for (source, result) in &downloaded {
+            // Every source now comes back whether it loaded or not, so the
+            // count above proves nothing on its own — this is the real check.
+            let text = result
+                .as_ref()
+                .unwrap_or_else(|e| panic!("default blocklist {source} failed: {e}"));
             let domains = parse_blocklist(text);
             assert!(
                 domains.len() > 100_000,

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -70,7 +70,7 @@ impl ClientPolicySet {
                 allow,
                 crate::domain_list::PersistedDomainList::unpersisted(),
             );
-            store.swap_domains(blocks, vec![]);
+            store.swap_domains(blocks);
             rules.push(ClientPolicy {
                 nets: CidrMatcher::from_entries(&cfg.from, &cfg.exclude, &format!("{ctx}.from"))?,
                 store,

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1513,7 +1513,7 @@ mod tests {
         );
         let mut domains = std::collections::HashSet::new();
         domains.insert("ads.tracker.test".to_string());
-        ctx.blocklist.write().unwrap().swap_domains(domains, vec![]);
+        ctx.blocklist.write().unwrap().swap_domains(domains);
         let ctx = Arc::new(ctx);
 
         let (resp, path) = resolve_in_test(&ctx, "ads.tracker.test", QueryType::A).await;
@@ -2015,7 +2015,7 @@ mod tests {
         let mut ctx = crate::testutil::test_ctx().await;
         let mut domains = std::collections::HashSet::new();
         domains.insert("ads.example.com".to_string());
-        ctx.blocklist.write().unwrap().swap_domains(domains, vec![]);
+        ctx.blocklist.write().unwrap().swap_domains(domains);
         ctx.client_policy = ctx_with_policy(&["192.168.1.50"], &[], &["ads.example.com"]);
         ctx.forwarding_rules = vec![ForwardingRule::new(
             "example.com".to_string(),
@@ -2044,7 +2044,7 @@ mod tests {
         let mut ctx = crate::testutil::test_ctx().await;
         let mut domains = std::collections::HashSet::new();
         domains.insert("ads.tracker.test".to_string());
-        ctx.blocklist.write().unwrap().swap_domains(domains, vec![]);
+        ctx.blocklist.write().unwrap().swap_domains(domains);
         ctx.client_policy = ctx_with_policy(&["127.0.0.0/8"], &["unrelated.test"], &[]);
         let ctx = Arc::new(ctx);
 
@@ -2132,7 +2132,7 @@ mod tests {
         let ctx = crate::testutil::test_ctx().await;
         let mut domains = std::collections::HashSet::new();
         domains.insert("ads.tracker.test".to_string());
-        ctx.blocklist.write().unwrap().swap_domains(domains, vec![]);
+        ctx.blocklist.write().unwrap().swap_domains(domains);
         let ctx = Arc::new(ctx);
 
         let (resp, path) = resolve_in_test(&ctx, "ads.tracker.test", QueryType::A).await;
@@ -2169,7 +2169,7 @@ mod tests {
         let ctx = crate::testutil::test_ctx().await;
         let mut domains = std::collections::HashSet::new();
         domains.insert("ads.tracker.test".to_string());
-        ctx.blocklist.write().unwrap().swap_domains(domains, vec![]);
+        ctx.blocklist.write().unwrap().swap_domains(domains);
         let ctx = Arc::new(ctx);
 
         // Blocked A → 0.0.0.0 sinkhole.

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -70,6 +70,11 @@ pub async fn run(config_path: String) -> crate::Result<()> {
         ),
         crate::domain_list::PersistedDomainList::new("blocking-block.json", &[]),
     );
+    // Seeded before the first fetch so the dashboard can tell a source that has
+    // not loaded yet from one that is not configured at all. Seeded even when
+    // blocking is off, or a disabled box reports its configured lists as though
+    // it had none; `health` reports the switch separately.
+    blocklist.set_sources(&config.blocking.lists);
     if !config.blocking.enabled {
         blocklist.set_enabled(false);
     }
@@ -281,7 +286,7 @@ fn spawn_background_services(
     bootstrap_resolver: &Arc<NumaResolver>,
     api_port: u16,
 ) -> crate::Result<()> {
-    let blocklist_lists = config.blocking.lists.clone();
+    let blocklist_lists = crate::blocklist::dedup_sources(&config.blocking.lists);
     let refresh_hours = config.blocking.refresh_hours;
     if config.blocking.enabled && !blocklist_lists.is_empty() {
         let bl_ctx = Arc::clone(ctx);
@@ -819,18 +824,27 @@ async fn load_blocklists(
 
     // Parse outside the lock to avoid blocking DNS queries during parse (~100ms)
     let mut all_domains = std::collections::HashSet::new();
-    let mut sources = Vec::new();
-    let mut failed = lists.len().saturating_sub(downloaded.len());
-    for (source, text) in &downloaded {
+    let mut outcomes = Vec::with_capacity(downloaded.len());
+    let mut failed = 0;
+    for (source, fetched) in &downloaded {
+        let text = match fetched {
+            Ok(text) => text,
+            Err(why) => {
+                failed += 1;
+                outcomes.push((source.clone(), Some(why.clone())));
+                continue;
+            }
+        };
         let domains = parse_blocklist(text);
         if let Some(why) = source_defect(source, text, &domains) {
             error!("blocklist source failed: {source} — {why}");
             failed += 1;
+            outcomes.push((source.clone(), Some("not a domain list".to_string())));
             continue;
         }
         info!("blocklist: {} domains from {}", domains.len(), source);
         all_domains.extend(domains);
-        sources.push(source.clone());
+        outcomes.push((source.clone(), None));
     }
     let total = all_domains.len();
 
@@ -838,7 +852,10 @@ async fn load_blocklists(
     // sources that all loaded and parsed to nothing are a deliberately emptied
     // list and must be allowed to clear the old one.
     if total == 0 && failed > 0 {
-        let kept = ctx.blocklist.read().unwrap().domains_loaded();
+        let mut store = ctx.blocklist.write().unwrap();
+        store.record_outcomes(&outcomes);
+        let kept = store.domains_loaded();
+        drop(store);
         error!(
             "blocklist refresh failed for {failed} of {} lists — keeping {kept} domains already loaded",
             lists.len()
@@ -846,12 +863,12 @@ async fn load_blocklists(
         return kept > 0;
     }
 
-    let loaded = sources.len();
+    let loaded = outcomes.len() - failed;
     // Swap under lock — sub-microsecond
-    ctx.blocklist
-        .write()
-        .unwrap()
-        .swap_domains(all_domains, sources);
+    let mut store = ctx.blocklist.write().unwrap();
+    store.record_outcomes(&outcomes);
+    store.swap_domains(all_domains);
+    drop(store);
     if failed > 0 {
         warn!(
             "blocking degraded: {total} unique domains from {loaded} of {} lists",
@@ -938,10 +955,10 @@ mod tests {
 
     async fn ctx_blocking(domains: &[&str]) -> ServerCtx {
         let ctx = crate::testutil::test_ctx().await;
-        ctx.blocklist.write().unwrap().swap_domains(
-            domains.iter().map(|d| d.to_string()).collect(),
-            vec!["seed".to_string()],
-        );
+        ctx.blocklist
+            .write()
+            .unwrap()
+            .swap_domains(domains.iter().map(|d| d.to_string()).collect());
         ctx
     }
 


### PR DESCRIPTION
Splits the reporting half of #338 out so it can land on its own. The on-disk last-known-good cache stays in #338, which will be rebased on top of this.

#337 fixed the *detection* of #336 but the API still could not express it. `/blocking/stats` only listed sources that loaded, so a source that 404'd vanished from the payload and these two were the same response:

```
all lists failed          →  {"domains_loaded":0, "list_sources":[], ...}
no lists configured       →  {"domains_loaded":0, "list_sources":[], ...}
```

The dashboard blanked the sources panel and left the `Blocked` card showing a lifetime counter that keeps looking healthy while nothing is being blocked. #336's defining property was that nothing looked wrong; that was still true in the UI.

`download_blocklists` now returns a result per source instead of dropping failures, and the store keeps every *configured* source with its outcome. Errors are short tokens (`HTTP 404`, `timeout`, `connection failed`, `unreadable`, `not a domain list`) rather than prose. The logs keep the full error chain; the dashboard gets something that fits on a line.

## health

| health | meaning |
|---|---|
| `off` | blocking is switched off |
| `unconfigured` | no lists configured |
| `loading` | configured, first fetch not finished |
| `ok` | every source loaded |
| `degraded` | some source failed, still blocking |
| `failed` | nothing loaded, not blocking |

It describes the *lists*, not the on/off switch, which `enabled` and `paused` already answer — but it reports the switch anyway, because list state is moot when nothing is being blocked on purpose, and sources are now seeded even on a disabled box (otherwise a box that will never fetch reads `loading` forever).

It doubles as a monitoring primitive: `curl -s .../blocking/stats | jq -r .health` is the check that would have caught #336, and an unattended box is noticed through metrics, not a dashboard nobody opens.

`stale` is deliberately absent. It cannot happen until the cache lands, and inventing a state with no way to reach it leaves dead code to maintain.

## per source

`status` is one field of `pending`/`ok`/`failed`, not a bool. As a bool a not-yet-fetched source serialised as `ok=false` with a null error, so the panel said "failed · never loaded" during startup while the aggregate said "loading" — the same class of lie as showing a dead list as healthy.

Sources are deduplicated. `record_outcomes` matches by URL and `find()` stops at the first hit, so a repeated entry never left `Pending` and pinned health at `loading` forever. The refresh loop takes the deduplicated list too, so a repeat no longer downloads the same list twice.

## Breaking

`list_sources` is now an array of objects, not strings, each with `url`, `status`, `error` and `last_ok_secs_ago`. Only the bundled dashboard consumed it.
