### PR TITLE
feat(cli): add effective config commands

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -185,6 +185,7 @@ struct StatsResponse {
     upstream: String,
     mode: &'static str, // "recursive" or "forward" — never "auto" at runtime
     config_path: String,
+    config_found: bool,
     data_dir: String,
     proxy_tld: String,
     dnssec: bool,
@@ -585,6 +586,7 @@ async fn stats(State(ctx): State<Arc<ServerCtx>>) -> Json<StatsResponse> {
         upstream,
         mode: ctx.upstream_mode.as_str(),
         config_path: ctx.config_path.clone(),
+        config_found: ctx.config_found,
         data_dir: ctx.data_dir.to_string_lossy().to_string(),
         proxy_tld: ctx.proxy_tld.clone(),
         dnssec: ctx.dnssec_enabled,

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -1,9 +1,10 @@
 use crate::config::{ConfigLoad, ServerConfig};
 use serde::Deserialize;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream};
 use std::path::Path;
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const DAEMON_TIMEOUT: Duration = Duration::from_millis(500);
 const DEFAULTS_NOTE: &str = "file does not exist yet, defaults apply";
@@ -119,44 +120,51 @@ fn probe_addr(server: &ServerConfig) -> SocketAddr {
     SocketAddr::new(ip, server.api_port)
 }
 
+/// One plaintext GET against the daemon's API — a bare `TcpStream`, like the
+/// liveness probe in system_dns.rs. `Connection: close` plus axum's sized
+/// `Json` bodies make read-to-EOF safe, with the read timeout shrinking
+/// toward a fixed deadline so a dribbling port squatter cannot hold us past
+/// `DAEMON_TIMEOUT`.
 fn query_daemon_config_path(server: &ServerConfig) -> Result<StatsConfigPath, String> {
     let addr = probe_addr(server);
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| format!("failed to start probe runtime: {error}"))?;
-    runtime.block_on(fetch_daemon_config(addr))
+    let deadline = Instant::now() + DAEMON_TIMEOUT;
+    let mut stream = TcpStream::connect_timeout(&addr, DAEMON_TIMEOUT)
+        .map_err(|_| format!("daemon not reachable at {addr}"))?;
+    stream
+        .set_write_timeout(Some(DAEMON_TIMEOUT))
+        .and_then(|()| {
+            let request =
+                format!("GET /stats HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+            stream.write_all(request.as_bytes())
+        })
+        .map_err(|error| format!("daemon probe failed: {error}"))?;
+
+    let mut response = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() || response.len() > 1 << 20 {
+            return Err("daemon response timed out".to_string());
+        }
+        let _ = stream.set_read_timeout(Some(remaining));
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => response.extend_from_slice(&buf[..n]),
+            Err(error) => return Err(format!("daemon probe failed: {error}")),
+        }
+    }
+    parse_stats_response(&response)
 }
 
