### PR TITLE
fix(recursive): reject bogon nameserver addresses

### DIFF
--- a/src/acl.rs
+++ b/src/acl.rs
@@ -8,6 +8,27 @@ use std::net::IpAddr;
 use ipnet::IpNet;
 use log::warn;
 
+/// Private / special-use ranges that must never appear as a routable
+/// destination — the shared definition of "inside the perimeter", consumed by
+/// the rebind filter (stripped from answers) and the recursive resolver's bogon
+/// guard (refused as upstream nameserver addresses). Loopback is included: it's
+/// a prime rebind target (localhost dev servers, Docker/Electron dashboards) and
+/// a nameserver there points recursion back at our own host.
+pub(crate) const PRIVATE_RANGES: &[&str] = &[
+    "127.0.0.0/8",    // RFC 1122 loopback
+    "10.0.0.0/8",     // RFC 1918
+    "172.16.0.0/12",  // RFC 1918
+    "192.168.0.0/16", // RFC 1918
+    "169.254.0.0/16", // RFC 3927 link-local
+    "100.64.0.0/10",  // RFC 6598 CGNAT — also Tailscale's address space
+    "0.0.0.0/8",      // RFC 1122 "this host" — 0.0.0.0 routes to localhost on connect
+    "fc00::/7",       // RFC 4193 ULA
+    "64:ff9b::/96",   // RFC 6052 NAT64 — synthesized addrs route to embedded v4
+    "fe80::/10",      // RFC 4291 link-local
+    "::1/128",        // loopback
+    "::/128",         // unspecified
+];
+
 pub(crate) fn parse_cidr_list(entries: &[String], context: &str) -> Result<Vec<IpNet>, String> {
     let mut nets = Vec::with_capacity(entries.len());
     for entry in entries {

--- a/src/rebind.rs
+++ b/src/rebind.rs
@@ -5,30 +5,11 @@
 
 use std::net::IpAddr;
 
-use crate::acl::CidrMatcher;
+use crate::acl::{CidrMatcher, PRIVATE_RANGES};
 use crate::domain_list::PersistedDomainList;
 use crate::packet::DnsPacket;
 use crate::question::QueryType;
 use crate::record::DnsRecord;
-
-/// Built-in private/special-use ranges, used when `rebind_private_ranges` is
-/// empty. Loopback is included — it's a prime rebind target (localhost dev
-/// servers, Docker/Electron dashboards); DNSBL/RBL users that resolve
-/// `127.0.0.x` should allowlist those zones.
-const DEFAULT_RANGES: &[&str] = &[
-    "127.0.0.0/8",    // RFC 1122 loopback — the canonical rebind target
-    "10.0.0.0/8",     // RFC 1918
-    "172.16.0.0/12",  // RFC 1918
-    "192.168.0.0/16", // RFC 1918
-    "169.254.0.0/16", // RFC 3927 link-local
-    "100.64.0.0/10",  // RFC 6598 CGNAT — also Tailscale's address space
-    "0.0.0.0/8",      // RFC 1122 "this host" — 0.0.0.0 routes to localhost on connect
-    "fc00::/7",       // RFC 4193 ULA
-    "64:ff9b::/96",   // RFC 6052 NAT64 — synthesized addrs route to embedded v4
-    "fe80::/10",      // RFC 4291 link-local
-    "::1/128",        // loopback
-    "::/128",         // unspecified
-];
 
 pub struct RebindFilter {
     enabled: bool,
@@ -46,7 +27,7 @@ impl RebindFilter {
         custom_ranges: &[String],
     ) -> Result<Self, String> {
         let range_strings: Vec<String> = if custom_ranges.is_empty() {
-            DEFAULT_RANGES.iter().map(|s| s.to_string()).collect()
+            PRIVATE_RANGES.iter().map(|s| s.to_string()).collect()
         } else {
             custom_ranges.to_vec()
         };

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -1,11 +1,12 @@
 use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicU16, Ordering};
-use std::sync::RwLock;
+use std::sync::{LazyLock, RwLock};
 use std::time::{Duration, Instant};
 
 use log::{debug, info};
 
+use crate::acl::CidrMatcher;
 use crate::cache::DnsCache;
 use crate::forward::forward_udp;
 use crate::header::ResultCode;
@@ -35,11 +36,32 @@ fn dns_addr(ip: impl Into<IpAddr>) -> SocketAddr {
 }
 
 fn record_to_addr(rec: &DnsRecord) -> Option<SocketAddr> {
-    match rec {
-        DnsRecord::A { addr, .. } => Some(dns_addr(*addr)),
-        DnsRecord::AAAA { addr, .. } => Some(dns_addr(*addr)),
-        _ => None,
-    }
+    let addr = match rec {
+        DnsRecord::A { addr, .. } => dns_addr(*addr),
+        DnsRecord::AAAA { addr, .. } => dns_addr(*addr),
+        _ => return None,
+    };
+    (!is_bogon(addr.ip())).then_some(addr)
+}
+
+/// A public authoritative server is only ever reachable at a globally-routable
+/// address, so refuse glue/NS addresses that point inward before we query them.
+/// Without this a malicious server can glue an NS at `127.0.0.1` or an RFC1918
+/// host and turn recursion into an internal-network probe (bounded to :53 by
+/// `dns_addr`, but a probe all the same). Shares the rebind filter's
+/// private-range list; `CidrMatcher` unmaps v4-mapped v6 before matching. Root
+/// priming funnels through here too, but real root/TLD glue is public and passes.
+static BOGON_RANGES: LazyLock<CidrMatcher> = LazyLock::new(|| {
+    let ranges: Vec<String> = crate::acl::PRIVATE_RANGES
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    CidrMatcher::from_entries(&ranges, &[], "bogon nameserver filter")
+        .expect("built-in private ranges are valid CIDRs")
+});
+
+fn is_bogon(ip: IpAddr) -> bool {
+    BOGON_RANGES.matches(ip)
 }
 
 pub fn reset_udp_state() {
@@ -958,6 +980,48 @@ mod tests {
             dns_addr("2001:db8::1".parse::<Ipv6Addr>().unwrap())
         );
         assert_eq!(addrs[1], dns_addr(Ipv4Addr::new(1, 2, 3, 4)));
+    }
+
+    #[test]
+    fn bogon_filter_rejects_internal_addrs() {
+        for ip in [
+            "127.0.0.1",
+            "10.1.2.3",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.0.1",
+            "100.64.0.1",
+            "0.0.0.0",
+        ] {
+            assert!(is_bogon(ip.parse().unwrap()), "{ip} should be a bogon");
+        }
+        for ip in [
+            "::1",
+            "fc00::1",
+            "fe80::1",
+            "::ffff:127.0.0.1",
+            "64:ff9b::7f00:1",
+        ] {
+            assert!(is_bogon(ip.parse().unwrap()), "{ip} should be a bogon");
+        }
+    }
+
+    #[test]
+    fn bogon_filter_accepts_public_addrs() {
+        for ip in ["8.8.8.8", "1.1.1.1", "2001:4860:4860::8888"] {
+            assert!(!is_bogon(ip.parse().unwrap()), "{ip} should be routable");
+        }
+    }
+
+    #[test]
+    fn glue_bogon_dropped_from_addrs() {
+        let mut pkt = DnsPacket::new();
+        pkt.resources.push(DnsRecord::A {
+            domain: "ns1.attacker.com".into(),
+            addr: Ipv4Addr::new(127, 0, 0, 1),
+            ttl: 3600,
+        });
+        assert!(glue_addrs_for(&pkt, "ns1.attacker.com").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
A malicious authoritative server could glue an NS at 127.0.0.1, an RFC1918 host, or a NAT64-embedded private v4 and turn recursion into an internal-network probe (bounded to :53 by dns_addr, but a probe all the same). Filter NS/glue addresses through record_to_addr before querying.

Reuses the rebind filter's private-range list as a single source of truth: the list moves to acl::PRIVATE_RANGES and both the rebind answer filter and this bogon guard build a CidrMatcher from it, so "inside the perimeter" has one definition (and CidrMatcher already unmaps v4-mapped v6). Root/TLD glue funnels through the same guard but is public and passes.

Recursive-mode only. On by default with no opt-out: recursion from the real root never legitimately reaches a private nameserver, so there is no false-positive topology short of custom internal root_hints.