### PR TITLE
fix(forward): TC=1 escape hatch and DO-bit walker hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1924,7 +1924,7 @@ dependencies = [
  "libc",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2193,7 +2193,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3039,7 +3039,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/fuzz/fuzz_targets/wire_patch.rs
+++ b/fuzz/fuzz_targets/wire_patch.rs
@@ -6,7 +6,7 @@
 //! `patch_ttls`, which does not re-check them — a bad offset there is an
 //! out-of-bounds write on the cache path, reachable from any upstream reply.
 use libfuzzer_sys::fuzz_target;
-use numa::wire::{ensure_do_bit, min_ttl_from_wire, patch_ttls, scan_ttl_offsets};
+use numa::wire::{ensure_do_bit, min_ttl_from_wire, patch_ttls, scan_ttl_offsets, APPENDED_DO_OPT};
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(meta) = scan_ttl_offsets(data) {
@@ -27,9 +27,8 @@ fuzz_target!(|data: &[u8]| {
     // Uncounted trailing bytes are dropped, so a shorter result is legal — but
     // only from the append path, which ends in the OPT it just wrote. Any other
     // shrink means counted records went missing.
-    const APPENDED_OPT: [u8; 11] = [0, 0, 41, 0x04, 0xD0, 0, 0, 0x80, 0, 0, 0];
     assert!(
-        patched.len() >= data.len() || patched.ends_with(&APPENDED_OPT),
+        patched.len() >= data.len() || patched.ends_with(&APPENDED_DO_OPT),
         "ensure_do_bit dropped bytes without appending an OPT"
     );
     if data.len() >= 12 {

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -577,6 +577,17 @@ pub async fn forward_with_failover_raw(
                     let rtt_ms = start.elapsed().as_millis() as u64;
                     srtt.write().unwrap().record_rtt(ip, t, rtt_ms);
                 }
+                // TC=1 says "retry over TCP" (RFC 1035 §4.2.1) and DO=1/1232
+                // makes it routine for large signed answers. Our own clients'
+                // TCP retries re-enter this same UDP path, so the protocol
+                // switch has to happen here or nowhere.
+                if crate::wire::is_truncated(&resp) {
+                    if let Upstream::Udp(addr) = upstream {
+                        if let Ok(full) = forward_tcp_raw(wire, *addr, timeout_duration).await {
+                            return Ok(full);
+                        }
+                    }
+                }
                 return Ok(resp);
             }
             Err(e) => {
@@ -981,6 +992,68 @@ mod tests {
         let mut buf = BytePacketBuffer::from_bytes(&resp_wire);
         let result = DnsPacket::from_buffer(&mut buf).unwrap();
         assert_eq!(result.header.id, 0xABCD);
+        assert_eq!(result.answers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn failover_retries_truncated_udp_over_tcp() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let query = make_query();
+        let full_wire = to_wire(&make_response(&query));
+
+        // UDP and TCP share the port: UDP always answers TC=1 with no
+        // records, TCP has the full answer — the shape of a signed response
+        // that outgrows the 1232-byte UDP budget. Without the TCP retry the
+        // TC reply is final: the client's own TCP retry re-enters this same
+        // UDP path and loops forever.
+        let udp = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let addr = udp.local_addr().unwrap();
+        let tcp = tokio::net::TcpListener::bind(addr).await.unwrap();
+
+        let mut tc = make_response(&query);
+        tc.answers.clear();
+        tc.header.truncated_message = true;
+        let tc_wire = to_wire(&tc);
+        tokio::spawn(async move {
+            let mut buf = [0u8; 4096];
+            while let Ok((n, src)) = udp.recv_from(&mut buf).await {
+                let mut reply = tc_wire.clone();
+                reply[0] = buf[0];
+                reply[1] = buf[1];
+                let _ = udp.send_to(&reply, src).await;
+                let _ = n;
+            }
+        });
+        tokio::spawn(async move {
+            let (mut stream, _) = tcp.accept().await.unwrap();
+            let mut len_buf = [0u8; 2];
+            stream.read_exact(&mut len_buf).await.unwrap();
+            let mut query_wire = vec![0u8; u16::from_be_bytes(len_buf) as usize];
+            stream.read_exact(&mut query_wire).await.unwrap();
+            let mut reply = full_wire.clone();
+            reply[0] = query_wire[0];
+            reply[1] = query_wire[1];
+            let mut out = Vec::with_capacity(2 + reply.len());
+            out.extend_from_slice(&(reply.len() as u16).to_be_bytes());
+            out.extend_from_slice(&reply);
+            stream.write_all(&out).await.unwrap();
+        });
+
+        let pool = UpstreamPool::new(vec![Upstream::Udp(addr)], vec![]);
+        let srtt = RwLock::new(SrttCache::new(true));
+        let resp_wire = forward_with_failover_raw(
+            &to_wire(&query),
+            &pool,
+            &srtt,
+            Duration::from_millis(500),
+            Duration::ZERO,
+        )
+        .await
+        .expect("truncated UDP answer must resolve over TCP");
+
+        assert!(!crate::wire::is_truncated(&resp_wire));
+        let mut buf = BytePacketBuffer::from_bytes(&resp_wire);
+        let result = DnsPacket::from_buffer(&mut buf).unwrap();
         assert_eq!(result.answers.len(), 1);
     }
 

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -123,28 +123,20 @@ pub fn aaaa_record_response(domain: &str, addr: std::net::Ipv6Addr, ttl: u32) ->
     }])
 }
 
-/// Spawn a UDP socket that replies to the first DNS query with the given
-/// response packet (patching the query ID to match). Returns the socket address.
+/// Spawn a UDP socket that answers every DNS query with the given response
+/// packet, honoring the query's advertised payload budget (TC=1 when the
+/// answer does not fit) and patching the query ID. Returns the socket address.
 pub async fn mock_upstream(response: DnsPacket) -> SocketAddr {
     let mut out = BytePacketBuffer::new();
     response.write(&mut out).unwrap();
-    mock_upstream_raw(out.filled().to_vec()).await
+    spawn_stub(out.filled().to_vec(), true, None).await
 }
 
-/// Like `mock_upstream` but sends raw wire bytes — for intentionally
-/// malformed responses that can't survive our own serializer.
+/// Like `mock_upstream` but sends raw wire bytes verbatim — for intentionally
+/// malformed responses that can't survive our own serializer, which must reach
+/// the resolver's parser untouched (no budget substitution).
 pub async fn mock_upstream_raw(bytes: Vec<u8>) -> SocketAddr {
-    let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-    let addr = sock.local_addr().unwrap();
-    tokio::spawn(async move {
-        let mut buf = [0u8; 4096];
-        let (n, src) = sock.recv_from(&mut buf).await.unwrap();
-        let mut reply = reply_within_budget(&bytes, &buf[..n]);
-        reply[0] = buf[0];
-        reply[1] = buf[1];
-        sock.send_to(&reply, src).await.unwrap();
-    });
-    addr
+    spawn_stub(bytes, false, None).await
 }
 
 /// Spawn a UDP socket that answers every query by qname from the given table
@@ -162,7 +154,7 @@ pub async fn mock_upstream_by_qname(responses: Vec<(&str, DnsPacket)>) -> Socket
     let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let addr = sock.local_addr().unwrap();
     tokio::spawn(async move {
-        let mut buf = [0u8; 512];
+        let mut buf = [0u8; 4096];
         while let Ok((n, src)) = sock.recv_from(&mut buf).await {
             let mut query_buf = BytePacketBuffer::from_bytes(&buf[..n]);
             let Ok(query) = DnsPacket::from_buffer(&mut query_buf) else {
@@ -187,27 +179,45 @@ pub async fn mock_upstream_by_qname(responses: Vec<(&str, DnsPacket)>) -> Socket
 /// (e.g. the DO bit, issue #191).
 pub async fn recording_upstream(
     response: DnsPacket,
-) -> (SocketAddr, tokio::sync::mpsc::Receiver<Vec<u8>>) {
+) -> (SocketAddr, tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>) {
     let mut out = BytePacketBuffer::new();
     response.write(&mut out).unwrap();
-    let bytes = out.filled().to_vec();
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let addr = spawn_stub(out.filled().to_vec(), true, Some(tx)).await;
+    (addr, rx)
+}
 
+/// The one stub-upstream socket loop behind `mock_upstream`,
+/// `mock_upstream_raw` and `recording_upstream`: answer every query with
+/// `bytes` (ID patched), optionally within the query's advertised budget,
+/// optionally reporting each inbound query wire. The unbounded recorder
+/// cannot block the reply loop, whatever the test's drain cadence.
+async fn spawn_stub(
+    bytes: Vec<u8>,
+    honor_budget: bool,
+    record: Option<tokio::sync::mpsc::UnboundedSender<Vec<u8>>>,
+) -> SocketAddr {
     let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let addr = sock.local_addr().unwrap();
-    let (tx, rx) = tokio::sync::mpsc::channel(8);
     tokio::spawn(async move {
-        let mut buf = [0u8; 1500];
-        while let Ok((n, peer)) = sock.recv_from(&mut buf).await {
-            let mut reply = reply_within_budget(&bytes, &buf[..n]);
+        let mut buf = [0u8; 4096];
+        while let Ok((n, src)) = sock.recv_from(&mut buf).await {
+            let mut reply = if honor_budget {
+                reply_within_budget(&bytes, &buf[..n])
+            } else {
+                bytes.clone()
+            };
             reply[0] = buf[0];
             reply[1] = buf[1];
-            let _ = sock.send_to(&reply, peer).await;
-            if tx.send(buf[..n].to_vec()).await.is_err() {
-                break;
+            let _ = sock.send_to(&reply, src).await;
+            if let Some(tx) = &record {
+                if tx.send(buf[..n].to_vec()).is_err() {
+                    break;
+                }
             }
         }
     });
-    (addr, rx)
+    addr
 }
 
 /// A resolver honors the requestor's advertised payload size: an answer that

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -19,14 +19,21 @@ pub struct WireMeta {
     pub answer_count: usize,
 }
 
-/// An OPT record always carries the root name (RFC 6891 §6.1.2), so these
-/// three bytes — root label, then type 41 — identify one without walking it.
-const OPT_RECORD_HEAD: [u8; 3] = [0x00, 0x00, 41];
-
 /// Read a 16-bit section count from the header.
 fn count(wire: &[u8], at: usize) -> usize {
     u16::from_be_bytes([wire[at], wire[at + 1]]) as usize
 }
+
+/// A record's TYPE sits in the two bytes before its CLASS, four before its
+/// TTL. Matching on it (not on literal root-name bytes) catches an OPT whose
+/// owner name reaches root through a compression pointer — the same trap
+/// `DnsPacket::read` already guards against.
+fn record_type(wire: &[u8], ttl_offset: usize) -> u16 {
+    u16::from_be_bytes([wire[ttl_offset - 4], wire[ttl_offset - 3]])
+}
+
+const TYPE_OPT: u16 = 41;
+const TYPE_TSIG: u16 = 250;
 
 /// Scan a DNS response's wire bytes and return metadata about TTL field locations.
 ///
@@ -49,9 +56,8 @@ pub fn scan_ttl_offsets(wire: &[u8]) -> Result<WireMeta> {
     // ANCOUNT, NSCOUNT, ARCOUNT: answers first, so they lead `ttl_offsets`.
     for (section, at) in [6, 8, 10].into_iter().enumerate() {
         for _ in 0..count(wire, at) {
-            let is_opt = wire.get(pos..pos + 3) == Some(&OPT_RECORD_HEAD[..]);
             let ttl_offset = skip_record(wire, &mut pos)?;
-            if !is_opt {
+            if record_type(wire, ttl_offset) != TYPE_OPT {
                 ttl_offsets.push(ttl_offset);
                 if section == 0 {
                     answer_count += 1;
@@ -121,16 +127,15 @@ pub fn is_truncated(wire: &[u8]) -> bool {
 /// (issue #191). Wires we cannot walk go upstream as they came.
 pub fn ensure_do_bit(wire: &[u8]) -> Cow<'_, [u8]> {
     match locate_opt(wire) {
-        Ok(OptSite::Flag(ttl))
-            if wire[ttl + 2] & DO_FLAG != 0 && payload_fits_dnssec(wire, ttl) =>
-        {
+        Ok(OptSite::Flag(ttl)) if wire[ttl + 2] & DO_FLAG != 0 && payload_in_budget(wire, ttl) => {
             Cow::Borrowed(wire)
         }
         Ok(OptSite::Flag(ttl)) => {
             let mut out = wire.to_vec();
             out[ttl + 2] |= DO_FLAG;
-            if !payload_fits_dnssec(&out, ttl) {
-                out[ttl - 2..ttl].copy_from_slice(&MIN_UPSTREAM_PAYLOAD.to_be_bytes());
+            if !payload_in_budget(&out, ttl) {
+                let clamped = payload(&out, ttl).clamp(MIN_UPSTREAM_PAYLOAD, MAX_UPSTREAM_PAYLOAD);
+                out[ttl - 2..ttl].copy_from_slice(&clamped.to_be_bytes());
             }
             Cow::Owned(out)
         }
@@ -147,23 +152,36 @@ pub fn ensure_do_bit(wire: &[u8]) -> Cow<'_, [u8]> {
 /// with no records, for answers that fit unsigned.
 const MIN_UPSTREAM_PAYLOAD: u16 = crate::packet::DEFAULT_EDNS_PAYLOAD;
 
+/// Ceiling on the budget we advertise: `forward_udp_raw` receives into 4096
+/// bytes, and a reply larger than the buffer is silently cut into a wire that
+/// cannot parse. Never invite an answer we cannot receive.
+const MAX_UPSTREAM_PAYLOAD: u16 = 4096;
+
+/// The bare OPT `append_do_opt` writes: root name, TYPE=41, our payload
+/// budget, DO=1. Public so the fuzz oracle asserts against the same bytes.
+pub const APPENDED_DO_OPT: [u8; 11] = {
+    let p = MIN_UPSTREAM_PAYLOAD.to_be_bytes();
+    [0, 0, 41, p[0], p[1], 0, 0, DO_FLAG, 0, 0, 0]
+};
+
 /// The OPT's CLASS field, which holds the payload size, sits in the two bytes
 /// before its TTL.
-fn payload_fits_dnssec(wire: &[u8], ttl: usize) -> bool {
-    u16::from_be_bytes([wire[ttl - 2], wire[ttl - 1]]) >= MIN_UPSTREAM_PAYLOAD
+fn payload(wire: &[u8], ttl: usize) -> u16 {
+    u16::from_be_bytes([wire[ttl - 2], wire[ttl - 1]])
+}
+
+fn payload_in_budget(wire: &[u8], ttl: usize) -> bool {
+    (MIN_UPSTREAM_PAYLOAD..=MAX_UPSTREAM_PAYLOAD).contains(&payload(wire, ttl))
 }
 
 /// `None` when ARCOUNT cannot cover one more record, since an appended OPT
 /// the count does not reach is trailing garbage to the upstream.
 fn append_do_opt(wire: &[u8]) -> Option<Vec<u8>> {
     let arcount = u16::from_be_bytes([wire[10], wire[11]]).checked_add(1)?;
-    let mut out = Vec::with_capacity(wire.len() + 11);
+    let mut out = Vec::with_capacity(wire.len() + APPENDED_DO_OPT.len());
     out.extend_from_slice(wire);
     out[10..12].copy_from_slice(&arcount.to_be_bytes());
-    out.extend_from_slice(&OPT_RECORD_HEAD);
-    out.extend_from_slice(&crate::packet::DEFAULT_EDNS_PAYLOAD.to_be_bytes());
-    out.extend_from_slice(&[0, 0, DO_FLAG, 0]); // ext-rcode, version, DO=1
-    out.extend_from_slice(&[0, 0]); // RDLENGTH
+    out.extend_from_slice(&APPENDED_DO_OPT);
     Some(out)
 }
 
@@ -190,10 +208,14 @@ fn locate_opt(wire: &[u8]) -> Result<OptSite> {
         skip_record(wire, &mut pos)?;
     }
     for _ in 0..count(wire, 10) {
-        let is_opt = wire.get(pos..pos + 3) == Some(&OPT_RECORD_HEAD[..]);
         let ttl_offset = skip_record(wire, &mut pos)?;
-        if is_opt {
-            return Ok(OptSite::Flag(ttl_offset));
+        match record_type(wire, ttl_offset) {
+            TYPE_OPT => return Ok(OptSite::Flag(ttl_offset)),
+            // A TSIG must stay the last record and its MAC covers the header
+            // (RFC 8945 §5.1) — appending an OPT behind it, or bumping
+            // ARCOUNT, voids the signature. Not ours to patch.
+            TYPE_TSIG => return Err("TSIG-signed message".into()),
+            _ => {}
         }
     }
 
@@ -1591,6 +1613,58 @@ mod tests {
     }
 
     #[test]
+    fn ensure_do_bit_lowers_a_payload_size_the_receive_buffer_cannot_hold() {
+        // `forward_udp_raw` receives into 4096 bytes; advertising 65535 invites
+        // a reply the kernel cuts mid-record into a wire that cannot parse.
+        let mut query = DnsPacket::query(0xABCD, "example.com", QueryType::A);
+        query.edns = Some(EdnsOpt {
+            udp_payload_size: 65535,
+            do_bit: true,
+            ..Default::default()
+        });
+        let wire = to_wire(&query);
+        let edns = parse_wire(&ensure_do_bit(&wire)).edns.expect("OPT present");
+
+        assert_eq!(edns.udp_payload_size, MAX_UPSTREAM_PAYLOAD);
+    }
+
+    #[test]
+    fn ensure_do_bit_patches_an_opt_named_via_compression_pointer() {
+        // RFC 6891 wants a literal root name on the OPT, but a peer can reach
+        // root through a compression pointer — packet.rs guards this exact
+        // shape. Missing it here would append a second OPT (FORMERR upstream).
+        let mut wire = query_wire();
+        wire[10..12].copy_from_slice(&1u16.to_be_bytes()); // ARCOUNT
+        let root_offset = wire.len() - 5; // qname's terminating root label
+        assert_eq!(wire[root_offset], 0);
+        let do_byte = wire.len() + 8; // pointer(2) + type + class + 2 into TTL
+        wire.extend_from_slice(&[0xC0, root_offset as u8]);
+        wire.extend_from_slice(&[0, 41]); // TYPE=OPT
+        wire.extend_from_slice(&MIN_UPSTREAM_PAYLOAD.to_be_bytes());
+        wire.extend_from_slice(&[0, 0, 0, 0, 0, 0]); // TTL (DO clear), RDLENGTH
+
+        let out = ensure_do_bit(&wire);
+
+        assert_eq!(out.len(), wire.len(), "patched in place, no second OPT");
+        assert_eq!(out[do_byte] & DO_FLAG, DO_FLAG, "DO set on the found OPT");
+    }
+
+    #[test]
+    fn ensure_do_bit_leaves_tsig_signed_wires_untouched() {
+        // A TSIG's MAC covers the header and the record must stay last
+        // (RFC 8945 §5.1); patching would void the signature upstream.
+        let mut wire = query_wire();
+        wire[10..12].copy_from_slice(&1u16.to_be_bytes()); // ARCOUNT
+        wire.extend_from_slice(&[0]); // root name
+        wire.extend_from_slice(&250u16.to_be_bytes()); // TYPE=TSIG
+        wire.extend_from_slice(&[0, 255]); // CLASS=ANY
+        wire.extend_from_slice(&[0, 0, 0, 0]); // TTL
+        wire.extend_from_slice(&[0, 0]); // RDLENGTH
+
+        assert_eq!(&ensure_do_bit(&wire)[..], &wire[..]);
+    }
+
+    #[test]
     fn ensure_do_bit_leaves_do_queries_byte_identical() {
         let mut query = DnsPacket::query(0xABCD, "example.com", QueryType::A);
         query.edns = Some(EdnsOpt {
@@ -1622,7 +1696,7 @@ mod tests {
         let mut wire = query_wire();
         wire[10..12].copy_from_slice(&1u16.to_be_bytes()); // ARCOUNT
         let do_byte = wire.len() + 7; // root name + type + class + 2 into TTL
-        wire.extend_from_slice(&OPT_RECORD_HEAD);
+        wire.extend_from_slice(&[0, 0, 41]); // root name, TYPE=OPT
         wire.extend_from_slice(&crate::packet::DEFAULT_EDNS_PAYLOAD.to_be_bytes());
         wire.extend_from_slice(&[0, 0, 0, 0]); // TTL, DO clear
         wire.extend_from_slice(&((4 + PADDING) as u16).to_be_bytes()); // RDLENGTH
@@ -1653,8 +1727,8 @@ mod tests {
 
         assert!(out.len() < FUZZED.len(), "trailing junk dropped");
         assert_eq!(
-            &out[out.len() - 11..],
-            &[0, 0, 41, 0x04, 0xD0, 0, 0, DO_FLAG, 0, 0, 0],
+            &out[out.len() - APPENDED_DO_OPT.len()..],
+            &APPENDED_DO_OPT,
             "wire ends with the OPT we appended"
         );
         assert_eq!(


### PR DESCRIPTION
Follow-ups to #191/#329, found by a post-merge review of the DO-bit work.

The load-bearing one: forcing DO=1 inside a 1232-byte budget makes TC=1 routine for large signed answers (DNSKEY sets, NSEC3 denials), but a truncated reply counted as success — the pool's Tcp siblings only fire on transport errors, the cache refuses TC wires, and a client's own TCP retry re-enters the same UDP path. Net effect on main today: any name whose signed answer tops 1232 bytes is unresolvable in forward mode. The fix retries the truncated answer over TCP against the same upstream before returning.

Also in the walker:
- an OPT whose owner name reaches root through a compression pointer was invisible to the byte-sniff, so a second OPT got appended (FORMERR per RFC 6891 §6.1.1) — packet.rs already documents and guards this exact trap; wire.rs now matches on TYPE=41 the same way
- TSIG-signed wires are left untouched: the MAC covers the header and the record must stay last (RFC 8945 §5.1)
- the advertised payload is capped at forward_udp_raw's 4096-byte receive buffer, so we never invite a reply the kernel would silently cut mid-record
- the appended-OPT bytes collapse to one shared constant (wire.rs, its test, and the fuzz oracle all hand-spelled them)

Testutil: mock_upstream_raw delivers malformed fixtures verbatim again instead of silently substituting a TC=1, the three stub loops fold into one with a single 4096-byte buffer, and the recorder channel is unbounded so it can't block replies.

Rides along: h2 bump for RUSTSEC-2026-0258 (published two days ago, fails `cargo audit` on main).

Tests:
- `cargo fmt --check`
- `cargo clippy --all-targets` (clean on touched files; pre-existing 1.94 drift in benches/recursive/srtt unchanged)
- `cargo test` (new: TC-over-UDP→TCP retry, pointer-named OPT patch, TSIG passthrough, budget clamp)
- `cargo +nightly check` on the fuzz crate
- `cargo audit` (clean after the h2 bump)