-async fn fetch_daemon_config(addr: SocketAddr) -> Result<StatsConfigPath, String> {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-    let client = reqwest::Client::builder()
-        .timeout(DAEMON_TIMEOUT)
-        .build()
-        .map_err(|error| format!("failed to build probe client: {error}"))?;
-    let response = client
-        .get(format!("http://{addr}/stats"))
-        .send()
-        .await
-        .map_err(|error| {
-            if error.is_connect() || error.is_timeout() {
-                format!("daemon not reachable at {addr}")
-            } else {
-                format!("daemon probe failed: {}", error.without_url())
-            }
-        })?;
-    if response.status() != reqwest::StatusCode::OK {
-        return Err(format!(
-            "daemon returned HTTP {}",
-            response.status().as_u16()
-        ));
+fn parse_stats_response(response: &[u8]) -> Result<StatsConfigPath, String> {
+    let unexpected = || "unexpected daemon response".to_string();
+    let text = std::str::from_utf8(response).map_err(|_| unexpected())?;
+    let (head, body) = text.split_once("\r\n\r\n").ok_or_else(unexpected)?;
+    let status = head.split_whitespace().nth(1).ok_or_else(unexpected)?;
+    if status != "200" {
+        return Err(format!("daemon returned HTTP {status}"));
     }
-    let body = response
-        .text()
-        .await
-        .map_err(|error| format!("failed to read daemon response: {}", error.without_url()))?;
-    let stats: StatsConfigPath =
-        serde_json::from_str(&body).map_err(|_| "unexpected daemon response".to_string())?;
+    let stats: StatsConfigPath = serde_json::from_str(body).map_err(|_| unexpected())?;
     if stats.config_path.is_empty() {
         return Err("daemon returned an empty config path".to_string());
     }

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -215,21 +215,13 @@ fn configured_editor() -> (String, Vec<String>) {
         .iter()
         .filter_map(|name| std::env::var(name).ok())
         .find(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| default_editor().to_string());
+        .unwrap_or_else(|| if cfg!(windows) { "notepad" } else { "vi" }.to_string());
     split_editor(&value)
-}
-
-fn default_editor() -> &'static str {
-    if cfg!(windows) {
-        "notepad"
-    } else {
-        "vi"
-    }
 }
 
 fn split_editor(value: &str) -> (String, Vec<String>) {
     let mut parts = value.split_whitespace().map(str::to_string);
-    let program = parts.next().unwrap_or_else(|| default_editor().to_string());
+    let program = parts.next().unwrap_or_default();
     (program, parts.collect())
 }
 
@@ -314,23 +306,16 @@ mod tests {
     }
 
     #[test]
-    fn probe_addr_maps_unspecified_to_loopback() {
+    fn probe_addr_targets_loopback_or_the_configured_bind_addr() {
         let mut server = ServerConfig {
             api_bind_addr: "0.0.0.0".to_string(),
-            ..ServerConfig::default()
-        };
-        assert_eq!(probe_addr(&server).ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
-        server.api_bind_addr = "::".to_string();
-        assert_eq!(probe_addr(&server).ip(), IpAddr::V6(Ipv6Addr::LOCALHOST));
-    }
-
-    #[test]
-    fn probe_addr_uses_configured_bind_addr() {
-        let server = ServerConfig {
-            api_bind_addr: "192.168.1.10".to_string(),
             api_port: 6123,
             ..ServerConfig::default()
         };
+        assert_eq!(probe_addr(&server).to_string(), "127.0.0.1:6123");
+        server.api_bind_addr = "::".to_string();
+        assert_eq!(probe_addr(&server).ip(), IpAddr::V6(Ipv6Addr::LOCALHOST));
+        server.api_bind_addr = "192.168.1.10".to_string();
         assert_eq!(probe_addr(&server).to_string(), "192.168.1.10:6123");
     }
 
@@ -386,27 +371,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         ensure_writable(&path).unwrap();
         assert!(!path.exists());
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn ensure_writable_rejects_read_only_dir() {
-        use std::os::unix::fs::PermissionsExt;
-        let dir = std::env::temp_dir().join("numa-config-cli-ro-test");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
-        if std::fs::write(dir.join("probe"), b"").is_ok() {
-            // Mode bits don't bind this user (running as root); nothing to assert.
-            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
-            let _ = std::fs::remove_dir_all(&dir);
-            return;
-        }
-        let path = dir.join("numa.toml");
-        let error = ensure_writable(&path).unwrap_err();
-        assert!(error.contains("not writable"), "error was: {error}");
-        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -1,0 +1,300 @@
+use crate::config::{ConfigLoad, ServerConfig};
+use serde::Deserialize;
+use std::ffi::OsString;
+use std::io::{Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpStream};
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+const DAEMON_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ConfigPathSource {
+    Daemon,
+    Local,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct EffectiveConfigPath {
+    path: String,
+    source: ConfigPathSource,
+}
+
+impl EffectiveConfigPath {
+    fn display(&self) -> String {
+        match self.source {
+            ConfigPathSource::Daemon => self.path.clone(),
+            ConfigPathSource::Local => {
+                format!("{} (daemon not running; resolved locally)", self.path)
+            }
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct StatsConfigPath {
+    config_path: String,
+}
+
+pub fn print_config_path() -> Result<(), String> {
+    let resolved = effective_config_path()?;
+    println!("{}", resolved.display());
+    Ok(())
+}
+
+pub fn edit_config() -> Result<(), String> {
+    let resolved = effective_config_path()?;
+    let path = Path::new(&resolved.path);
+    if !config_is_writable(path)? {
+        #[cfg(not(windows))]
+        eprintln!(
+            "warning: {} is not writable, re-run with sudo",
+            path.display()
+        );
+        #[cfg(windows)]
+        eprintln!("warning: {} is not writable", path.display());
+        return Ok(());
+    }
+
+    let editor = configured_editor();
+    let status = Command::new(&editor)
+        .arg(path)
+        .status()
+        .map_err(|error| format!("failed to start {}: {error}", editor.to_string_lossy()))?;
+
+    println!("{}", resolved.display());
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{} exited with status {status}",
+            editor.to_string_lossy()
+        ))
+    }
+}
+
+pub(crate) fn service_config_path() -> Result<String, String> {
+    effective_config_path().map(|resolved| resolved.display())
+}
+
+fn effective_config_path() -> Result<EffectiveConfigPath, String> {
+    let local = crate::config::load_config("numa.toml");
+    resolve_effective_config_path(local, query_daemon_config_path)
+}
+
+fn resolve_effective_config_path<F>(
+    local: crate::Result<ConfigLoad>,
+    query_daemon: F,
+) -> Result<EffectiveConfigPath, String>
+where
+    F: FnOnce(u16) -> Result<String, String>,
+{
+    let api_port = local
+        .as_ref()
+        .map(|loaded| loaded.config.server.api_port)
+        .unwrap_or_else(|_| ServerConfig::default().api_port);
+
+    if let Ok(path) = query_daemon(api_port) {
+        return Ok(EffectiveConfigPath {
+            path,
+            source: ConfigPathSource::Daemon,
+        });
+    }
+
+    let loaded = local.map_err(|error| error.to_string())?;
+    Ok(EffectiveConfigPath {
+        path: loaded.path,
+        source: ConfigPathSource::Local,
+    })
+}
+
+fn query_daemon_config_path(port: u16) -> Result<String, String> {
+    let address = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port));
+    let mut stream = TcpStream::connect_timeout(&address, DAEMON_TIMEOUT)
+        .map_err(|error| format!("daemon connection failed: {error}"))?;
+    stream
+        .set_read_timeout(Some(DAEMON_TIMEOUT))
+        .map_err(|error| format!("failed to set daemon read timeout: {error}"))?;
+    stream
+        .set_write_timeout(Some(DAEMON_TIMEOUT))
+        .map_err(|error| format!("failed to set daemon write timeout: {error}"))?;
+
+    let request = format!(
+        "GET /stats HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nAccept: application/json\r\nConnection: close\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| format!("failed to query daemon: {error}"))?;
+
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .map_err(|error| format!("failed to read daemon response: {error}"))?;
+    let body = parse_http_response(&response)?;
+    let stats: StatsConfigPath = serde_json::from_slice(&body)
+        .map_err(|error| format!("invalid daemon response: {error}"))?;
+    if stats.config_path.is_empty() {
+        Err("daemon returned an empty config path".to_string())
+    } else {
+        Ok(stats.config_path)
+    }
+}
+
+fn parse_http_response(response: &[u8]) -> Result<Vec<u8>, String> {
+    let header_end = response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(|| "invalid daemon HTTP response".to_string())?;
+    let headers = std::str::from_utf8(&response[..header_end])
+        .map_err(|error| format!("invalid daemon HTTP headers: {error}"))?;
+    let status = headers
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .ok_or_else(|| "missing daemon HTTP status".to_string())?;
+    if status != "200" {
+        return Err(format!("daemon returned HTTP {status}"));
+    }
+
+    let body = &response[header_end + 4..];
+    if headers.lines().any(|line| {
+        line.split_once(':').is_some_and(|(name, value)| {
+            name.eq_ignore_ascii_case("transfer-encoding")
+                && value.trim().eq_ignore_ascii_case("chunked")
+        })
+    }) {
+        decode_chunked_body(body)
+    } else {
+        Ok(body.to_vec())
+    }
+}
+
+fn decode_chunked_body(body: &[u8]) -> Result<Vec<u8>, String> {
+    let mut decoded = Vec::new();
+    let mut remaining = body;
+    loop {
+        let line_end = remaining
+            .windows(2)
+            .position(|window| window == b"\r\n")
+            .ok_or_else(|| "invalid chunked daemon response".to_string())?;
+        let size_text = std::str::from_utf8(&remaining[..line_end])
+            .map_err(|error| format!("invalid chunk size: {error}"))?;
+        let size = usize::from_str_radix(size_text.split(';').next().unwrap_or_default(), 16)
+            .map_err(|error| format!("invalid chunk size: {error}"))?;
+        remaining = &remaining[line_end + 2..];
+        if size == 0 {
+            return Ok(decoded);
+        }
+        if remaining.len() < size + 2 || &remaining[size..size + 2] != b"\r\n" {
+            return Err("truncated chunked daemon response".to_string());
+        }
+        decoded.extend_from_slice(&remaining[..size]);
+        remaining = &remaining[size + 2..];
+    }
+}
+
+fn config_is_writable(path: &Path) -> Result<bool, String> {
+    if !path.exists() {
+        return Ok(true);
+    }
+    match std::fs::OpenOptions::new().write(true).open(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => Ok(false),
+        Err(error) => Err(format!(
+            "failed to check whether {} is writable: {error}",
+            path.display()
+        )),
+    }
+}
+
+fn configured_editor() -> OsString {
+    std::env::var_os("EDITOR")
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var_os("VISUAL").filter(|value| !value.is_empty()))
+        .unwrap_or_else(|| {
+            if cfg!(windows) {
+                OsString::from("notepad")
+            } else {
+                OsString::from("vi")
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn local_config(path: &str, api_port: u16) -> crate::Result<ConfigLoad> {
+        let mut config = Config::default();
+        config.server.api_port = api_port;
+        Ok(ConfigLoad {
+            config,
+            path: path.to_string(),
+            found: true,
+        })
+    }
+
+    #[test]
+    fn daemon_path_takes_precedence() {
+        let resolved =
+            resolve_effective_config_path(local_config("/local/numa.toml", 6123), |port| {
+                assert_eq!(port, 6123);
+                Ok("/daemon/numa.toml".to_string())
+            })
+            .unwrap();
+
+        assert_eq!(resolved.display(), "/daemon/numa.toml");
+    }
+
+    #[test]
+    fn local_fallback_is_labeled() {
+        let resolved =
+            resolve_effective_config_path(local_config("/local/numa.toml", 5380), |_| {
+                Err("not running".to_string())
+            })
+            .unwrap();
+
+        assert_eq!(
+            resolved.display(),
+            "/local/numa.toml (daemon not running; resolved locally)"
+        );
+    }
+
+    #[test]
+    fn daemon_query_reads_config_path_from_stats() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 512];
+            let length = stream.read(&mut request).unwrap();
+            assert!(request[..length].starts_with(b"GET /stats HTTP/1.1\r\n"));
+            let body = br#"{"config_path":"/var/lib/numa/numa.toml"}"#;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .unwrap();
+            stream.write_all(body).unwrap();
+        });
+
+        assert_eq!(
+            query_daemon_config_path(port).unwrap(),
+            "/var/lib/numa/numa.toml"
+        );
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn chunked_stats_response_is_supported() {
+        let response = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\nf\r\n{\"config_path\":\r\n11\r\n\"/tmp/numa.toml\"}\r\n0\r\n\r\n";
+        let body = parse_http_response(response).unwrap();
+        let stats: StatsConfigPath = serde_json::from_slice(&body).unwrap();
+        assert_eq!(stats.config_path, "/tmp/numa.toml");
+    }
+}

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -1,33 +1,24 @@
 use crate::config::{ConfigLoad, ServerConfig};
 use serde::Deserialize;
-use std::ffi::OsString;
-use std::io::{Read, Write};
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpStream};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
 
 const DAEMON_TIMEOUT: Duration = Duration::from_millis(500);
+const DEFAULTS_NOTE: &str = "file does not exist yet, defaults apply";
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ConfigPathSource {
-    Daemon,
-    Local,
-}
-
-#[derive(Debug, Eq, PartialEq)]
 struct EffectiveConfigPath {
     path: String,
-    source: ConfigPathSource,
+    from_daemon: bool,
+    note: Option<String>,
 }
 
 impl EffectiveConfigPath {
     fn display(&self) -> String {
-        match self.source {
-            ConfigPathSource::Daemon => self.path.clone(),
-            ConfigPathSource::Local => {
-                format!("{} (daemon not running; resolved locally)", self.path)
-            }
+        match &self.note {
+            Some(note) => format!("{} ({note})", self.path),
+            None => self.path.clone(),
         }
     }
 }
@@ -35,43 +26,43 @@ impl EffectiveConfigPath {
 #[derive(Deserialize)]
 struct StatsConfigPath {
     config_path: String,
+    // Absent on daemons predating this field; assume the pre-existing behavior.
+    #[serde(default = "default_true")]
+    config_found: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 pub fn print_config_path() -> Result<(), String> {
     let resolved = effective_config_path()?;
-    println!("{}", resolved.display());
+    println!("{}", resolved.path);
+    if let Some(note) = &resolved.note {
+        eprintln!("note: {note}");
+    }
     Ok(())
 }
 
 pub fn edit_config() -> Result<(), String> {
     let resolved = effective_config_path()?;
     let path = Path::new(&resolved.path);
-    if !config_is_writable(path)? {
-        #[cfg(not(windows))]
-        eprintln!(
-            "warning: {} is not writable, re-run with sudo",
-            path.display()
-        );
-        #[cfg(windows)]
-        eprintln!("warning: {} is not writable", path.display());
-        return Ok(());
-    }
+    ensure_writable(path)?;
 
-    let editor = configured_editor();
+    let (editor, args) = configured_editor();
     let status = Command::new(&editor)
+        .args(&args)
         .arg(path)
         .status()
-        .map_err(|error| format!("failed to start {}: {error}", editor.to_string_lossy()))?;
-
-    println!("{}", resolved.display());
-    if status.success() {
-        Ok(())
-    } else {
-        Err(format!(
-            "{} exited with status {status}",
-            editor.to_string_lossy()
-        ))
+        .map_err(|error| format!("failed to start {editor}: {error}"))?;
+    if !status.success() {
+        return Err(format!("{editor} exited with status {status}"));
     }
+
+    if resolved.from_daemon {
+        eprintln!("note: restart numa to apply changes (numa service restart)");
+    }
+    Ok(())
 }
 
 pub(crate) fn service_config_path() -> Result<String, String> {
@@ -79,7 +70,7 @@ pub(crate) fn service_config_path() -> Result<String, String> {
 }
 
 fn effective_config_path() -> Result<EffectiveConfigPath, String> {
-    let local = crate::config::load_config("numa.toml");
+    let local = crate::config::load_config(&crate::cli_config_path());
     resolve_effective_config_path(local, query_daemon_config_path)
 }
 
@@ -88,162 +79,191 @@ fn resolve_effective_config_path<F>(
     query_daemon: F,
 ) -> Result<EffectiveConfigPath, String>
 where
-    F: FnOnce(u16) -> Result<String, String>,
+    F: FnOnce(&ServerConfig) -> Result<StatsConfigPath, String>,
 {
-    let api_port = local
+    let default_server = ServerConfig::default();
+    let server = local
         .as_ref()
-        .map(|loaded| loaded.config.server.api_port)
-        .unwrap_or_else(|_| ServerConfig::default().api_port);
+        .map(|loaded| &loaded.config.server)
+        .unwrap_or(&default_server);
 
-    if let Ok(path) = query_daemon(api_port) {
-        return Ok(EffectiveConfigPath {
-            path,
-            source: ConfigPathSource::Daemon,
-        });
-    }
-
-    let loaded = local.map_err(|error| error.to_string())?;
-    Ok(EffectiveConfigPath {
-        path: loaded.path,
-        source: ConfigPathSource::Local,
-    })
-}
-
-fn query_daemon_config_path(port: u16) -> Result<String, String> {
-    let address = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port));
-    let mut stream = TcpStream::connect_timeout(&address, DAEMON_TIMEOUT)
-        .map_err(|error| format!("daemon connection failed: {error}"))?;
-    stream
-        .set_read_timeout(Some(DAEMON_TIMEOUT))
-        .map_err(|error| format!("failed to set daemon read timeout: {error}"))?;
-    stream
-        .set_write_timeout(Some(DAEMON_TIMEOUT))
-        .map_err(|error| format!("failed to set daemon write timeout: {error}"))?;
-
-    let request = format!(
-        "GET /stats HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nAccept: application/json\r\nConnection: close\r\n\r\n"
-    );
-    stream
-        .write_all(request.as_bytes())
-        .map_err(|error| format!("failed to query daemon: {error}"))?;
-
-    let mut response = Vec::new();
-    stream
-        .read_to_end(&mut response)
-        .map_err(|error| format!("failed to read daemon response: {error}"))?;
-    let body = parse_http_response(&response)?;
-    let stats: StatsConfigPath = serde_json::from_slice(&body)
-        .map_err(|error| format!("invalid daemon response: {error}"))?;
-    if stats.config_path.is_empty() {
-        Err("daemon returned an empty config path".to_string())
-    } else {
-        Ok(stats.config_path)
-    }
-}
-
-fn parse_http_response(response: &[u8]) -> Result<Vec<u8>, String> {
-    let header_end = response
-        .windows(4)
-        .position(|window| window == b"\r\n\r\n")
-        .ok_or_else(|| "invalid daemon HTTP response".to_string())?;
-    let headers = std::str::from_utf8(&response[..header_end])
-        .map_err(|error| format!("invalid daemon HTTP headers: {error}"))?;
-    let status = headers
-        .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().nth(1))
-        .ok_or_else(|| "missing daemon HTTP status".to_string())?;
-    if status != "200" {
-        return Err(format!("daemon returned HTTP {status}"));
-    }
-
-    let body = &response[header_end + 4..];
-    if headers.lines().any(|line| {
-        line.split_once(':').is_some_and(|(name, value)| {
-            name.eq_ignore_ascii_case("transfer-encoding")
-                && value.trim().eq_ignore_ascii_case("chunked")
-        })
-    }) {
-        decode_chunked_body(body)
-    } else {
-        Ok(body.to_vec())
-    }
-}
-
-fn decode_chunked_body(body: &[u8]) -> Result<Vec<u8>, String> {
-    let mut decoded = Vec::new();
-    let mut remaining = body;
-    loop {
-        let line_end = remaining
-            .windows(2)
-            .position(|window| window == b"\r\n")
-            .ok_or_else(|| "invalid chunked daemon response".to_string())?;
-        let size_text = std::str::from_utf8(&remaining[..line_end])
-            .map_err(|error| format!("invalid chunk size: {error}"))?;
-        let size = usize::from_str_radix(size_text.split(';').next().unwrap_or_default(), 16)
-            .map_err(|error| format!("invalid chunk size: {error}"))?;
-        remaining = &remaining[line_end + 2..];
-        if size == 0 {
-            return Ok(decoded);
-        }
-        if remaining.len() < size + 2 || &remaining[size..size + 2] != b"\r\n" {
-            return Err("truncated chunked daemon response".to_string());
-        }
-        decoded.extend_from_slice(&remaining[..size]);
-        remaining = &remaining[size + 2..];
-    }
-}
-
-fn config_is_writable(path: &Path) -> Result<bool, String> {
-    if !path.exists() {
-        return Ok(true);
-    }
-    match std::fs::OpenOptions::new().write(true).open(path) {
-        Ok(_) => Ok(true),
-        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => Ok(false),
-        Err(error) => Err(format!(
-            "failed to check whether {} is writable: {error}",
-            path.display()
-        )),
-    }
-}
-
-fn configured_editor() -> OsString {
-    std::env::var_os("EDITOR")
-        .filter(|value| !value.is_empty())
-        .or_else(|| std::env::var_os("VISUAL").filter(|value| !value.is_empty()))
-        .unwrap_or_else(|| {
-            if cfg!(windows) {
-                OsString::from("notepad")
-            } else {
-                OsString::from("vi")
+    match query_daemon(server) {
+        Ok(stats) => Ok(EffectiveConfigPath {
+            path: stats.config_path,
+            from_daemon: true,
+            note: (!stats.config_found).then(|| DEFAULTS_NOTE.to_string()),
+        }),
+        Err(probe_error) => {
+            let loaded = local.map_err(|error| error.to_string())?;
+            let mut note = format!("{probe_error}; resolved locally");
+            if !loaded.found {
+                note.push_str("; ");
+                note.push_str(DEFAULTS_NOTE);
             }
-        })
+            Ok(EffectiveConfigPath {
+                path: loaded.path,
+                from_daemon: false,
+                note: Some(note),
+            })
+        }
+    }
+}
+
+fn probe_addr(server: &ServerConfig) -> SocketAddr {
+    let ip = match server.api_bind_addr.parse::<IpAddr>() {
+        Ok(IpAddr::V4(ip)) if ip.is_unspecified() => IpAddr::V4(Ipv4Addr::LOCALHOST),
+        Ok(IpAddr::V6(ip)) if ip.is_unspecified() => IpAddr::V6(Ipv6Addr::LOCALHOST),
+        Ok(ip) => ip,
+        Err(_) => IpAddr::V4(Ipv4Addr::LOCALHOST),
+    };
+    SocketAddr::new(ip, server.api_port)
+}
+
+fn query_daemon_config_path(server: &ServerConfig) -> Result<StatsConfigPath, String> {
+    let addr = probe_addr(server);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("failed to start probe runtime: {error}"))?;
+    runtime.block_on(fetch_daemon_config(addr))
+}
+
+async fn fetch_daemon_config(addr: SocketAddr) -> Result<StatsConfigPath, String> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let client = reqwest::Client::builder()
+        .timeout(DAEMON_TIMEOUT)
+        .build()
+        .map_err(|error| format!("failed to build probe client: {error}"))?;
+    let response = client
+        .get(format!("http://{addr}/stats"))
+        .send()
+        .await
+        .map_err(|error| {
+            if error.is_connect() || error.is_timeout() {
+                format!("daemon not reachable at {addr}")
+            } else {
+                format!("daemon probe failed: {}", error.without_url())
+            }
+        })?;
+    if response.status() != reqwest::StatusCode::OK {
+        return Err(format!(
+            "daemon returned HTTP {}",
+            response.status().as_u16()
+        ));
+    }
+    let body = response
+        .text()
+        .await
+        .map_err(|error| format!("failed to read daemon response: {}", error.without_url()))?;
+    let stats: StatsConfigPath =
+        serde_json::from_str(&body).map_err(|_| "unexpected daemon response".to_string())?;
+    if stats.config_path.is_empty() {
+        return Err("daemon returned an empty config path".to_string());
+    }
+    Ok(stats)
+}
+
+fn ensure_writable(path: &Path) -> Result<(), String> {
+    let probe = if path.exists() {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .map(|_| false)
+    } else {
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                if error.kind() == std::io::ErrorKind::PermissionDenied {
+                    not_writable_message(path)
+                } else {
+                    format!("cannot create {}: {error}", parent.display())
+                }
+            })?;
+        }
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .map(|_| true)
+    };
+    match probe {
+        Ok(created) => {
+            if created {
+                let _ = std::fs::remove_file(path);
+            }
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+            Err(not_writable_message(path))
+        }
+        Err(error) => Err(format!("cannot write {}: {error}", path.display())),
+    }
+}
+
+fn not_writable_message(path: &Path) -> String {
+    if cfg!(windows) {
+        format!("{} is not writable", path.display())
+    } else {
+        format!("{} is not writable, re-run with sudo", path.display())
+    }
+}
+
+fn configured_editor() -> (String, Vec<String>) {
+    let value = ["VISUAL", "EDITOR"]
+        .iter()
+        .filter_map(|name| std::env::var(name).ok())
+        .find(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| default_editor().to_string());
+    split_editor(&value)
+}
+
+fn default_editor() -> &'static str {
+    if cfg!(windows) {
+        "notepad"
+    } else {
+        "vi"
+    }
+}
+
+fn split_editor(value: &str) -> (String, Vec<String>) {
+    let mut parts = value.split_whitespace().map(str::to_string);
+    let program = parts.next().unwrap_or_else(|| default_editor().to_string());
+    (program, parts.collect())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::Config;
+    use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
 
-    fn local_config(path: &str, api_port: u16) -> crate::Result<ConfigLoad> {
+    fn local_config(path: &str, api_port: u16, found: bool) -> crate::Result<ConfigLoad> {
         let mut config = Config::default();
         config.server.api_port = api_port;
         Ok(ConfigLoad {
             config,
             path: path.to_string(),
-            found: true,
+            found,
         })
+    }
+
+    fn daemon_config(path: &str, found: bool) -> StatsConfigPath {
+        StatsConfigPath {
+            config_path: path.to_string(),
+            config_found: found,
+        }
     }
 
     #[test]
     fn daemon_path_takes_precedence() {
         let resolved =
-            resolve_effective_config_path(local_config("/local/numa.toml", 6123), |port| {
-                assert_eq!(port, 6123);
-                Ok("/daemon/numa.toml".to_string())
+            resolve_effective_config_path(local_config("/local/numa.toml", 6123, true), |server| {
+                assert_eq!(server.api_port, 6123);
+                Ok(daemon_config("/daemon/numa.toml", true))
             })
             .unwrap();
 
@@ -251,17 +271,67 @@ mod tests {
     }
 
     #[test]
-    fn local_fallback_is_labeled() {
+    fn daemon_on_defaults_is_labeled() {
         let resolved =
-            resolve_effective_config_path(local_config("/local/numa.toml", 5380), |_| {
-                Err("not running".to_string())
+            resolve_effective_config_path(local_config("/local/numa.toml", 5380, true), |_| {
+                Ok(daemon_config("/daemon/numa.toml", false))
             })
             .unwrap();
 
         assert_eq!(
             resolved.display(),
-            "/local/numa.toml (daemon not running; resolved locally)"
+            "/daemon/numa.toml (file does not exist yet, defaults apply)"
         );
+    }
+
+    #[test]
+    fn local_fallback_is_labeled_with_probe_error() {
+        let resolved =
+            resolve_effective_config_path(local_config("/local/numa.toml", 5380, true), |_| {
+                Err("daemon not reachable at 127.0.0.1:5380".to_string())
+            })
+            .unwrap();
+
+        assert_eq!(
+            resolved.display(),
+            "/local/numa.toml (daemon not reachable at 127.0.0.1:5380; resolved locally)"
+        );
+    }
+
+    #[test]
+    fn local_fallback_without_file_is_labeled() {
+        let resolved =
+            resolve_effective_config_path(local_config("/local/numa.toml", 5380, false), |_| {
+                Err("daemon not reachable at 127.0.0.1:5380".to_string())
+            })
+            .unwrap();
+
+        assert_eq!(
+            resolved.display(),
+            "/local/numa.toml (daemon not reachable at 127.0.0.1:5380; resolved locally; \
+             file does not exist yet, defaults apply)"
+        );
+    }
+
+    #[test]
+    fn probe_addr_maps_unspecified_to_loopback() {
+        let mut server = ServerConfig {
+            api_bind_addr: "0.0.0.0".to_string(),
+            ..ServerConfig::default()
+        };
+        assert_eq!(probe_addr(&server).ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        server.api_bind_addr = "::".to_string();
+        assert_eq!(probe_addr(&server).ip(), IpAddr::V6(Ipv6Addr::LOCALHOST));
+    }
+
+    #[test]
+    fn probe_addr_uses_configured_bind_addr() {
+        let server = ServerConfig {
+            api_bind_addr: "192.168.1.10".to_string(),
+            api_port: 6123,
+            ..ServerConfig::default()
+        };
+        assert_eq!(probe_addr(&server).to_string(), "192.168.1.10:6123");
     }
 
     #[test]
@@ -270,10 +340,10 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
-            let mut request = [0_u8; 512];
+            let mut request = [0_u8; 1024];
             let length = stream.read(&mut request).unwrap();
             assert!(request[..length].starts_with(b"GET /stats HTTP/1.1\r\n"));
-            let body = br#"{"config_path":"/var/lib/numa/numa.toml"}"#;
+            let body = br#"{"config_path":"/var/lib/numa/numa.toml","config_found":true}"#;
             write!(
                 stream,
                 "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -283,18 +353,60 @@ mod tests {
             stream.write_all(body).unwrap();
         });
 
-        assert_eq!(
-            query_daemon_config_path(port).unwrap(),
-            "/var/lib/numa/numa.toml"
-        );
+        let config = ServerConfig {
+            api_port: port,
+            ..ServerConfig::default()
+        };
+        let stats = query_daemon_config_path(&config).unwrap();
+        assert_eq!(stats.config_path, "/var/lib/numa/numa.toml");
+        assert!(stats.config_found);
         server.join().unwrap();
     }
 
     #[test]
-    fn chunked_stats_response_is_supported() {
-        let response = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\nf\r\n{\"config_path\":\r\n11\r\n\"/tmp/numa.toml\"}\r\n0\r\n\r\n";
-        let body = parse_http_response(response).unwrap();
-        let stats: StatsConfigPath = serde_json::from_slice(&body).unwrap();
-        assert_eq!(stats.config_path, "/tmp/numa.toml");
+    fn missing_config_found_defaults_to_true() {
+        let stats: StatsConfigPath =
+            serde_json::from_str(r#"{"config_path":"/etc/numa.toml"}"#).unwrap();
+        assert!(stats.config_found);
+    }
+
+    #[test]
+    fn split_editor_handles_arguments() {
+        assert_eq!(
+            split_editor("code --wait"),
+            ("code".to_string(), vec!["--wait".to_string()])
+        );
+        assert_eq!(split_editor("vi"), ("vi".to_string(), vec![]));
+    }
+
+    #[test]
+    fn ensure_writable_accepts_missing_file_in_writable_dir() {
+        let dir = std::env::temp_dir().join("numa-config-cli-test");
+        let path = dir.join("nested").join("numa.toml");
+        let _ = std::fs::remove_dir_all(&dir);
+        ensure_writable(&path).unwrap();
+        assert!(!path.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_writable_rejects_read_only_dir() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join("numa-config-cli-ro-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+        if std::fs::write(dir.join("probe"), b"").is_ok() {
+            // Mode bits don't bind this user (running as root); nothing to assert.
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+            let _ = std::fs::remove_dir_all(&dir);
+            return;
+        }
+        let path = dir.join("numa.toml");
+        let error = ensure_writable(&path).unwrap_err();
+        assert!(error.contains("not writable"), "error was: {error}");
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod buffer;
 pub mod cache;
 pub mod client_policy;
 pub mod config;
+pub mod config_cli;
 pub mod ctx;
 pub mod dnssec;
 pub mod doh;

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,17 @@ fn main() -> numa::Result<()> {
                 }
             };
         }
+        "config" => {
+            let sub = std::env::args().nth(2).unwrap_or_default();
+            return match sub.as_str() {
+                "path" => numa::config_cli::print_config_path().map_err(|e| e.into()),
+                "edit" => numa::config_cli::edit_config().map_err(|e| e.into()),
+                _ => {
+                    eprintln!("Usage: numa config <path|edit>");
+                    Ok(())
+                }
+            };
+        }
         "setup-phone" => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -141,6 +152,8 @@ fn main() -> numa::Result<()> {
             eprintln!("  service stop    Uninstall the system service");
             eprintln!("  service restart Restart the service with updated binary");
             eprintln!("  service status  Check if the service is running");
+            eprintln!("  config path     Show the effective config file");
+            eprintln!("  config edit     Open the effective config file in an editor");
             eprintln!("  lan on|off      Enable/disable LAN service discovery (mDNS)");
             eprintln!("  block on|off    Enable/disable ad-blocking");
             eprintln!("  dnssec on|off   Enable/disable DNSSEC validation");

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -1350,6 +1350,7 @@ fn parse_launchctl_program(stdout: &[u8]) -> Result<String, String> {
 
 /// Show the service status.
 pub fn service_status() -> Result<(), String> {
+    eprintln!("  config: {}", crate::config_cli::service_config_path()?);
     #[cfg(target_os = "macos")]
     {
         service_status_macos()

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -1350,7 +1350,10 @@ fn parse_launchctl_program(stdout: &[u8]) -> Result<String, String> {
 
 /// Show the service status.
 pub fn service_status() -> Result<(), String> {
-    eprintln!("  config: {}", crate::config_cli::service_config_path()?);
+    match crate::config_cli::service_config_path() {
+        Ok(path) => eprintln!("  config: {path}"),
+        Err(error) => eprintln!("  config: <unavailable: {error}>"),
+    }
     #[cfg(target_os = "macos")]
     {
         service_status_macos()


### PR DESCRIPTION
Closes #328

Adds `numa config path` and `numa config edit`. Both prefer the running daemon's `/stats` response and clearly label the existing local config walk when the daemon is unavailable. Editing honors `EDITOR`, `VISUAL`, and the platform fallback, and refuses to open an existing config that is not writable.

`numa service status` now prints the same effective config path before the platform service details.

Tests:
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo audit`