### PR TITLE
fix(cli): follow-ups to #346 — sudo in the restart hint, README pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Turnkey compose recipes:
 - [Blog: DNS-over-TLS from Scratch in Rust](https://numa.rs/blog/posts/dot-from-scratch.html)
 - [Blog: Implementing DNSSEC from Scratch in Rust](https://numa.rs/blog/posts/dnssec-from-scratch.html)
 - [Blog: I Built a DNS Resolver from Scratch](https://numa.rs/blog/posts/dns-from-scratch.html)
-- [Configuration reference](numa.toml) — all options documented inline
+- [Configuration reference](numa.toml) — all options documented inline; `numa config path` shows which file your install is using, `numa config edit` opens it
 - [REST API](src/api.rs) — overrides, cache, blocking, services, diagnostics
 - [numa-metrics](https://github.com/razvandimescu/numa-metrics) — durable query history & analytics, off-host by design (no SD-card writes)
 

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -61,7 +61,12 @@ pub fn edit_config() -> Result<(), String> {
     }
 
     if resolved.from_daemon {
-        eprintln!("note: restart numa to apply changes (numa service restart)");
+        let restart = if cfg!(windows) {
+            "numa service restart"
+        } else {
+            "sudo numa service restart"
+        };
+        eprintln!("note: restart numa to apply changes ({restart})");
     }
     Ok(())
 }


### PR DESCRIPTION
two small follow-ups from #346:

- the hint after `numa config edit` said `numa service restart`, which fails without sudo — for exactly the user who just re-ran edit with sudo because the config is root-owned. now suggests `sudo numa service restart` on unix, unchanged on windows.
- the README linked the numa.toml reference without saying where an install's copy lives. added a pointer to `numa config path` / `numa config edit`.