### PR TITLE
docs(dnssec): cite the section that carries the AD-on-replies rule

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -715,7 +715,7 @@ pub(crate) fn shape_response_for_client(
 
     response.header.authoritative_answer = false;
 
-    // RFC 6840 §5.7: AD answers a question only DO or AD asks. Forward modes
+    // RFC 6840 §5.8: AD answers a question only DO or AD asks. Forward modes
     // pass upstream's claim through and recursive sets its own, so without
     // this both hand the verdict to clients that opted out of DNSSEC.
     if !client_do && !query.header.authed_data {
@@ -2496,7 +2496,7 @@ mod tests {
 
     #[test]
     fn shape_clears_ad_for_a_client_that_asked_for_neither_do_nor_ad() {
-        // RFC 6840 §5.7: AD belongs only in replies to requestors that set DO
+        // RFC 6840 §5.8: AD belongs only in replies to requestors that set DO
         // or AD. A client that opted out of DNSSEC has no way to act on it,
         // and in forward mode the bit is upstream's claim rather than ours.
         let query = DnsPacket::query(0x1, "example.com", QueryType::A);
@@ -2513,8 +2513,8 @@ mod tests {
 
     #[test]
     fn shape_keeps_ad_for_a_client_that_set_only_the_ad_bit() {
-        // RFC 6840 §5.7 again: AD=1 with DO=0 is how a client asks for the
-        // verdict without wanting the RRSIGs that back it.
+        // RFC 6840 §5.7, the query side of the rule: AD=1 with DO=0 is how a
+        // client asks for the verdict without wanting the RRSIGs that back it.
         let mut query = DnsPacket::query(0x1, "example.com", QueryType::A);
         query.header.authed_data = true;
         let mut response = DnsPacket::response_from(&query, ResultCode::NOERROR);


### PR DESCRIPTION
Comment-only follow-up to #340.

The rule that limits AD to requestors which set DO or AD is RFC 6840 §5.8
("Setting the AD Bit on Replies"). §5.7 is the query side: it defines AD-in-query
as "i understand AD and want the verdict", which is why the AD-only client keeps
the bit. #340 cited §5.7 for both, so the comment on the clearing branch points at
the wrong section.

No behavior change. `shape_response_for_client` and its tests are untouched.

While verifying #340 live, two notes on its test plan worth recording here:

- A cold-cache `+noadflag` query does not exercise the fix. Forward mode relays the
  client's wire as-is, so quad9 receives DO=0/AD=0, does not set AD itself, and
  there is nothing to strip. The leak needs an AD-aware client to populate the
  cache first: `+dnssec ripe.net` then `+noadflag +noedns ripe.net` shows `ad`
  before #340 and no `ad` after, with the AD-set and DO-set clients still getting it.
- `www.isc.org` is not a useful name for this — it CNAMEs to `isc.map.fastlydns.net`,
  which is unsigned, so quad9 returns no `ad` either way.
