### PR TITLE
fix(recursive): bound per-resolution query budget + NS fan-out width

### DIFF
--- a/src/dnssec.rs
+++ b/src/dnssec.rs
@@ -554,9 +554,17 @@ async fn fetch_dnskeys(
 
     trace!("dnssec: fetch_dnskeys('{}') cache miss — resolving", zone);
     stats.lock().unwrap().dnskey_fetches += 1;
-    if let Ok(pkt) =
-        crate::recursive::resolve_iterative(zone, QueryType::DNSKEY, cache, root_hints, srtt, 0, 0)
-            .await
+    if let Ok(pkt) = crate::recursive::resolve_iterative(
+        zone,
+        QueryType::DNSKEY,
+        cache,
+        root_hints,
+        srtt,
+        0,
+        0,
+        &std::sync::atomic::AtomicUsize::new(0),
+    )
+    .await
     {
         cache.write().unwrap().insert(zone, QueryType::DNSKEY, &pkt);
         return pkt.answers;
@@ -580,9 +588,17 @@ async fn fetch_ds(
     }
 
     stats.lock().unwrap().ds_fetches += 1;
-    if let Ok(pkt) =
-        crate::recursive::resolve_iterative(child, QueryType::DS, cache, root_hints, srtt, 0, 0)
-            .await
+    if let Ok(pkt) = crate::recursive::resolve_iterative(
+        child,
+        QueryType::DS,
+        cache,
+        root_hints,
+        srtt,
+        0,
+        0,
+        &std::sync::atomic::AtomicUsize::new(0),
+    )
+    .await
     {
         cache.write().unwrap().insert(child, QueryType::DS, &pkt);
         return pkt.answers;

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -18,18 +18,10 @@ use crate::stats::UpstreamTransport;
 
 const MAX_REFERRAL_DEPTH: u8 = 10;
 const MAX_CNAME_DEPTH: u8 = 8;
-/// Total upstream queries one client resolution may spend across *every* branch
-/// (referral chain, glue-less NS fan-out, CNAME re-chase). Depth caps bound each
-/// branch in isolation; only this bounds the sum, so a crafted referral tree
-/// can't turn one client query into unbounded work (NXNS / NRDelegation class).
-/// Above hickory's 24, well under BIND's `max-recursion-queries` 100 — generous
-/// enough that legit deep names survive, tight enough to kill the amplification.
+// Depth bounds each branch; these bound the whole resolution against NXNS /
+// NRDelegation fan-out. 48 total upstream queries (~hickory 24, <BIND 100), and
+// MaxFetch(k) caps glue-less NS names chased per referral (only balloons on failure).
 const MAX_TOTAL_QUERIES: usize = 48;
-/// Max glue-less NS names one referral may trigger address lookups for
-/// (MaxFetch(k) from the NXNSAttack paper). The fan-out stops early on the first
-/// name that resolves, so this only bites a referral whose names keep failing —
-/// the amplification vector. PowerDNS ships 13; a legit delegation rarely lists
-/// more than a handful.
 const MAX_NS_FETCH: usize = 10;
 const NS_QUERY_TIMEOUT: Duration = Duration::from_millis(400);
 const TCP_TIMEOUT: Duration = Duration::from_millis(400);
@@ -44,10 +36,7 @@ fn next_id() -> u16 {
     QUERY_ID.fetch_add(1, Ordering::Relaxed)
 }
 
-/// Claim one unit of the per-resolution query budget. Returns false once
-/// `MAX_TOTAL_QUERIES` have been spent. One logical upstream query (a single
-/// `send_query_hedged`, hedging included) = one unit; the counter is shared by
-/// reference across the whole recursion, so branches draw from one pool.
+// Shared by reference across the whole recursion, so every branch draws from one pool.
 fn claim_query_budget(spent: &AtomicUsize) -> bool {
     spent.fetch_add(1, Ordering::Relaxed) < MAX_TOTAL_QUERIES
 }
@@ -213,9 +202,7 @@ pub async fn resolve_recursive(
     root_hints: &[SocketAddr],
     srtt: &RwLock<SrttCache>,
 ) -> crate::Result<DnsPacket> {
-    // Each hop is bounded by NS_QUERY_TIMEOUT (UDP + TCP fallback), MAX_REFERRAL_DEPTH
-    // caps the chain length, and `budget` caps the total upstream queries this one
-    // client resolution may spend across all branches.
+    // `budget` caps the total upstream queries this one client resolution may spend.
     let budget = AtomicUsize::new(0);
     let mut resp = resolve_iterative(qname, qtype, cache, root_hints, srtt, 0, 0, &budget).await?;
 

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -25,6 +25,12 @@ const MAX_CNAME_DEPTH: u8 = 8;
 /// Above hickory's 24, well under BIND's `max-recursion-queries` 100 — generous
 /// enough that legit deep names survive, tight enough to kill the amplification.
 const MAX_TOTAL_QUERIES: usize = 48;
+/// Max glue-less NS names one referral may trigger address lookups for
+/// (MaxFetch(k) from the NXNSAttack paper). The fan-out stops early on the first
+/// name that resolves, so this only bites a referral whose names keep failing —
+/// the amplification vector. PowerDNS ships 13; a legit delegation rarely lists
+/// more than a handful.
+const MAX_NS_FETCH: usize = 10;
 const NS_QUERY_TIMEOUT: Duration = Duration::from_millis(400);
 const TCP_TIMEOUT: Duration = Duration::from_millis(400);
 const UDP_FAIL_THRESHOLD: u8 = 3;
@@ -381,7 +387,7 @@ pub(crate) fn resolve_iterative<'a>(
                 resolve_ns_addrs_from_glue(&response, &ns_names, &server_zone, cache);
 
             if new_ns_addrs.is_empty() {
-                for ns_name in &ns_names {
+                for ns_name in ns_names.iter().take(MAX_NS_FETCH) {
                     if referral_depth < MAX_REFERRAL_DEPTH {
                         debug!("recursive: resolving glue-less NS {}", ns_name);
                         for qt in [QueryType::A, QueryType::AAAA] {

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr};
-use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
 use std::sync::{LazyLock, RwLock};
 use std::time::{Duration, Instant};
 
@@ -18,6 +18,13 @@ use crate::stats::UpstreamTransport;
 
 const MAX_REFERRAL_DEPTH: u8 = 10;
 const MAX_CNAME_DEPTH: u8 = 8;
+/// Total upstream queries one client resolution may spend across *every* branch
+/// (referral chain, glue-less NS fan-out, CNAME re-chase). Depth caps bound each
+/// branch in isolation; only this bounds the sum, so a crafted referral tree
+/// can't turn one client query into unbounded work (NXNS / NRDelegation class).
+/// Above hickory's 24, well under BIND's `max-recursion-queries` 100 — generous
+/// enough that legit deep names survive, tight enough to kill the amplification.
+const MAX_TOTAL_QUERIES: usize = 48;
 const NS_QUERY_TIMEOUT: Duration = Duration::from_millis(400);
 const TCP_TIMEOUT: Duration = Duration::from_millis(400);
 const UDP_FAIL_THRESHOLD: u8 = 3;
@@ -29,6 +36,14 @@ pub(crate) static UDP_DISABLED: std::sync::atomic::AtomicBool =
 
 fn next_id() -> u16 {
     QUERY_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Claim one unit of the per-resolution query budget. Returns false once
+/// `MAX_TOTAL_QUERIES` have been spent. One logical upstream query (a single
+/// `send_query_hedged`, hedging included) = one unit; the counter is shared by
+/// reference across the whole recursion, so branches draw from one pool.
+fn claim_query_budget(spent: &AtomicUsize) -> bool {
+    spent.fetch_add(1, Ordering::Relaxed) < MAX_TOTAL_QUERIES
 }
 
 fn dns_addr(ip: impl Into<IpAddr>) -> SocketAddr {
@@ -192,9 +207,11 @@ pub async fn resolve_recursive(
     root_hints: &[SocketAddr],
     srtt: &RwLock<SrttCache>,
 ) -> crate::Result<DnsPacket> {
-    // No overall timeout — each hop is bounded by NS_QUERY_TIMEOUT (UDP + TCP fallback),
-    // and MAX_REFERRAL_DEPTH caps the chain length.
-    let mut resp = resolve_iterative(qname, qtype, cache, root_hints, srtt, 0, 0).await?;
+    // Each hop is bounded by NS_QUERY_TIMEOUT (UDP + TCP fallback), MAX_REFERRAL_DEPTH
+    // caps the chain length, and `budget` caps the total upstream queries this one
+    // client resolution may spend across all branches.
+    let budget = AtomicUsize::new(0);
+    let mut resp = resolve_iterative(qname, qtype, cache, root_hints, srtt, 0, 0, &budget).await?;
 
     resp.header.id = original_query.header.id;
     resp.header.recursion_available = true;
@@ -203,6 +220,7 @@ pub async fn resolve_recursive(
     Ok(resp)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn resolve_iterative<'a>(
     qname: &'a str,
     qtype: QueryType,
@@ -211,6 +229,7 @@ pub(crate) fn resolve_iterative<'a>(
     srtt: &'a RwLock<SrttCache>,
     referral_depth: u8,
     cname_depth: u8,
+    budget: &'a AtomicUsize,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = crate::Result<DnsPacket>> + Send + 'a>> {
     Box::pin(async move {
         if referral_depth > MAX_REFERRAL_DEPTH {
@@ -228,6 +247,10 @@ pub(crate) fn resolve_iterative<'a>(
         for _ in 0..MAX_REFERRAL_DEPTH {
             if ns_idx >= ns_addrs.len() {
                 return Err("no nameserver available".into());
+            }
+
+            if !claim_query_budget(budget) {
+                return Err(format!("query budget exhausted resolving {}", qname).into());
             }
 
             let (q_name, q_type) = minimize_query(qname, qtype, &current_zone);
@@ -311,6 +334,7 @@ pub(crate) fn resolve_iterative<'a>(
                         srtt,
                         0,
                         cname_depth + 1,
+                        budget,
                     )
                     .await?;
 
@@ -369,6 +393,7 @@ pub(crate) fn resolve_iterative<'a>(
                                 srtt,
                                 referral_depth + 1,
                                 cname_depth,
+                                budget,
                             )
                             .await
                             {
@@ -1025,6 +1050,16 @@ mod tests {
     }
 
     #[test]
+    fn query_budget_permits_exactly_max_then_denies() {
+        let spent = AtomicUsize::new(0);
+        for i in 0..MAX_TOTAL_QUERIES {
+            assert!(claim_query_budget(&spent), "query {i} within budget");
+        }
+        assert!(!claim_query_budget(&spent), "one past the budget is denied");
+        assert!(!claim_query_budget(&spent), "stays denied");
+    }
+
+    #[test]
     fn cname_extraction() {
         let mut pkt = DnsPacket::new();
         pkt.answers.push(DnsRecord::CNAME {
@@ -1467,6 +1502,7 @@ mod tests {
             &srtt,
             0,
             0,
+            &AtomicUsize::new(0),
         )
         .await;
 


### PR DESCRIPTION
closes the last actionable items from the recursive-defense audit (after the bailiwick trio #354/#355 and the bogon filter #356). two layers of the NXNS / NRDelegation amplification defense (USENIX Sec '20 / '23).

## the gap

depth caps bound each branch in isolation, but nothing bounded the *sum* across branches. two ways one client query fans out past what depth implies:

- glue-less NS fan-out spawns a full sub-resolution per NS name (A + AAAA each)
- the CNAME chase recurses with `referral_depth` reset to 0

so a crafted referral tree can drive far more upstream work than `MAX_REFERRAL_DEPTH` suggests. every mature recursive resolver caps total work per client query (BIND `max-recursion-queries` 100, PowerDNS `max-qperq` 60, hickory 24), numa only had depth.

## fix 1 — total query budget

thread a shared per-resolution counter (`AtomicUsize`) through `resolve_iterative`, refuse past `MAX_TOTAL_QUERIES` (48). one `send_query_hedged` = one unit, hedging included. every branch draws from the same pool, so the CNAME reset can't launder fresh budget. the two DNSSEC validation fetches get their own budgets, matching their independent depth counters.

48 sits above hickory's 24 (a value known to survive production) and well under BIND's 100 — generous enough for legit deep names, tight enough to kill the amplification.

## fix 2 — NS fan-out width cap (MaxFetch)

the budget alone still lets a single referral spend all 48 in one shot by listing many glue-less NS names that keep failing. cap the fan-out at `MAX_NS_FETCH` (10) names per referral — MaxFetch(k) from the NXNS paper (PowerDNS ships 13). the loop already stops on the first name that resolves, so this only bites the amplification case (all names failing); a legit delegation lists a handful.

recursive-mode only, so forward mode (the shipped default) is unaffected.

## test

boundary unit test pins the budget off-by-one (permits exactly 48, denies the 49th). end-to-end exhaustion is the same single-hop mock constraint as the bailiwick work (glue resolves to :53, and loopback glue is now bogon-filtered), so the fan-out mechanisms are verified by construction + the boundary test.