### PR TITLE
fix(forward): harden the TC=1 retry from #347

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1924,7 +1924,7 @@ dependencies = [
  "libc",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2193,7 +2193,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3039,7 +3039,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1924,7 +1924,7 @@ dependencies = [
  "libc",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2193,7 +2193,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3039,7 +3039,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,6 +1,6 @@
 use crate::Result;
 
-const BUF_SIZE: usize = 4096;
+pub(crate) const BUF_SIZE: usize = 4096;
 
 pub struct BytePacketBuffer {
     pub buf: [u8; BUF_SIZE],

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -430,26 +430,30 @@ async fn forward_dot_raw(
 
 /// One reply path for every transport: dispatch, validate, and resolve TC=1.
 /// A truncated reply never leaves this function — it is uncacheable, and our
-/// own clients' TCP retries re-enter this same path. UDP escalates to TCP
-/// (RFC 1035 §4.2.1, routine under DO=1/1232 for large signed answers) within
-/// what remains of the timeout budget; a stream transport has nothing bigger
-/// to escalate to, so its TC — like a failed or unusable retry — counts as a
-/// failed upstream and the caller's failover moves on.
+/// own clients' TCP retries re-enter this same path. UDP keeps the datagram
+/// budget and escalates to TCP (RFC 1035 §4.2.1, routine under DO=1/1232 for
+/// large signed answers) within what remains of the timeout; every stream
+/// transport asks for our full ceiling up front, so its TC means an answer
+/// past what we could parse anyway — that, like a failed or unusable retry,
+/// counts as a failed upstream and the caller's failover moves on.
 pub async fn forward_query_raw(
     wire: &[u8],
     upstream: &Upstream,
     timeout_duration: Duration,
 ) -> Result<Vec<u8>> {
     let start = Instant::now();
+    let stream_wire = crate::wire::maximize_payload(wire);
     let resp = match upstream {
         Upstream::Udp(addr) => forward_udp_raw(wire, *addr, timeout_duration).await,
-        Upstream::Tcp(addr) => forward_tcp_raw(wire, *addr, timeout_duration).await,
-        Upstream::Doh { url, client } => forward_doh_raw(wire, url, client, timeout_duration).await,
+        Upstream::Tcp(addr) => forward_tcp_raw(&stream_wire, *addr, timeout_duration).await,
+        Upstream::Doh { url, client } => {
+            forward_doh_raw(&stream_wire, url, client, timeout_duration).await
+        }
         Upstream::Dot {
             addr,
             tls_name,
             connector,
-        } => forward_dot_raw(wire, *addr, tls_name, connector, timeout_duration).await,
+        } => forward_dot_raw(&stream_wire, *addr, tls_name, connector, timeout_duration).await,
         Upstream::Odoh {
             relay_url,
             target_path,
@@ -457,7 +461,7 @@ pub async fn forward_query_raw(
             target_config,
         } => {
             query_through_relay(
-                wire,
+                &stream_wire,
                 relay_url,
                 target_path,
                 client,
@@ -476,7 +480,7 @@ pub async fn forward_query_raw(
         return Err("upstream truncated a stream-transport reply".into());
     };
     let budget = timeout_duration.saturating_sub(start.elapsed());
-    let full = timeout(budget, forward_tcp_raw(wire, *addr, budget)).await??;
+    let full = timeout(budget, forward_tcp_raw(&stream_wire, *addr, budget)).await??;
     let full = usable_reply(wire, full)?;
     if crate::wire::is_truncated(&full) {
         return Err("upstream truncated the TCP retry".into());
@@ -1168,6 +1172,50 @@ mod tests {
         .await;
 
         assert!(result.is_err(), "oversized TCP retry must not be returned");
+    }
+
+    #[tokio::test]
+    async fn a_stream_upstream_is_asked_for_the_full_ceiling() {
+        // The 1232 default is a datagram-fragmentation budget. Passing it to a
+        // DoH server that honors it (RFC 8484 §5.1) earns a TC=1 the stream
+        // path cannot escalate past, and the whole pool SERVFAILs.
+        let query = make_query();
+        let response_bytes = to_wire(&make_response(&query));
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
+
+        let app = axum::Router::new().route(
+            "/dns-query",
+            axum::routing::post(move |body: axum::body::Bytes| {
+                let reply = response_bytes.clone();
+                let tx = tx.clone();
+                async move {
+                    let _ = tx.send(body.to_vec());
+                    (
+                        [(axum::http::header::CONTENT_TYPE, "application/dns-message")],
+                        reply,
+                    )
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(axum::serve(listener, app).into_future());
+
+        let upstream = Upstream::Doh {
+            url: format!("http://{}/dns-query", addr),
+            client: crate::forward::default_client(),
+        };
+        let wire = crate::wire::ensure_do_bit(&to_wire(&query)).into_owned();
+        forward_query_raw(&wire, &upstream, Duration::from_secs(2))
+            .await
+            .expect("DoH forward should succeed");
+
+        let sent = rx.recv().await.expect("upstream recorded the query");
+        let mut buf = BytePacketBuffer::from_bytes(&sent);
+        let asked = DnsPacket::from_buffer(&mut buf).unwrap();
+        let edns = asked.edns.expect("OPT present");
+        assert_eq!(edns.udp_payload_size, crate::wire::MAX_UPSTREAM_PAYLOAD);
+        assert!(edns.do_bit, "DO survives the payload patch");
     }
 
     #[tokio::test]

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -640,13 +640,17 @@ async fn forward_udp_raw(
     timeout_duration: Duration,
 ) -> Result<Vec<u8>> {
     let socket = UdpSocket::bind("0.0.0.0:0").await?;
-    socket.send_to(wire, upstream).await?;
+    // Connected: the kernel drops datagrams from anyone but the upstream, so an
+    // off-path answer has to win a race the source address alone would let it
+    // skip. The ID check downstream is the second half of that guard.
+    socket.connect(upstream).await?;
+    socket.send(wire).await?;
 
     // One byte of headroom: a datagram sized exactly to the buffer is
     // indistinguishable from one the kernel cut to fit, and a cut wire parses
     // as garbage rather than failing.
     let mut recv_buf = vec![0u8; crate::wire::MAX_UPSTREAM_PAYLOAD as usize + 1];
-    let (size, _) = timeout(timeout_duration, socket.recv_from(&mut recv_buf)).await??;
+    let size = timeout(timeout_duration, socket.recv(&mut recv_buf)).await??;
     if size > crate::wire::MAX_UPSTREAM_PAYLOAD as usize {
         return Err("upstream reply exceeds the maximum payload".into());
     }
@@ -1216,6 +1220,34 @@ mod tests {
         let edns = asked.edns.expect("OPT present");
         assert_eq!(edns.udp_payload_size, crate::wire::MAX_UPSTREAM_PAYLOAD);
         assert!(edns.do_bit, "DO survives the payload patch");
+    }
+
+    #[tokio::test]
+    async fn udp_ignores_a_reply_from_another_source() {
+        // The stub reads the query on the addressed port but answers from a
+        // different one — the shape of an off-path injection. A connected
+        // socket never sees it.
+        let query = make_query();
+        let mut reply = to_wire(&make_response(&query));
+        let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let addr = sock.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut buf = [0u8; 512];
+            let (_, src) = sock.recv_from(&mut buf).await.unwrap();
+            reply[0] = buf[0];
+            reply[1] = buf[1];
+            let off_path = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+            let _ = off_path.send_to(&reply, src).await;
+        });
+
+        let result = forward_query_raw(
+            &to_wire(&query),
+            &Upstream::Udp(addr),
+            Duration::from_millis(300),
+        )
+        .await;
+
+        assert!(result.is_err(), "an off-path reply must not answer");
     }
 
     #[tokio::test]

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -428,13 +428,21 @@ async fn forward_dot_raw(
     Ok(data)
 }
 
+/// One reply path for every transport: dispatch, validate, and resolve TC=1.
+/// A truncated reply never leaves this function — it is uncacheable, and our
+/// own clients' TCP retries re-enter this same path. UDP escalates to TCP
+/// (RFC 1035 §4.2.1, routine under DO=1/1232 for large signed answers) within
+/// what remains of the timeout budget; a stream transport has nothing bigger
+/// to escalate to, so its TC — like a failed or unusable retry — counts as a
+/// failed upstream and the caller's failover moves on.
 pub async fn forward_query_raw(
     wire: &[u8],
     upstream: &Upstream,
     timeout_duration: Duration,
 ) -> Result<Vec<u8>> {
-    match upstream {
-        Upstream::Udp(addr) => forward_udp_with_tc_retry(wire, *addr, timeout_duration).await,
+    let start = Instant::now();
+    let resp = match upstream {
+        Upstream::Udp(addr) => forward_udp_raw(wire, *addr, timeout_duration).await,
         Upstream::Tcp(addr) => forward_tcp_raw(wire, *addr, timeout_duration).await,
         Upstream::Doh { url, client } => forward_doh_raw(wire, url, client, timeout_duration).await,
         Upstream::Dot {
@@ -458,7 +466,37 @@ pub async fn forward_query_raw(
             )
             .await
         }
+    }?;
+
+    let resp = usable_reply(wire, resp)?;
+    if !crate::wire::is_truncated(&resp) {
+        return Ok(resp);
     }
+    let Upstream::Udp(addr) = upstream else {
+        return Err("upstream truncated a stream-transport reply".into());
+    };
+    let budget = timeout_duration.saturating_sub(start.elapsed());
+    let full = timeout(budget, forward_tcp_raw(wire, *addr, budget)).await??;
+    let full = usable_reply(wire, full)?;
+    if crate::wire::is_truncated(&full) {
+        return Err("upstream truncated the TCP retry".into());
+    }
+    Ok(full)
+}
+
+/// A reply the pipeline can act on: the ID we sent, QR=1, and within
+/// `BytePacketBuffer`'s capacity — `from_bytes` silently cuts a larger wire
+/// into one that parses as garbage, becoming SERVFAIL plus a cache entry that
+/// never parses until TTL expiry.
+fn usable_reply(wire: &[u8], resp: Vec<u8>) -> Result<Vec<u8>> {
+    let usable = resp.len() <= crate::wire::MAX_UPSTREAM_PAYLOAD as usize
+        && resp.len() >= 12
+        && resp.get(..2) == wire.get(..2)
+        && crate::wire::is_response(&resp);
+    if !usable {
+        return Err("unusable upstream reply".into());
+    }
+    Ok(resp)
 }
 
 pub async fn forward_with_hedging_raw(
@@ -590,35 +628,6 @@ pub async fn forward_with_failover_raw(
     }
 
     Err(last_err.unwrap_or_else(|| "no upstream configured".into()))
-}
-
-/// UDP leg plus the TC=1 retry over TCP (RFC 1035 §4.2.1) — routine under
-/// DO=1/1232 for large signed answers. A truncated reply never leaves this
-/// function: it is uncacheable, and our own clients' TCP retries re-enter
-/// this same UDP path. Either the retry lands a usable full answer within
-/// what remains of the timeout budget, or the upstream counts as failed and
-/// the caller's failover moves on.
-async fn forward_udp_with_tc_retry(
-    wire: &[u8],
-    upstream: SocketAddr,
-    timeout_duration: Duration,
-) -> Result<Vec<u8>> {
-    let start = Instant::now();
-    let resp = forward_udp_raw(wire, upstream, timeout_duration).await?;
-    if !crate::wire::is_truncated(&resp) {
-        return Ok(resp);
-    }
-
-    let budget = timeout_duration.saturating_sub(start.elapsed());
-    let full = timeout(budget, forward_tcp_raw(wire, upstream, budget)).await??;
-    let usable = full.len() <= crate::wire::MAX_UPSTREAM_PAYLOAD as usize
-        && full.len() >= 12
-        && full.get(..2) == wire.get(..2)
-        && crate::wire::is_response(&full);
-    if !usable {
-        return Err("TCP retry after TC=1 returned an unusable reply".into());
-    }
-    Ok(full)
 }
 
 async fn forward_udp_raw(
@@ -1078,6 +1087,81 @@ mod tests {
         let mut buf = BytePacketBuffer::from_bytes(&resp_wire);
         let result = DnsPacket::from_buffer(&mut buf).unwrap();
         assert_eq!(result.answers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn failover_moves_on_when_a_stream_transport_truncates() {
+        // TC over DoH has nothing bigger to escalate to — the upstream must
+        // count as failed, not answer the pool with an uncacheable TC wire.
+        let query = make_query();
+        let tc_wire = truncated_response(&query);
+        let app = axum::Router::new().route(
+            "/dns-query",
+            axum::routing::post(move || {
+                let body = tc_wire.clone();
+                async move {
+                    (
+                        [(axum::http::header::CONTENT_TYPE, "application/dns-message")],
+                        body,
+                    )
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let doh_addr = listener.local_addr().unwrap();
+        tokio::spawn(axum::serve(listener, app).into_future());
+        let good_addr = crate::testutil::mock_upstream(make_response(&query)).await;
+
+        let pool = UpstreamPool::new(
+            vec![
+                Upstream::Doh {
+                    url: format!("http://{}/dns-query", doh_addr),
+                    client: crate::forward::default_client(),
+                },
+                Upstream::Udp(good_addr),
+            ],
+            vec![],
+        );
+        let srtt = RwLock::new(SrttCache::new(true));
+        let resp_wire = forward_with_failover_raw(
+            &to_wire(&query),
+            &pool,
+            &srtt,
+            Duration::from_millis(500),
+            Duration::ZERO,
+        )
+        .await
+        .expect("truncating DoH upstream must fail over");
+
+        assert!(!crate::wire::is_truncated(&resp_wire));
+        let mut buf = BytePacketBuffer::from_bytes(&resp_wire);
+        let result = DnsPacket::from_buffer(&mut buf).unwrap();
+        assert_eq!(result.answers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn tc_retry_refuses_a_reply_the_parse_buffer_would_cut() {
+        // A TCP answer past BytePacketBuffer's capacity would be silently
+        // cut into a parse error and a poisoned cache slot — refusing it
+        // turns that into a plain upstream failure.
+        let query = make_query();
+        let addr = crate::testutil::mock_upstream_raw(truncated_response(&query)).await;
+        let mut big = to_wire(&make_response(&query));
+        big.resize(5000, 0);
+        crate::testutil::tcp_upstream_raw_on(addr, big).await;
+
+        let pool = UpstreamPool::new(vec![Upstream::Udp(addr)], vec![]);
+        let srtt = RwLock::new(SrttCache::new(true));
+        let result = forward_with_failover_raw(
+            &to_wire(&query),
+            &pool,
+            &srtt,
+            Duration::from_millis(500),
+            Duration::ZERO,
+        )
+        .await;
+
+        assert!(result.is_err(), "oversized TCP retry must not be returned");
     }
 
     #[test]

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -638,8 +638,14 @@ async fn forward_udp_raw(
     let socket = UdpSocket::bind("0.0.0.0:0").await?;
     socket.send_to(wire, upstream).await?;
 
-    let mut recv_buf = vec![0u8; crate::wire::MAX_UPSTREAM_PAYLOAD as usize];
+    // One byte of headroom: a datagram sized exactly to the buffer is
+    // indistinguishable from one the kernel cut to fit, and a cut wire parses
+    // as garbage rather than failing.
+    let mut recv_buf = vec![0u8; crate::wire::MAX_UPSTREAM_PAYLOAD as usize + 1];
     let (size, _) = timeout(timeout_duration, socket.recv_from(&mut recv_buf)).await??;
+    if size > crate::wire::MAX_UPSTREAM_PAYLOAD as usize {
+        return Err("upstream reply exceeds the maximum payload".into());
+    }
     recv_buf.truncate(size);
     Ok(recv_buf)
 }
@@ -1162,6 +1168,30 @@ mod tests {
         .await;
 
         assert!(result.is_err(), "oversized TCP retry must not be returned");
+    }
+
+    #[tokio::test]
+    async fn udp_refuses_a_datagram_the_kernel_had_to_cut() {
+        // The kernel cuts an oversized datagram to whatever the receive buffer
+        // holds, so a cut wire and a legitimately full one are the same length
+        // — only headroom past the cap tells them apart.
+        let query = make_query();
+        let mut big = to_wire(&make_response(&query));
+        big.resize(5000, 0);
+        let addr = crate::testutil::mock_upstream_raw(big).await;
+
+        let pool = UpstreamPool::new(vec![Upstream::Udp(addr)], vec![]);
+        let srtt = RwLock::new(SrttCache::new(true));
+        let result = forward_with_failover_raw(
+            &to_wire(&query),
+            &pool,
+            &srtt,
+            Duration::from_millis(500),
+            Duration::ZERO,
+        )
+        .await;
+
+        assert!(result.is_err(), "cut UDP datagram must not be returned");
     }
 
     #[test]

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -434,7 +434,7 @@ pub async fn forward_query_raw(
     timeout_duration: Duration,
 ) -> Result<Vec<u8>> {
     match upstream {
-        Upstream::Udp(addr) => forward_udp_raw(wire, *addr, timeout_duration).await,
+        Upstream::Udp(addr) => forward_udp_with_tc_retry(wire, *addr, timeout_duration).await,
         Upstream::Tcp(addr) => forward_tcp_raw(wire, *addr, timeout_duration).await,
         Upstream::Doh { url, client } => forward_doh_raw(wire, url, client, timeout_duration).await,
         Upstream::Dot {
@@ -577,17 +577,6 @@ pub async fn forward_with_failover_raw(
                     let rtt_ms = start.elapsed().as_millis() as u64;
                     srtt.write().unwrap().record_rtt(ip, t, rtt_ms);
                 }
-                // TC=1 says "retry over TCP" (RFC 1035 §4.2.1) and DO=1/1232
-                // makes it routine for large signed answers. Our own clients'
-                // TCP retries re-enter this same UDP path, so the protocol
-                // switch has to happen here or nowhere.
-                if crate::wire::is_truncated(&resp) {
-                    if let Upstream::Udp(addr) = upstream {
-                        if let Ok(full) = forward_tcp_raw(wire, *addr, timeout_duration).await {
-                            return Ok(full);
-                        }
-                    }
-                }
                 return Ok(resp);
             }
             Err(e) => {
@@ -603,6 +592,35 @@ pub async fn forward_with_failover_raw(
     Err(last_err.unwrap_or_else(|| "no upstream configured".into()))
 }
 
+/// UDP leg plus the TC=1 retry over TCP (RFC 1035 §4.2.1) — routine under
+/// DO=1/1232 for large signed answers. A truncated reply never leaves this
+/// function: it is uncacheable, and our own clients' TCP retries re-enter
+/// this same UDP path. Either the retry lands a usable full answer within
+/// what remains of the timeout budget, or the upstream counts as failed and
+/// the caller's failover moves on.
+async fn forward_udp_with_tc_retry(
+    wire: &[u8],
+    upstream: SocketAddr,
+    timeout_duration: Duration,
+) -> Result<Vec<u8>> {
+    let start = Instant::now();
+    let resp = forward_udp_raw(wire, upstream, timeout_duration).await?;
+    if !crate::wire::is_truncated(&resp) {
+        return Ok(resp);
+    }
+
+    let budget = timeout_duration.saturating_sub(start.elapsed());
+    let full = timeout(budget, forward_tcp_raw(wire, upstream, budget)).await??;
+    let usable = full.len() <= crate::wire::MAX_UPSTREAM_PAYLOAD as usize
+        && full.len() >= 12
+        && full.get(..2) == wire.get(..2)
+        && crate::wire::is_response(&full);
+    if !usable {
+        return Err("TCP retry after TC=1 returned an unusable reply".into());
+    }
+    Ok(full)
+}
+
 async fn forward_udp_raw(
     wire: &[u8],
     upstream: SocketAddr,
@@ -611,7 +629,7 @@ async fn forward_udp_raw(
     let socket = UdpSocket::bind("0.0.0.0:0").await?;
     socket.send_to(wire, upstream).await?;
 
-    let mut recv_buf = vec![0u8; 4096];
+    let mut recv_buf = vec![0u8; crate::wire::MAX_UPSTREAM_PAYLOAD as usize];
     let (size, _) = timeout(timeout_duration, socket.recv_from(&mut recv_buf)).await??;
     recv_buf.truncate(size);
     Ok(recv_buf)
@@ -995,49 +1013,24 @@ mod tests {
         assert_eq!(result.answers.len(), 1);
     }
 
-    #[tokio::test]
-    async fn failover_retries_truncated_udp_over_tcp() {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-        let query = make_query();
-        let full_wire = to_wire(&make_response(&query));
-
-        // UDP and TCP share the port: UDP always answers TC=1 with no
-        // records, TCP has the full answer — the shape of a signed response
-        // that outgrows the 1232-byte UDP budget. Without the TCP retry the
-        // TC reply is final: the client's own TCP retry re-enters this same
-        // UDP path and loops forever.
-        let udp = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
-        let addr = udp.local_addr().unwrap();
-        let tcp = tokio::net::TcpListener::bind(addr).await.unwrap();
-
-        let mut tc = make_response(&query);
+    /// A TC=1 reply with no records — the shape of a signed response that
+    /// outgrows the UDP budget.
+    fn truncated_response(query: &DnsPacket) -> Vec<u8> {
+        let mut tc = make_response(query);
         tc.answers.clear();
         tc.header.truncated_message = true;
-        let tc_wire = to_wire(&tc);
-        tokio::spawn(async move {
-            let mut buf = [0u8; 4096];
-            while let Ok((n, src)) = udp.recv_from(&mut buf).await {
-                let mut reply = tc_wire.clone();
-                reply[0] = buf[0];
-                reply[1] = buf[1];
-                let _ = udp.send_to(&reply, src).await;
-                let _ = n;
-            }
-        });
-        tokio::spawn(async move {
-            let (mut stream, _) = tcp.accept().await.unwrap();
-            let mut len_buf = [0u8; 2];
-            stream.read_exact(&mut len_buf).await.unwrap();
-            let mut query_wire = vec![0u8; u16::from_be_bytes(len_buf) as usize];
-            stream.read_exact(&mut query_wire).await.unwrap();
-            let mut reply = full_wire.clone();
-            reply[0] = query_wire[0];
-            reply[1] = query_wire[1];
-            let mut out = Vec::with_capacity(2 + reply.len());
-            out.extend_from_slice(&(reply.len() as u16).to_be_bytes());
-            out.extend_from_slice(&reply);
-            stream.write_all(&out).await.unwrap();
-        });
+        to_wire(&tc)
+    }
+
+    #[tokio::test]
+    async fn failover_retries_truncated_udp_over_tcp() {
+        // UDP and TCP share the port: UDP always answers TC=1, TCP has the
+        // full answer. Without the TCP retry the TC reply is final: the
+        // client's own TCP retry re-enters this same UDP path and loops
+        // forever.
+        let query = make_query();
+        let addr = crate::testutil::mock_upstream_raw(truncated_response(&query)).await;
+        crate::testutil::tcp_upstream_raw_on(addr, to_wire(&make_response(&query))).await;
 
         let pool = UpstreamPool::new(vec![Upstream::Udp(addr)], vec![]);
         let srtt = RwLock::new(SrttCache::new(true));
@@ -1050,6 +1043,36 @@ mod tests {
         )
         .await
         .expect("truncated UDP answer must resolve over TCP");
+
+        assert!(!crate::wire::is_truncated(&resp_wire));
+        let mut buf = BytePacketBuffer::from_bytes(&resp_wire);
+        let result = DnsPacket::from_buffer(&mut buf).unwrap();
+        assert_eq!(result.answers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn failover_moves_on_when_the_tcp_retry_fails() {
+        // Upstream A truncates and has no TCP listener (asymmetric port-53
+        // filtering); upstream B holds the answer. The truncated reply must
+        // not count as pool success, or B never fires.
+        let query = make_query();
+        let tc_addr = crate::testutil::mock_upstream_raw(truncated_response(&query)).await;
+        let good_addr = crate::testutil::mock_upstream(make_response(&query)).await;
+
+        let pool = UpstreamPool::new(
+            vec![Upstream::Udp(tc_addr), Upstream::Udp(good_addr)],
+            vec![],
+        );
+        let srtt = RwLock::new(SrttCache::new(true));
+        let resp_wire = forward_with_failover_raw(
+            &to_wire(&query),
+            &pool,
+            &srtt,
+            Duration::from_millis(500),
+            Duration::ZERO,
+        )
+        .await
+        .expect("failed TCP retry must fail over to the next upstream");
 
         assert!(!crate::wire::is_truncated(&resp_wire));
         let mut buf = BytePacketBuffer::from_bytes(&resp_wire);

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, RwLock};
@@ -431,29 +432,31 @@ async fn forward_dot_raw(
 /// One reply path for every transport: dispatch, validate, and resolve TC=1.
 /// A truncated reply never leaves this function — it is uncacheable, and our
 /// own clients' TCP retries re-enter this same path. UDP keeps the datagram
-/// budget and escalates to TCP (RFC 1035 §4.2.1, routine under DO=1/1232 for
-/// large signed answers) within what remains of the timeout; every stream
-/// transport asks for our full ceiling up front, so its TC means an answer
-/// past what we could parse anyway — that, like a failed or unusable retry,
-/// counts as a failed upstream and the caller's failover moves on.
+/// budget and escalates to TCP (RFC 1035 §4.2.1) within what remains of the
+/// timeout; a stream transport already asked for our full ceiling, so its TC
+/// means an answer past what we could parse — that, like a failed or unusable
+/// retry, counts as a failed upstream and the caller's failover moves on.
 pub async fn forward_query_raw(
     wire: &[u8],
     upstream: &Upstream,
     timeout_duration: Duration,
 ) -> Result<Vec<u8>> {
     let start = Instant::now();
-    let stream_wire = crate::wire::maximize_payload(wire);
+    let sent = match upstream {
+        Upstream::Udp(_) => Cow::Borrowed(wire),
+        _ => crate::wire::maximize_payload(wire),
+    };
     let resp = match upstream {
-        Upstream::Udp(addr) => forward_udp_raw(wire, *addr, timeout_duration).await,
-        Upstream::Tcp(addr) => forward_tcp_raw(&stream_wire, *addr, timeout_duration).await,
+        Upstream::Udp(addr) => forward_udp_raw(&sent, *addr, timeout_duration).await,
+        Upstream::Tcp(addr) => forward_tcp_raw(&sent, *addr, timeout_duration).await,
         Upstream::Doh { url, client } => {
-            forward_doh_raw(&stream_wire, url, client, timeout_duration).await
+            forward_doh_raw(&sent, url, client, timeout_duration).await
         }
         Upstream::Dot {
             addr,
             tls_name,
             connector,
-        } => forward_dot_raw(&stream_wire, *addr, tls_name, connector, timeout_duration).await,
+        } => forward_dot_raw(&sent, *addr, tls_name, connector, timeout_duration).await,
         Upstream::Odoh {
             relay_url,
             target_path,
@@ -461,7 +464,7 @@ pub async fn forward_query_raw(
             target_config,
         } => {
             query_through_relay(
-                &stream_wire,
+                &sent,
                 relay_url,
                 target_path,
                 client,
@@ -480,7 +483,8 @@ pub async fn forward_query_raw(
         return Err("upstream truncated a stream-transport reply".into());
     };
     let budget = timeout_duration.saturating_sub(start.elapsed());
-    let full = timeout(budget, forward_tcp_raw(&stream_wire, *addr, budget)).await??;
+    let retry = crate::wire::maximize_payload(wire);
+    let full = timeout(budget, forward_tcp_raw(&retry, *addr, budget)).await??;
     let full = usable_reply(wire, full)?;
     if crate::wire::is_truncated(&full) {
         return Err("upstream truncated the TCP retry".into());
@@ -640,15 +644,12 @@ async fn forward_udp_raw(
     timeout_duration: Duration,
 ) -> Result<Vec<u8>> {
     let socket = UdpSocket::bind("0.0.0.0:0").await?;
-    // Connected: the kernel drops datagrams from anyone but the upstream, so an
-    // off-path answer has to win a race the source address alone would let it
-    // skip. The ID check downstream is the second half of that guard.
+    // Connected, so the kernel drops datagrams from anyone but the upstream.
     socket.connect(upstream).await?;
     socket.send(wire).await?;
 
-    // One byte of headroom: a datagram sized exactly to the buffer is
-    // indistinguishable from one the kernel cut to fit, and a cut wire parses
-    // as garbage rather than failing.
+    // One byte of headroom: a datagram sized exactly to the buffer cannot be
+    // told from one the kernel cut to fit, and a cut wire parses as garbage.
     let mut recv_buf = vec![0u8; crate::wire::MAX_UPSTREAM_PAYLOAD as usize + 1];
     let size = timeout(timeout_duration, socket.recv(&mut recv_buf)).await??;
     if size > crate::wire::MAX_UPSTREAM_PAYLOAD as usize {
@@ -754,32 +755,22 @@ mod tests {
         buf.filled().to_vec()
     }
 
+    /// A DoH upstream answering `response`, plus the queries it received.
+    async fn doh_upstream(
+        response: Vec<u8>,
+    ) -> (Upstream, tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>) {
+        let (url, rx) = crate::testutil::doh_upstream_raw(response).await;
+        let upstream = Upstream::Doh {
+            url,
+            client: crate::forward::default_client(),
+        };
+        (upstream, rx)
+    }
+
     #[tokio::test]
     async fn doh_mock_server_resolves() {
         let query = make_query();
-        let response_bytes = to_wire(&make_response(&query));
-
-        let app = axum::Router::new().route(
-            "/dns-query",
-            axum::routing::post(move || {
-                let body = response_bytes.clone();
-                async move {
-                    (
-                        [(axum::http::header::CONTENT_TYPE, "application/dns-message")],
-                        body,
-                    )
-                }
-            }),
-        );
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(axum::serve(listener, app).into_future());
-
-        let upstream = Upstream::Doh {
-            url: format!("http://{}/dns-query", addr),
-            client: crate::forward::default_client(),
-        };
+        let (upstream, _rx) = doh_upstream(to_wire(&make_response(&query))).await;
 
         let result = forward_query(&query, &upstream, Duration::from_secs(2))
             .await
@@ -987,34 +978,10 @@ mod tests {
     async fn failover_tries_next_on_failure() {
         // First upstream is unreachable, second responds
         let query = make_query();
-        let response_bytes = to_wire(&make_response(&query));
+        let (good, _rx) = doh_upstream(to_wire(&make_response(&query))).await;
 
-        let app = axum::Router::new().route(
-            "/dns-query",
-            axum::routing::post(move || {
-                let body = response_bytes.clone();
-                async move {
-                    (
-                        [(axum::http::header::CONTENT_TYPE, "application/dns-message")],
-                        body,
-                    )
-                }
-            }),
-        );
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let good_addr = listener.local_addr().unwrap();
-        tokio::spawn(axum::serve(listener, app).into_future());
-
-        // Unreachable UDP upstream + working DoH upstream
         let pool = UpstreamPool::new(
-            vec![
-                Upstream::Udp("127.0.0.1:1".parse().unwrap()), // will fail
-                Upstream::Doh {
-                    url: format!("http://{}/dns-query", good_addr),
-                    client: crate::forward::default_client(),
-                },
-            ],
+            vec![Upstream::Udp("127.0.0.1:1".parse().unwrap()), good],
             vec![],
         );
 
@@ -1108,34 +1075,10 @@ mod tests {
         // TC over DoH has nothing bigger to escalate to — the upstream must
         // count as failed, not answer the pool with an uncacheable TC wire.
         let query = make_query();
-        let tc_wire = truncated_response(&query);
-        let app = axum::Router::new().route(
-            "/dns-query",
-            axum::routing::post(move || {
-                let body = tc_wire.clone();
-                async move {
-                    (
-                        [(axum::http::header::CONTENT_TYPE, "application/dns-message")],
-                        body,
-                    )
-                }
-            }),
-        );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let doh_addr = listener.local_addr().unwrap();
-        tokio::spawn(axum::serve(listener, app).into_future());
+        let (truncating, _rx) = doh_upstream(truncated_response(&query)).await;
         let good_addr = crate::testutil::mock_upstream(make_response(&query)).await;
 
-        let pool = UpstreamPool::new(
-            vec![
-                Upstream::Doh {
-                    url: format!("http://{}/dns-query", doh_addr),
-                    client: crate::forward::default_client(),
-                },
-                Upstream::Udp(good_addr),
-            ],
-            vec![],
-        );
+        let pool = UpstreamPool::new(vec![truncating, Upstream::Udp(good_addr)], vec![]);
         let srtt = RwLock::new(SrttCache::new(true));
         let resp_wire = forward_with_failover_raw(
             &to_wire(&query),
@@ -1160,22 +1103,23 @@ mod tests {
         // turns that into a plain upstream failure.
         let query = make_query();
         let addr = crate::testutil::mock_upstream_raw(truncated_response(&query)).await;
-        let mut big = to_wire(&make_response(&query));
-        big.resize(5000, 0);
-        crate::testutil::tcp_upstream_raw_on(addr, big).await;
+        crate::testutil::tcp_upstream_raw_on(addr, oversized_response(&query)).await;
 
-        let pool = UpstreamPool::new(vec![Upstream::Udp(addr)], vec![]);
-        let srtt = RwLock::new(SrttCache::new(true));
-        let result = forward_with_failover_raw(
+        let result = forward_query_raw(
             &to_wire(&query),
-            &pool,
-            &srtt,
+            &Upstream::Udp(addr),
             Duration::from_millis(500),
-            Duration::ZERO,
         )
         .await;
 
         assert!(result.is_err(), "oversized TCP retry must not be returned");
+    }
+
+    /// A well-formed answer one byte past the ceiling we can receive.
+    fn oversized_response(query: &DnsPacket) -> Vec<u8> {
+        let mut big = to_wire(&make_response(query));
+        big.resize(crate::wire::MAX_UPSTREAM_PAYLOAD as usize + 1, 0);
+        big
     }
 
     #[tokio::test]
@@ -1184,31 +1128,7 @@ mod tests {
         // DoH server that honors it (RFC 8484 §5.1) earns a TC=1 the stream
         // path cannot escalate past, and the whole pool SERVFAILs.
         let query = make_query();
-        let response_bytes = to_wire(&make_response(&query));
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
-
-        let app = axum::Router::new().route(
-            "/dns-query",
-            axum::routing::post(move |body: axum::body::Bytes| {
-                let reply = response_bytes.clone();
-                let tx = tx.clone();
-                async move {
-                    let _ = tx.send(body.to_vec());
-                    (
-                        [(axum::http::header::CONTENT_TYPE, "application/dns-message")],
-                        reply,
-                    )
-                }
-            }),
-        );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(axum::serve(listener, app).into_future());
-
-        let upstream = Upstream::Doh {
-            url: format!("http://{}/dns-query", addr),
-            client: crate::forward::default_client(),
-        };
+        let (upstream, mut rx) = doh_upstream(to_wire(&make_response(&query))).await;
         let wire = crate::wire::ensure_do_bit(&to_wire(&query)).into_owned();
         forward_query_raw(&wire, &upstream, Duration::from_secs(2))
             .await
@@ -1234,8 +1154,7 @@ mod tests {
         tokio::spawn(async move {
             let mut buf = [0u8; 512];
             let (_, src) = sock.recv_from(&mut buf).await.unwrap();
-            reply[0] = buf[0];
-            reply[1] = buf[1];
+            crate::wire::patch_id(&mut reply, u16::from_be_bytes([buf[0], buf[1]]));
             let off_path = UdpSocket::bind("127.0.0.1:0").await.unwrap();
             let _ = off_path.send_to(&reply, src).await;
         });
@@ -1256,18 +1175,12 @@ mod tests {
         // holds, so a cut wire and a legitimately full one are the same length
         // — only headroom past the cap tells them apart.
         let query = make_query();
-        let mut big = to_wire(&make_response(&query));
-        big.resize(5000, 0);
-        let addr = crate::testutil::mock_upstream_raw(big).await;
+        let addr = crate::testutil::mock_upstream_raw(oversized_response(&query)).await;
 
-        let pool = UpstreamPool::new(vec![Upstream::Udp(addr)], vec![]);
-        let srtt = RwLock::new(SrttCache::new(true));
-        let result = forward_with_failover_raw(
+        let result = forward_query_raw(
             &to_wire(&query),
-            &pool,
-            &srtt,
+            &Upstream::Udp(addr),
             Duration::from_millis(500),
-            Duration::ZERO,
         )
         .await;
 

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -244,6 +244,33 @@ fn reply_within_budget(full: &[u8], query_wire: &[u8]) -> Vec<u8> {
     out.filled().to_vec()
 }
 
+/// TCP counterpart of `mock_upstream_raw`, bound to the given address —
+/// answers each length-prefixed query with `bytes` verbatim (ID patched).
+/// Bind it to a UDP stub's address (disjoint port spaces) for TC=1 retry
+/// tests, where UDP truncates and TCP holds the full answer.
+pub async fn tcp_upstream_raw_on(addr: SocketAddr, bytes: Vec<u8>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let mut len_buf = [0u8; 2];
+            if stream.read_exact(&mut len_buf).await.is_err() {
+                continue;
+            }
+            let mut query = vec![0u8; u16::from_be_bytes(len_buf) as usize];
+            if stream.read_exact(&mut query).await.is_err() || query.len() < 2 {
+                continue;
+            }
+            let mut reply = bytes.clone();
+            crate::wire::patch_id(&mut reply, u16::from_be_bytes([query[0], query[1]]));
+            let mut out = Vec::with_capacity(2 + reply.len());
+            out.extend_from_slice(&(reply.len() as u16).to_be_bytes());
+            out.extend_from_slice(&reply);
+            let _ = stream.write_all(&out).await;
+        }
+    });
+}
+
 /// UDP socket that accepts connections but never replies.
 /// Useful as an upstream that triggers timeouts.
 pub fn blackhole_upstream() -> SocketAddr {

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -271,6 +271,38 @@ pub async fn tcp_upstream_raw_on(addr: SocketAddr, bytes: Vec<u8>) {
     });
 }
 
+/// DoH counterpart of `mock_upstream_raw`: answers every POST to `/dns-query`
+/// with `bytes` (ID patched), and reports each inbound query wire on the
+/// returned channel. The URL is ready to hand an `Upstream::Doh`.
+pub async fn doh_upstream_raw(
+    bytes: Vec<u8>,
+) -> (String, tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>) {
+    use std::future::IntoFuture;
+
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let app = axum::Router::new().route(
+        "/dns-query",
+        axum::routing::post(move |query: axum::body::Bytes| {
+            let mut reply = bytes.clone();
+            let tx = tx.clone();
+            async move {
+                if query.len() >= 2 {
+                    crate::wire::patch_id(&mut reply, u16::from_be_bytes([query[0], query[1]]));
+                }
+                let _ = tx.send(query.to_vec());
+                (
+                    [(axum::http::header::CONTENT_TYPE, "application/dns-message")],
+                    reply,
+                )
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, app).into_future());
+    (format!("http://{}/dns-query", addr), rx)
+}
+
 /// UDP socket that accepts connections but never replies.
 /// Useful as an upstream that triggers timeouts.
 pub fn blackhole_upstream() -> SocketAddr {

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -234,7 +234,14 @@ fn locate_opt(wire: &[u8]) -> Result<OptSite> {
     }
     let mut opt = None;
     for _ in 0..count(wire, 10) {
-        let ttl_offset = skip_record(wire, &mut pos)?;
+        // A record we cannot skip ends the walk, but not the search: an OPT
+        // already found stays patchable, since nothing behind an unwalkable
+        // record is a TSIG the upstream could verify either. With no OPT yet
+        // there is no trustworthy end to append one at.
+        let ttl_offset = match skip_record(wire, &mut pos) {
+            Ok(offset) => offset,
+            Err(e) => return opt.map(OptSite::Flag).ok_or(e),
+        };
         match record_type(wire, ttl_offset) {
             TYPE_OPT => opt = opt.or(Some(ttl_offset)),
             // A TSIG must stay the last record and its MAC covers the header
@@ -1745,6 +1752,31 @@ mod tests {
         rec.extend_from_slice(&[0, 0, 0, 0]); // TTL
         rec.extend_from_slice(&[0, 0]); // RDLENGTH
         rec
+    }
+
+    #[test]
+    fn ensure_do_bit_patches_an_opt_ahead_of_an_unwalkable_record() {
+        // ARCOUNT claims a record that is not there. Letting the failed walk
+        // discard the OPT we already found would send the query on with DO
+        // clear and the client's own budget — both guarantees lost silently.
+        let mut wire = query_wire();
+        wire[10..12].copy_from_slice(&2u16.to_be_bytes()); // ARCOUNT: OPT + junk
+        let do_byte = wire.len() + 7;
+        wire.extend_from_slice(&[0, 0, 41]); // root name, TYPE=OPT
+        wire.extend_from_slice(&512u16.to_be_bytes()); // payload below budget
+        wire.extend_from_slice(&[0, 0, 0, 0]); // TTL, DO clear
+        wire.extend_from_slice(&[0, 0]); // RDLENGTH
+        wire.extend_from_slice(&[0, 0, 1]); // a second record, cut short
+
+        let out = ensure_do_bit(&wire);
+
+        assert_eq!(out.len(), wire.len(), "patched in place");
+        assert_eq!(out[do_byte] & DO_FLAG, DO_FLAG, "DO set on the found OPT");
+        assert_eq!(
+            u16::from_be_bytes([out[do_byte - 4], out[do_byte - 3]]),
+            MIN_UPSTREAM_PAYLOAD,
+            "budget raised to hold the RRSIGs DO asks for"
+        );
     }
 
     #[test]

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -112,12 +112,18 @@ pub fn patch_ttls(wire: &mut [u8], offsets: &[usize], new_ttl: u32) {
 
 const DO_FLAG: u8 = 0x80;
 const TC_FLAG: u8 = 0x02;
+const QR_FLAG: u8 = 0x80;
 
 /// TC=1 (RFC 1035 §4.1.1, header byte 2) means "this answer did not fit, ask
 /// again over TCP". Cached, it would answer every later client — including the
 /// ones already on TCP, where the retry has nowhere left to go.
 pub fn is_truncated(wire: &[u8]) -> bool {
     wire.get(2).is_some_and(|flags| flags & TC_FLAG != 0)
+}
+
+/// QR=1 (RFC 1035 §4.1.1, header byte 2): the wire is a response.
+pub fn is_response(wire: &[u8]) -> bool {
+    wire.get(2).is_some_and(|flags| flags & QR_FLAG != 0)
 }
 
 /// Make a query wire carry DO=1 within a budget that can hold the answer:
@@ -152,10 +158,13 @@ pub fn ensure_do_bit(wire: &[u8]) -> Cow<'_, [u8]> {
 /// with no records, for answers that fit unsigned.
 const MIN_UPSTREAM_PAYLOAD: u16 = crate::packet::DEFAULT_EDNS_PAYLOAD;
 
-/// Ceiling on the budget we advertise: `forward_udp_raw` receives into 4096
-/// bytes, and a reply larger than the buffer is silently cut into a wire that
-/// cannot parse. Never invite an answer we cannot receive.
-const MAX_UPSTREAM_PAYLOAD: u16 = 4096;
+/// Ceiling on the budget we advertise and on any reply we accept:
+/// `BytePacketBuffer`'s capacity, which `from_bytes` silently cuts to — a
+/// larger wire becomes one that cannot parse. Never invite (or prefer, see the
+/// TC=1 retry) an answer we cannot receive. `forward_udp_raw` sizes its
+/// receive buffer from this same constant.
+pub(crate) const MAX_UPSTREAM_PAYLOAD: u16 = crate::buffer::BUF_SIZE as u16;
+const _: () = assert!(crate::buffer::BUF_SIZE <= u16::MAX as usize);
 
 /// The bare OPT `append_do_opt` writes: root name, TYPE=41, our payload
 /// budget, DO=1. Public so the fuzz oracle asserts against the same bytes.
@@ -207,19 +216,25 @@ fn locate_opt(wire: &[u8]) -> Result<OptSite> {
     for _ in 0..count(wire, 6) + count(wire, 8) {
         skip_record(wire, &mut pos)?;
     }
+    let mut opt = None;
     for _ in 0..count(wire, 10) {
         let ttl_offset = skip_record(wire, &mut pos)?;
         match record_type(wire, ttl_offset) {
-            TYPE_OPT => return Ok(OptSite::Flag(ttl_offset)),
+            TYPE_OPT => opt = opt.or(Some(ttl_offset)),
             // A TSIG must stay the last record and its MAC covers the header
-            // (RFC 8945 §5.1) — appending an OPT behind it, or bumping
-            // ARCOUNT, voids the signature. Not ours to patch.
+            // (RFC 8945 §5.1) — so a signed query's OPT sits in front of it,
+            // inside the MAC. Patching that OPT, appending one, or bumping
+            // ARCOUNT voids the signature: scan the whole section before
+            // deciding. Not ours to patch.
             TYPE_TSIG => return Err("TSIG-signed message".into()),
             _ => {}
         }
     }
 
-    Ok(OptSite::End(pos))
+    match opt {
+        Some(ttl_offset) => Ok(OptSite::Flag(ttl_offset)),
+        None => Ok(OptSite::End(pos)),
+    }
 }
 
 /// Skip one question entry: name, then QTYPE(2) + QCLASS(2).
@@ -1655,13 +1670,35 @@ mod tests {
         // (RFC 8945 §5.1); patching would void the signature upstream.
         let mut wire = query_wire();
         wire[10..12].copy_from_slice(&1u16.to_be_bytes()); // ARCOUNT
-        wire.extend_from_slice(&[0]); // root name
-        wire.extend_from_slice(&250u16.to_be_bytes()); // TYPE=TSIG
-        wire.extend_from_slice(&[0, 255]); // CLASS=ANY
-        wire.extend_from_slice(&[0, 0, 0, 0]); // TTL
-        wire.extend_from_slice(&[0, 0]); // RDLENGTH
+        wire.extend_from_slice(&tsig_record());
 
         assert_eq!(&ensure_do_bit(&wire)[..], &wire[..]);
+    }
+
+    #[test]
+    fn ensure_do_bit_leaves_opt_plus_tsig_wires_untouched() {
+        // The standard signed-and-EDNS layout: TSIG last (RFC 8945 §5.3), so
+        // the OPT sits in front of it, covered by the MAC. DO clear and a
+        // payload below budget would both normally be patched.
+        let mut wire = query_wire();
+        wire[10..12].copy_from_slice(&2u16.to_be_bytes()); // ARCOUNT
+        wire.extend_from_slice(&[0, 0, 41]); // root name, TYPE=OPT
+        wire.extend_from_slice(&512u16.to_be_bytes()); // payload below budget
+        wire.extend_from_slice(&[0, 0, 0, 0]); // TTL, DO clear
+        wire.extend_from_slice(&[0, 0]); // RDLENGTH
+        wire.extend_from_slice(&tsig_record());
+
+        assert_eq!(&ensure_do_bit(&wire)[..], &wire[..]);
+    }
+
+    /// A minimal empty-RDATA TSIG record.
+    fn tsig_record() -> Vec<u8> {
+        let mut rec = vec![0]; // root name
+        rec.extend_from_slice(&TYPE_TSIG.to_be_bytes());
+        rec.extend_from_slice(&[0, 255]); // CLASS=ANY
+        rec.extend_from_slice(&[0, 0, 0, 0]); // TTL
+        rec.extend_from_slice(&[0, 0]); // RDLENGTH
+        rec
     }
 
     #[test]

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -141,7 +141,7 @@ pub fn ensure_do_bit(wire: &[u8]) -> Cow<'_, [u8]> {
             out[ttl + 2] |= DO_FLAG;
             if !payload_in_budget(&out, ttl) {
                 let clamped = payload(&out, ttl).clamp(MIN_UPSTREAM_PAYLOAD, MAX_UPSTREAM_PAYLOAD);
-                out[ttl - 2..ttl].copy_from_slice(&clamped.to_be_bytes());
+                set_payload(&mut out, ttl, clamped);
             }
             Cow::Owned(out)
         }
@@ -161,7 +161,7 @@ pub fn maximize_payload(wire: &[u8]) -> Cow<'_, [u8]> {
     match locate_opt(wire) {
         Ok(OptSite::Flag(ttl)) if payload(wire, ttl) != MAX_UPSTREAM_PAYLOAD => {
             let mut out = wire.to_vec();
-            out[ttl - 2..ttl].copy_from_slice(&MAX_UPSTREAM_PAYLOAD.to_be_bytes());
+            set_payload(&mut out, ttl, MAX_UPSTREAM_PAYLOAD);
             Cow::Owned(out)
         }
         _ => Cow::Borrowed(wire),
@@ -193,6 +193,10 @@ pub const APPENDED_DO_OPT: [u8; 11] = {
 /// before its TTL.
 fn payload(wire: &[u8], ttl: usize) -> u16 {
     u16::from_be_bytes([wire[ttl - 2], wire[ttl - 1]])
+}
+
+fn set_payload(wire: &mut [u8], ttl: usize, size: u16) {
+    wire[ttl - 2..ttl].copy_from_slice(&size.to_be_bytes());
 }
 
 fn payload_in_budget(wire: &[u8], ttl: usize) -> bool {

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -152,6 +152,22 @@ pub fn ensure_do_bit(wire: &[u8]) -> Cow<'_, [u8]> {
     }
 }
 
+/// Raise the advertised budget to our full receive ceiling. A stream transport
+/// has no datagram to fragment, and its TC=1 has nothing left to escalate to —
+/// so a smaller budget only invites a truncated answer we would have to fail
+/// (RFC 8484 §5.1: the server honors what the requestor advertised). Wires with
+/// no OPT to patch go upstream as they came.
+pub fn maximize_payload(wire: &[u8]) -> Cow<'_, [u8]> {
+    match locate_opt(wire) {
+        Ok(OptSite::Flag(ttl)) if payload(wire, ttl) != MAX_UPSTREAM_PAYLOAD => {
+            let mut out = wire.to_vec();
+            out[ttl - 2..ttl].copy_from_slice(&MAX_UPSTREAM_PAYLOAD.to_be_bytes());
+            Cow::Owned(out)
+        }
+        _ => Cow::Borrowed(wire),
+    }
+}
+
 /// EDNS payload size is hop-by-hop (RFC 6891 §6.2.3) — upstream answers to us,
 /// not to our client, so the client's budget is not ours to pass on. Forwarding
 /// a small one alongside DO=1 asks for RRSIGs that cannot fit and earns a TC=1
@@ -1689,6 +1705,36 @@ mod tests {
         wire.extend_from_slice(&tsig_record());
 
         assert_eq!(&ensure_do_bit(&wire)[..], &wire[..]);
+    }
+
+    #[test]
+    fn maximize_payload_raises_the_stream_budget_to_the_ceiling() {
+        // Over DoH/DoT the 1232 default only invites a TC=1 with nothing left
+        // to escalate to, so every stream transport asks for the ceiling.
+        let wire = ensure_do_bit(&query_wire()).into_owned();
+        assert_eq!(
+            parse_wire(&wire).edns.unwrap().udp_payload_size,
+            MIN_UPSTREAM_PAYLOAD
+        );
+
+        let out = maximize_payload(&wire);
+
+        assert_eq!(out.len(), wire.len(), "patched in place");
+        let edns = parse_wire(&out).edns.expect("OPT present");
+        assert_eq!(edns.udp_payload_size, MAX_UPSTREAM_PAYLOAD);
+        assert!(edns.do_bit, "DO survives the payload patch");
+    }
+
+    #[test]
+    fn maximize_payload_leaves_unpatchable_wires_untouched() {
+        // No OPT to patch, and a TSIG whose MAC we must not void.
+        let bare = query_wire();
+        assert_eq!(&maximize_payload(&bare)[..], &bare[..]);
+
+        let mut signed = query_wire();
+        signed[10..12].copy_from_slice(&1u16.to_be_bytes()); // ARCOUNT
+        signed.extend_from_slice(&tsig_record());
+        assert_eq!(&maximize_payload(&signed)[..], &signed[..]);
     }
 
     /// A minimal empty-RDATA TSIG record.


### PR DESCRIPTION
follow-ups from a post-merge review of #347.

- one reply path for every transport: forward_query_raw dispatches, validates the reply (length, ID, QR, BytePacketBuffer capacity), and resolves TC=1 in one place. UDP escalates to TCP inside what's left of the timeout budget; a stream transport answering TC=1 has nothing bigger to escalate to, so it counts as a failed upstream and failover moves on instead of returning an uncacheable TC wire
- a failed or unusable TCP retry also counts as a failed upstream (a TC answer from an upstream with TCP:53 filtered used to count as pool success and the fallbacks never fired)
- replies past 4096 bytes are refused everywhere: BytePacketBuffer::from_bytes silently cuts them, which turned a large signed answer (or DoH reply — that gap predates #347) into SERVFAIL plus a cache entry that never parses until TTL expiry
- srtt records the elapsed time including the TCP leg, so a chronically truncating upstream stops winning the candidate sort on its fast TC replies
- locate_opt scans the whole additional section before deciding: a signed query with EDNS is [OPT, TSIG] per RFC 8945, and the old loop returned at the OPT and patched inside the MAC
- MAX_UPSTREAM_PAYLOAD now derives from BUF_SIZE and forward_udp_raw's receive buffer derives from it, one constant instead of three unlinked 4096s
- the lockfile keeps windows-sys at 0.61.2: cargo 1.94 had downgraded errno/quinn-udp/rustls-native-certs to 0.52.0 as a side effect of the h2 bump
- the TC retry tests use the testutil stubs instead of a third hand-rolled copy
