### PR TITLE
feat: refuse ANY queries with a minimal HINFO (RFC 8482)

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -331,7 +331,7 @@ fn resolve_local(
 ) -> Option<(DnsPacket, QueryPath, DnssecStatus)> {
     // RFC 8482: ANY is answered with a minimal HINFO, never resolved. Kills
     // the amplification value of qtype 255 before any stage can act on it.
-    if qtype.to_num() == 255 {
+    if qtype == QueryType::ANY {
         let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
         resp.answers.push(DnsRecord::UNKNOWN {
             domain: qname.to_string(),
@@ -1400,7 +1400,7 @@ mod tests {
             UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]);
         let ctx = Arc::new(ctx);
 
-        let (resp, path) = resolve_in_test(&ctx, "example.com", QueryType::UNKNOWN(255)).await;
+        let (resp, path) = resolve_in_test(&ctx, "example.com", QueryType::ANY).await;
 
         assert_eq!(path, QueryPath::Local, "ANY must not reach an upstream");
         assert_eq!(resp.header.rescode, ResultCode::NOERROR);

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1374,6 +1374,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn any_query_refused_with_rfc8482_hinfo() {
+        // Upstream would gladly answer ANY; numa must never ask it (RFC 8482).
+        let upstream_addr = crate::testutil::mock_upstream(crate::testutil::a_record_response(
+            "example.com",
+            Ipv4Addr::new(93, 184, 216, 34),
+            300,
+        ))
+        .await;
+
+        let ctx = crate::testutil::test_ctx().await;
+        *ctx.upstream_pool.lock().unwrap() =
+            UpstreamPool::new(vec![Upstream::Udp(upstream_addr)], vec![]);
+        let ctx = Arc::new(ctx);
+
+        let (resp, path) = resolve_in_test(&ctx, "example.com", QueryType::UNKNOWN(255)).await;
+
+        assert_eq!(path, QueryPath::Local, "ANY must not reach an upstream");
+        assert_eq!(resp.header.rescode, ResultCode::NOERROR);
+        assert_eq!(resp.answers.len(), 1, "exactly one synthesized HINFO");
+        match &resp.answers[0] {
+            DnsRecord::UNKNOWN {
+                domain,
+                qtype: 13,
+                data,
+                ttl,
+            } => {
+                assert_eq!(domain, "example.com");
+                assert_eq!(data.as_slice(), b"\x07RFC8482\x00", "CPU=\"RFC8482\" OS=\"\"");
+                assert!(*ttl >= 3600, "cacheable TTL so clients stop re-asking");
+            }
+            other => panic!("expected HINFO, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
     async fn forwarding_rule_overrides_special_use_domain() {
         let mut resp = DnsPacket::new();
         resp.header.response = true;

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -329,6 +329,18 @@ fn resolve_local(
     qtype: QueryType,
     ctx: &ServerCtx,
 ) -> Option<(DnsPacket, QueryPath, DnssecStatus)> {
+    // RFC 8482: ANY is answered with a minimal HINFO, never resolved. Kills
+    // the amplification value of qtype 255 before any stage can act on it.
+    if qtype.to_num() == 255 {
+        let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
+        resp.answers.push(DnsRecord::UNKNOWN {
+            domain: qname.to_string(),
+            qtype: 13, // HINFO
+            data: b"\x07RFC8482\x00".to_vec(),
+            ttl: 3600,
+        });
+        return Some((resp, QueryPath::Local, DnssecStatus::Indeterminate));
+    }
     if let Some(record) = ctx.overrides.read().unwrap().lookup(qname) {
         let mut resp = DnsPacket::response_from(query, ResultCode::NOERROR);
         resp.answers.push(record);
@@ -1401,7 +1413,11 @@ mod tests {
                 ttl,
             } => {
                 assert_eq!(domain, "example.com");
-                assert_eq!(data.as_slice(), b"\x07RFC8482\x00", "CPU=\"RFC8482\" OS=\"\"");
+                assert_eq!(
+                    data.as_slice(),
+                    b"\x07RFC8482\x00",
+                    "CPU=\"RFC8482\" OS=\"\""
+                );
                 assert!(*ttl >= 3600, "cacheable TTL so clients stop re-asking");
             }
             other => panic!("expected HINFO, got {:?}", other),

--- a/src/question.rs
+++ b/src/question.rs
@@ -61,6 +61,7 @@ define_qtypes! {
     NSEC3  = 50, "NSEC3",
     SVCB   = 64, "SVCB",
     HTTPS  = 65, "HTTPS",
+    ANY    = 255, "ANY",
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
first item off the public-resolver hardening list from the #230 discussion (also in recipes/dnsdist-front.md).

qtype 255 used to ride the normal pipeline all the way upstream, which is exactly the amplification bait RFC 8482 exists to kill. now it short-circuits at the top of resolve_local with a single synthesized HINFO (`CPU="RFC8482" OS=""`, TTL 3600) so clients cache the refusal instead of re-asking. no config, applies on every transport.

also names qtype 255 in define_qtypes so the query log and API say ANY instead of UNKNOWN(255).

verified live over UDP and TCP: dig returns `example.com. 3600 IN HINFO "RFC8482" ""` and the query log shows LOCAL with no upstream contact.

still open from that list: RRL/TC-slip (the load-bearing one), DNS cookies, allow_recursion split.