### PR TITLE
fix(blocking): regressions from the #336 hardening

### DIFF
--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -1564,7 +1564,7 @@ function renderBlockingInfo(info) {
     <div style="font-size:0.65rem;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-dim);margin-bottom:0.4rem;">Sources &middot; ${formatNumber(info.domains_loaded)} domains</div>
     ${sources.map(s => `
       <div style="padding:0.3rem 0;font-family:var(--font-mono);font-size:0.72rem;">
-        <a href="${h(s.url)}" target="_blank" rel="noopener" style="color:var(--text-secondary);text-decoration:none;" title="${h(s.url)}">${shortenUrl(s.url)}</a>
+        <a href="${h(s.url)}" target="_blank" rel="noopener" style="color:var(--text-secondary);text-decoration:none;" title="${h(s.url)}">${h(shortenUrl(s.url))}</a>
         ${sourceNote(s)}
       </div>
     `).join('')}

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -242,8 +242,9 @@ impl BlocklistStore {
             .any(|s| matches!(s.outcome, SourceOutcome::Failed(_)))
         {
             // Domains present means something is still being blocked, from the
-            // sources that did load or from a list a failed refresh left alone.
-            return if self.domains.is_empty() {
+            // sources that did load, a list a failed refresh left alone, or the
+            // manual list, which enforces independently of the sources.
+            return if self.domains.is_empty() && self.manual.is_empty() {
                 "failed"
             } else {
                 "degraded"
@@ -365,21 +366,40 @@ pub fn dedup_sources(lists: &[String]) -> Vec<String> {
         .collect()
 }
 
+pub struct ParsedList {
+    pub domains: HashSet<String>,
+    entry_lines: usize,
+    parsed_lines: usize,
+}
+
 /// Parse a blocklist text file into a set of domains.
 pub fn parse_blocklist(text: &str) -> HashSet<String> {
+    parse_blocklist_counted(text).domains
+}
+
+/// One walk that also counts how many entry lines yielded a domain, so
+/// `source_defect` never re-derives that from a second pass with a filter that
+/// could drift. Lines are judged for validity, not novelty: a dual-stack hosts
+/// file names every domain on both a `0.0.0.0` and a `::` line, and both count.
+pub(crate) fn parse_blocklist_counted(text: &str) -> ParsedList {
     let mut domains = HashSet::new();
+    let mut entry_lines = 0;
+    let mut parsed_lines = 0;
     for line in text.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') || line.starts_with('!') {
             continue;
         }
+        entry_lines += 1;
 
         if line.starts_with("0.0.0.0") || line.starts_with("127.0.0.1") || line.starts_with("::") {
             // BSD hosts(5): an IP followed by N aliases; '#' starts an inline comment.
             let payload = line.split('#').next().unwrap_or(line);
+            let mut any = false;
             for alias in payload.split_whitespace().skip(1) {
-                insert_if_valid(&mut domains, alias);
+                any |= insert_if_valid(&mut domains, alias);
             }
+            parsed_lines += usize::from(any);
             continue;
         }
 
@@ -390,9 +410,13 @@ pub fn parse_blocklist(text: &str) -> HashSet<String> {
         // Plain domain or adblock filter syntax.
         let d = line.trim_start_matches("*.").trim_start_matches("||");
         let d = d.split('$').next().unwrap_or(d); // strip adblock $options
-        insert_if_valid(&mut domains, d.trim_end_matches('^'));
+        parsed_lines += usize::from(insert_if_valid(&mut domains, d.trim_end_matches('^')));
     }
-    domains
+    ParsedList {
+        domains,
+        entry_lines,
+        parsed_lines,
+    }
 }
 
 /// Share of entry lines that must parse as domains for a body to be a list at
@@ -407,21 +431,16 @@ const MIN_PARSED_PERCENT: usize = 50;
 /// entry lines and stays valid, while an error page parses almost none. An
 /// empty local file is a deliberate "block nothing"; an empty remote body is a
 /// broken upstream, never an instruction.
-pub(crate) fn source_defect(source: &str, text: &str, domains: &HashSet<String>) -> Option<String> {
-    let entries = text
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty() && !l.starts_with('#') && !l.starts_with('!'))
-        .count();
-    if entries == 0 {
+pub(crate) fn source_defect(source: &str, parsed: &ParsedList) -> Option<String> {
+    if parsed.entry_lines == 0 {
         return local_path(source)
             .is_none()
             .then(|| "response body has no entries".to_string());
     }
-    if domains.len() * 100 < entries * MIN_PARSED_PERCENT {
+    if parsed.parsed_lines * 100 < parsed.entry_lines * MIN_PARSED_PERCENT {
         return Some(format!(
-            "only {} of {entries} entry lines parsed as domains",
-            domains.len()
+            "only {} of {} entry lines parsed as domains",
+            parsed.parsed_lines, parsed.entry_lines
         ));
     }
     None
@@ -448,11 +467,14 @@ pub(crate) fn find_in_set<'a>(domain: &'a str, set: &HashSet<String>) -> Option<
     None
 }
 
-fn insert_if_valid(set: &mut HashSet<String>, raw: &str) {
+fn insert_if_valid(set: &mut HashSet<String>, raw: &str) -> bool {
     let d = normalize(raw);
-    if !d.is_empty() && d.contains('.') && d != "localhost" && d != "localhost.localdomain" {
+    let valid =
+        !d.is_empty() && d.contains('.') && d != "localhost" && d != "localhost.localdomain";
+    if valid {
         set.insert(d);
     }
+    valid
 }
 
 #[cfg(test)]
@@ -640,7 +662,7 @@ mod tests {
     }
 
     fn defect(source: &str, text: &str) -> Option<String> {
-        source_defect(source, text, &parse_blocklist(text))
+        source_defect(source, &parse_blocklist_counted(text))
     }
 
     /// A soft-error page small enough to yield one domain-shaped token still
@@ -672,6 +694,41 @@ mod tests {
         )
         .is_none());
         assert!(defect("https://cdn.example/l.txt", "||a.com^\n||b.com^\n").is_none());
+    }
+
+    /// A dual-stack hosts file carries every domain on two entry lines
+    /// (`0.0.0.0 d` and `:: d`) plus localhost boilerplate, so unique domains
+    /// land under half the entry count. v0.22.0 loaded these; the parse-ratio
+    /// gate must not read one as an error page.
+    #[test]
+    fn dual_stack_hosts_list_is_not_a_defect() {
+        let body = "# StevenBlack-style header\n\
+            127.0.0.1 localhost\n\
+            ::1 localhost\n\
+            255.255.255.255 broadcasthost\n\
+            0.0.0.0 ads.example\n\
+            :: ads.example\n\
+            0.0.0.0 tracker.example\n\
+            :: tracker.example\n\
+            0.0.0.0 metrics.example\n\
+            :: metrics.example\n";
+        let domains = parse_blocklist(body);
+        assert_eq!(domains.len(), 3, "precondition: aliases parse");
+        assert_eq!(defect("https://cdn.example/hosts", body), None);
+    }
+
+    /// All remote lists down while the user holds manual blocks: `is_blocked`
+    /// still consults the manual list, so "failed" (rendered as `all lists
+    /// failed · not blocking`) contradicts what the resolver actually does.
+    #[test]
+    fn manual_blocks_keep_health_out_of_failed() {
+        let mut store = empty_store();
+        let a = "https://a.example/l.txt";
+        store.set_sources(&[a.to_string()]);
+        store.record_outcomes(&[(a.to_string(), SourceResult::Failed("HTTP 403".to_string()))]);
+        store.add_to_blocklist("ads.example.com");
+        assert!(store.is_blocked("ads.example.com"));
+        assert_eq!(store.health(), "degraded", "still blocking manual domains");
     }
 
     /// Emptying your own list file is an instruction to block nothing; an empty

--- a/src/config.rs
+++ b/src/config.rs
@@ -552,10 +552,28 @@ pub struct BlockingConfig {
     pub enabled: bool,
     #[serde(default = "default_blocklists")]
     pub lists: Vec<String>,
-    #[serde(default = "default_refresh_hours")]
+    #[serde(
+        default = "default_refresh_hours",
+        deserialize_with = "nonzero_refresh_hours"
+    )]
     pub refresh_hours: u64,
     #[serde(default)]
     pub allowlist: Vec<String>,
+}
+
+/// A zero would spin the refresh loop with a zero-second sleep, re-downloading
+/// every list back to back; the config is the one place that can refuse it.
+fn nonzero_refresh_hours<'de, D>(deserializer: D) -> std::result::Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let hours = u64::deserialize(deserializer)?;
+    if hours == 0 {
+        return Err(serde::de::Error::custom(
+            "blocking.refresh_hours must be at least 1",
+        ));
+    }
+    Ok(hours)
 }
 
 impl Default for BlockingConfig {
@@ -1050,6 +1068,15 @@ key_path = "/etc/numa/proxy/key.pem"
     fn lan_enabled_parses() {
         let config: Config = toml::from_str("[lan]\nenabled = true").unwrap();
         assert!(config.lan.enabled);
+    }
+
+    /// `refresh_hours = 0` would spin the refresh loop with a zero sleep.
+    #[test]
+    fn blocking_refresh_hours_zero_is_rejected() {
+        let err = toml::from_str::<Config>("[blocking]\nrefresh_hours = 0\n")
+            .err()
+            .expect("zero must be rejected");
+        assert!(err.to_string().contains("refresh_hours must be at least 1"));
     }
 
     #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -843,7 +843,11 @@ async fn load_blocklists(
                         "not a domain list".to_string()
                     }
                     None => {
-                        info!("blocklist: {} domains from {}", parsed.domains.len(), source);
+                        info!(
+                            "blocklist: {} domains from {}",
+                            parsed.domains.len(),
+                            source
+                        );
                         cache.store(source, text);
                         all_domains.extend(parsed.domains);
                         outcomes.push((source.clone(), SourceResult::Loaded));

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -11,7 +11,8 @@ use std::time::Duration;
 use log::{debug, error, info, warn};
 
 use crate::blocklist::{
-    download_blocklists, parse_blocklist, source_defect, BlocklistStore, SourceResult,
+    download_blocklists, parse_blocklist, parse_blocklist_counted, source_defect, BlocklistStore,
+    SourceResult,
 };
 use crate::blocklist_cache::BlocklistCache;
 use crate::bootstrap_resolver::NumaResolver;
@@ -835,16 +836,16 @@ async fn load_blocklists(
         let live_error = match fetched {
             Err(why) => why.clone(),
             Ok(text) => {
-                let domains = parse_blocklist(text);
-                match source_defect(source, text, &domains) {
+                let parsed = parse_blocklist_counted(text);
+                match source_defect(source, &parsed) {
                     Some(why) => {
                         error!("blocklist source failed: {source} — {why}");
                         "not a domain list".to_string()
                     }
                     None => {
-                        info!("blocklist: {} domains from {}", domains.len(), source);
+                        info!("blocklist: {} domains from {}", parsed.domains.len(), source);
                         cache.store(source, text);
-                        all_domains.extend(domains);
+                        all_domains.extend(parsed.domains);
                         outcomes.push((source.clone(), SourceResult::Loaded));
                         continue;
                     }


### PR DESCRIPTION
follow-ups on #337/#339, found reviewing everything since v0.22.0:

- the parse-ratio gate compared unique domains to entry lines, so a dual-stack hosts file (every domain listed under both `0.0.0.0` and `::`) read as "not a domain list" and silently vanished — the exact failure the gate was added to prevent. it now counts lines that yielded a domain, in the same walk parse_blocklist already does, which also drops the hand-copied second pass over the body.
- `refresh_hours = 0` spun the refresh loop with a zero sleep (before #337 the interval panicked the task, which accidentally meant "load once"). the config rejects it now.
- health() said `failed` and the dashboard said "not blocking" while manual blocks were still enforcing. the manual list counts now, so `failed` only renders when nothing is blocked at all.
- the dashboard source link text reached innerHTML unescaped whenever the url doesn't parse, which is every bare local path.

still open from the same review: partial refresh failure wiping the failed source's domains (waiting on #338, the cache changes what the fix should be) and runtime toggle-on never spawning a loader.