### PR TITLE
fix(dnssec): only send AD to clients that asked for it

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -715,6 +715,13 @@ pub(crate) fn shape_response_for_client(
 
     response.header.authoritative_answer = false;
 
+    // RFC 6840 §5.7: AD answers a question only DO or AD asks. Forward modes
+    // pass upstream's claim through and recursive sets its own, so without
+    // this both hand the verdict to clients that opted out of DNSSEC.
+    if !client_do && !query.header.authed_data {
+        response.header.authed_data = false;
+    }
+
     if !client_do {
         strip_dnssec_records(response);
         if filter_aaaa {
@@ -2485,6 +2492,55 @@ mod tests {
         let mut v = vec![0, 15, 0, 2];
         v.extend_from_slice(&code.to_be_bytes());
         v
+    }
+
+    #[test]
+    fn shape_clears_ad_for_a_client_that_asked_for_neither_do_nor_ad() {
+        // RFC 6840 §5.7: AD belongs only in replies to requestors that set DO
+        // or AD. A client that opted out of DNSSEC has no way to act on it,
+        // and in forward mode the bit is upstream's claim rather than ours.
+        let query = DnsPacket::query(0x1, "example.com", QueryType::A);
+        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        response.header.authed_data = true;
+
+        shape_response_for_client(&mut response, &query, false);
+
+        assert!(
+            !response.header.authed_data,
+            "AD went to a client that asked for neither DO nor AD"
+        );
+    }
+
+    #[test]
+    fn shape_keeps_ad_for_a_client_that_set_only_the_ad_bit() {
+        // RFC 6840 §5.7 again: AD=1 with DO=0 is how a client asks for the
+        // verdict without wanting the RRSIGs that back it.
+        let mut query = DnsPacket::query(0x1, "example.com", QueryType::A);
+        query.header.authed_data = true;
+        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        response.header.authed_data = true;
+
+        shape_response_for_client(&mut response, &query, false);
+
+        assert!(
+            response.header.authed_data,
+            "a client that set AD asked for the verdict and must keep it"
+        );
+    }
+
+    #[test]
+    fn shape_keeps_ad_for_a_do_client() {
+        let mut query = DnsPacket::query(0x1, "example.com", QueryType::A);
+        query.edns = Some(crate::packet::EdnsOpt {
+            do_bit: true,
+            ..Default::default()
+        });
+        let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        response.header.authed_data = true;
+
+        shape_response_for_client(&mut response, &query, false);
+
+        assert!(response.header.authed_data);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- RFC 6840 §5.7 limits the AD bit to requestors that set DO or AD. numa set it for everyone: recursive marks every Secure answer, and forward/odoh pass upstream's claim straight through.
- In forward mode that bit is the upstream's assertion, not ours — handing it to a stub that opted out of DNSSEC is the part worth fixing.
- Cleared in `shape_response_for_client`, the seam that already reconciles the response with what the client asked for, so both resolution modes are covered in one place.
- AD=1 with DO=0 keeps the bit. That combination is how a client asks for the verdict without wanting the RRSIGs behind it.

Spun out of the #329 review rather than folded into it, since it is independent of the DO-bit work.

## Test plan

- Three unit tests on `shape_response_for_client`: cleared when the client set neither, kept for AD-only, kept for DO. The first is red before the change; the other two exist so "clear it always" cannot pass.
- `make all` green.
- Live, forward mode to quad9: `+noadflag` → no `ad`; dig's default (which sets AD) → `ad` kept; `+dnssec` → `ad` kept, matching upstream on www.isc.org, www.ikea.com and org DNSKEY.

Note for reviewers: `dig` sets AD in queries by default, so reproducing the old behavior needs `+noadflag`. With plain `dig` this change looks like a no-op.
