### PR TITLE
fix(recursive): randomize TXIDs and validate UDP replies (RFC 5452)

### DIFF
--- a/src/bootstrap_resolver.rs
+++ b/src/bootstrap_resolver.rs
@@ -123,8 +123,8 @@ async fn resolve_via_bootstrap(
 ) -> Result<Vec<SocketAddr>, Box<dyn std::error::Error + Send + Sync>> {
     let mut last_err: Option<String> = None;
     for &server in bootstrap {
-        let q_a = DnsPacket::query(0xBEEF, hostname, QueryType::A);
-        let q_aaaa = DnsPacket::query(0xBEF0, hostname, QueryType::AAAA);
+        let q_a = DnsPacket::query(crate::packet::random_id(), hostname, QueryType::A);
+        let q_aaaa = DnsPacket::query(crate::packet::random_id(), hostname, QueryType::AAAA);
         let (a_res, aaaa_res) = tokio::join!(
             query_with_tcp_fallback(&q_a, server),
             query_with_tcp_fallback(&q_aaaa, server),

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 use tokio::net::UdpSocket;
-use tokio::time::timeout;
+use tokio::time::{timeout, timeout_at};
 
 use crate::buffer::BytePacketBuffer;
 use crate::odoh::{query_through_relay, OdohConfigCache};
@@ -350,9 +350,47 @@ pub(crate) async fn forward_udp(
 ) -> Result<DnsPacket> {
     let mut send_buffer = BytePacketBuffer::new();
     query.write(&mut send_buffer)?;
-    let data = forward_udp_raw(send_buffer.filled(), upstream, timeout_duration).await?;
-    let mut recv_buffer = BytePacketBuffer::from_bytes(&data);
-    DnsPacket::from_buffer(&mut recv_buffer)
+
+    let socket = UdpSocket::bind("0.0.0.0:0").await?;
+    // Connected, so the kernel drops datagrams from anyone but the upstream.
+    socket.connect(upstream).await?;
+    socket.send(send_buffer.filled()).await?;
+
+    // Loop until a datagram answers the exact question we asked, or the deadline
+    // lapses. A spoof that raced the real reply onto our ephemeral port (SAD DNS
+    // infers it) fails the match and must not end the wait — a single recv would
+    // let the first forged packet win. One byte of headroom over the cap: a
+    // datagram the kernel cut to fit is indistinguishable from a full one, so
+    // discard it (§ RFC 5452 acceptance check).
+    let deadline = tokio::time::Instant::now() + timeout_duration;
+    let mut recv_buf = vec![0u8; crate::wire::MAX_UPSTREAM_PAYLOAD as usize + 1];
+    loop {
+        let size = timeout_at(deadline, socket.recv(&mut recv_buf)).await??;
+        if size > crate::wire::MAX_UPSTREAM_PAYLOAD as usize {
+            continue;
+        }
+        let mut recv_buffer = BytePacketBuffer::from_bytes(&recv_buf[..size]);
+        if let Ok(resp) = DnsPacket::from_buffer(&mut recv_buffer) {
+            if response_matches(query, &resp) {
+                return Ok(resp);
+            }
+        }
+    }
+}
+
+/// A UDP reply we'll act on: QR=1, our transaction ID, and the same question we
+/// asked (case-insensitive name, same type). The connected socket already drops
+/// off-source datagrams; this rejects a source-spoofing off-path injection that
+/// forged the upstream's address to race the real answer.
+fn response_matches(query: &DnsPacket, resp: &DnsPacket) -> bool {
+    resp.header.response
+        && resp.header.id == query.header.id
+        && match (query.questions.first(), resp.questions.first()) {
+            (Some(asked), Some(got)) => {
+                asked.qtype == got.qtype && asked.name.eq_ignore_ascii_case(&got.name)
+            }
+            _ => false,
+        }
 }
 
 /// DNS over TCP (RFC 1035 §4.2.2): 2-byte length prefix, then the DNS message.
@@ -1167,6 +1205,91 @@ mod tests {
         .await;
 
         assert!(result.is_err(), "an off-path reply must not answer");
+    }
+
+    #[test]
+    fn response_matches_accepts_the_echoed_question() {
+        let query = make_query();
+        assert!(response_matches(&query, &make_response(&query)));
+    }
+
+    #[test]
+    fn response_matches_rejects_wrong_id_name_type_or_query() {
+        let query = make_query();
+
+        let mut wrong_id = make_response(&query);
+        wrong_id.header.id ^= 0xFFFF;
+        assert!(!response_matches(&query, &wrong_id), "id must match");
+
+        let mut wrong_name = make_response(&query);
+        wrong_name.questions[0].name = "evil.example".to_string();
+        assert!(!response_matches(&query, &wrong_name), "qname must match");
+
+        let mut wrong_type = make_response(&query);
+        wrong_type.questions[0].qtype = QueryType::AAAA;
+        assert!(!response_matches(&query, &wrong_type), "qtype must match");
+
+        let mut not_a_response = make_response(&query);
+        not_a_response.header.response = false;
+        assert!(!response_matches(&query, &not_a_response), "QR must be set");
+    }
+
+    #[test]
+    fn response_matches_is_case_insensitive_on_name() {
+        let query = make_query();
+        let mut mixed_case = make_response(&query);
+        mixed_case.questions[0].name = "ExAmPlE.CoM".to_string();
+        assert!(
+            response_matches(&query, &mixed_case),
+            "0x20 case must not reject"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_udp_discards_a_spoof_and_takes_the_match() {
+        // The upstream sends a wrong-id spoof first, then the real reply, both
+        // from the connected source. The recv loop must skip the spoof and
+        // return the answer that matches the question we asked.
+        let query = make_query();
+        let good = to_wire(&make_response(&query));
+        let mut spoof = good.clone();
+        crate::wire::patch_id(&mut spoof, query.header.id ^ 0xFFFF);
+
+        let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let addr = sock.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut buf = [0u8; 512];
+            let (_, src) = sock.recv_from(&mut buf).await.unwrap();
+            let _ = sock.send_to(&spoof, src).await;
+            let _ = sock.send_to(&good, src).await;
+        });
+
+        let resp = forward_udp(&query, addr, Duration::from_millis(500))
+            .await
+            .expect("the matching reply must win the race");
+        assert_eq!(resp.header.id, query.header.id);
+        assert_eq!(resp.answers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn forward_udp_times_out_on_a_wrong_id_only_reply() {
+        let query = make_query();
+        let mut spoof = to_wire(&make_response(&query));
+        crate::wire::patch_id(&mut spoof, query.header.id ^ 0xFFFF);
+
+        let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let addr = sock.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut buf = [0u8; 512];
+            let (_, src) = sock.recv_from(&mut buf).await.unwrap();
+            let _ = sock.send_to(&spoof, src).await;
+        });
+
+        let result = forward_udp(&query, addr, Duration::from_millis(200)).await;
+        assert!(
+            result.is_err(),
+            "a reply that never matches must not be accepted"
+        );
     }
 
     #[tokio::test]

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -351,22 +351,24 @@ pub(crate) async fn forward_udp(
     let mut send_buffer = BytePacketBuffer::new();
     query.write(&mut send_buffer)?;
 
-    let socket = UdpSocket::bind("0.0.0.0:0").await?;
-    // Connected, so the kernel drops datagrams from anyone but the upstream.
-    socket.connect(upstream).await?;
+    let socket = connected_udp(upstream).await?;
     socket.send(send_buffer.filled()).await?;
 
     // Loop until a datagram answers the exact question we asked, or the deadline
     // lapses. A spoof that raced the real reply onto our ephemeral port (SAD DNS
     // infers it) fails the match and must not end the wait — a single recv would
-    // let the first forged packet win. One byte of headroom over the cap: a
-    // datagram the kernel cut to fit is indistinguishable from a full one, so
-    // discard it (§ RFC 5452 acceptance check).
+    // let the first forged packet win (§ RFC 5452 acceptance check). The txid is
+    // the first two wire bytes, so reject the flood cheaply before a full parse.
+    let want_id = query.header.id.to_be_bytes();
     let deadline = tokio::time::Instant::now() + timeout_duration;
     let mut recv_buf = vec![0u8; crate::wire::MAX_UPSTREAM_PAYLOAD as usize + 1];
     loop {
         let size = timeout_at(deadline, socket.recv(&mut recv_buf)).await??;
-        if size > crate::wire::MAX_UPSTREAM_PAYLOAD as usize {
+        // Over the cap: the kernel cut an oversized datagram to fit, and a cut
+        // wire is indistinguishable from a full one. Under 12: no DNS header.
+        if !(12..=crate::wire::MAX_UPSTREAM_PAYLOAD as usize).contains(&size)
+            || recv_buf[..2] != want_id
+        {
             continue;
         }
         let mut recv_buffer = BytePacketBuffer::from_bytes(&recv_buf[..size]);
@@ -378,19 +380,31 @@ pub(crate) async fn forward_udp(
     }
 }
 
+/// A connected UDP socket to `upstream`: the kernel then drops datagrams from
+/// anyone but it, leaving source-spoofed off-path injection as the only path in.
+async fn connected_udp(upstream: SocketAddr) -> Result<UdpSocket> {
+    let socket = UdpSocket::bind("0.0.0.0:0").await?;
+    socket.connect(upstream).await?;
+    Ok(socket)
+}
+
 /// A UDP reply we'll act on: QR=1, our transaction ID, and the same question we
 /// asked (case-insensitive name, same type). The connected socket already drops
 /// off-source datagrams; this rejects a source-spoofing off-path injection that
 /// forged the upstream's address to race the real answer.
 fn response_matches(query: &DnsPacket, resp: &DnsPacket) -> bool {
-    resp.header.response
-        && resp.header.id == query.header.id
-        && match (query.questions.first(), resp.questions.first()) {
-            (Some(asked), Some(got)) => {
-                asked.qtype == got.qtype && asked.name.eq_ignore_ascii_case(&got.name)
-            }
-            _ => false,
-        }
+    if !resp.header.response || resp.header.id != query.header.id {
+        return false;
+    }
+    match resp.questions.first() {
+        Some(got) => query.questions.first().is_some_and(|asked| {
+            asked.qtype == got.qtype && asked.name.eq_ignore_ascii_case(&got.name)
+        }),
+        // Some servers drop the question on errors (FORMERR/REFUSED). Accept
+        // one only when it carries nothing to cache — a bare failure — so a
+        // forged answer can't ride in without naming the question it answers.
+        None => resp.answers.is_empty() && resp.authorities.is_empty(),
+    }
 }
 
 /// DNS over TCP (RFC 1035 §4.2.2): 2-byte length prefix, then the DNS message.
@@ -681,9 +695,7 @@ async fn forward_udp_raw(
     upstream: SocketAddr,
     timeout_duration: Duration,
 ) -> Result<Vec<u8>> {
-    let socket = UdpSocket::bind("0.0.0.0:0").await?;
-    // Connected, so the kernel drops datagrams from anyone but the upstream.
-    socket.connect(upstream).await?;
+    let socket = connected_udp(upstream).await?;
     socket.send(wire).await?;
 
     // One byte of headroom: a datagram sized exactly to the buffer cannot be
@@ -1232,6 +1244,30 @@ mod tests {
         let mut not_a_response = make_response(&query);
         not_a_response.header.response = false;
         assert!(!response_matches(&query, &not_a_response), "QR must be set");
+    }
+
+    #[test]
+    fn response_matches_handles_a_question_less_reply_by_cacheability() {
+        let query = make_query();
+
+        // A bare error that omitted the question is accepted so the caller can
+        // fail fast instead of blocking to the deadline.
+        let mut bare_error = make_response(&query);
+        bare_error.questions.clear();
+        bare_error.answers.clear();
+        bare_error.header.rescode = ResultCode::SERVFAIL;
+        assert!(
+            response_matches(&query, &bare_error),
+            "bare error is a match"
+        );
+
+        // The same reply carrying an answer must not ride in unnamed.
+        let mut smuggled_answer = make_response(&query);
+        smuggled_answer.questions.clear();
+        assert!(
+            !response_matches(&query, &smuggled_answer),
+            "a question-less reply may not carry records"
+        );
     }
 
     #[test]

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -3,9 +3,20 @@ use crate::header::DnsHeader;
 use crate::question::{DnsQuestion, QueryType};
 use crate::record::DnsRecord;
 use crate::Result;
+use rand_core::TryRngCore;
 
 /// Recommended EDNS0 UDP payload size (DNS Flag Day 2020) — avoids IP fragmentation.
 pub const DEFAULT_EDNS_PAYLOAD: u16 = 1232;
+
+/// A random transaction ID for an outbound query. Off-path spoofing (DNSpooq,
+/// SAD DNS) hinges on predicting it, so it must be unguessable — never a counter.
+pub(crate) fn random_id() -> u16 {
+    let mut buf = [0u8; 2];
+    rand_core::OsRng
+        .try_fill_bytes(&mut buf)
+        .expect("OS RNG unavailable");
+    u16::from_be_bytes(buf)
+}
 
 /// EDNS0 OPT pseudo-record (RFC 6891)
 #[derive(Clone, Debug)]

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr};
-use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{LazyLock, RwLock};
 use std::time::{Duration, Instant};
 
@@ -27,14 +27,9 @@ const NS_QUERY_TIMEOUT: Duration = Duration::from_millis(400);
 const TCP_TIMEOUT: Duration = Duration::from_millis(400);
 const UDP_FAIL_THRESHOLD: u8 = 3;
 
-static QUERY_ID: AtomicU16 = AtomicU16::new(1);
 static UDP_FAILURES: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
 pub(crate) static UDP_DISABLED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
-
-fn next_id() -> u16 {
-    QUERY_ID.fetch_add(1, Ordering::Relaxed)
-}
 
 // Shared by reference across the whole recursion, so every branch draws from one pool.
 fn claim_query_budget(spent: &AtomicUsize) -> bool {
@@ -88,7 +83,7 @@ pub async fn probe_udp(root_hints: &[SocketAddr]) {
         Some(h) => *h,
         None => return,
     };
-    let mut probe = DnsPacket::query(next_id(), ".", QueryType::NS);
+    let mut probe = DnsPacket::query(crate::packet::random_id(), ".", QueryType::NS);
     probe.header.recursion_desired = false;
     if forward_udp(&probe, hint, Duration::from_millis(1500))
         .await
@@ -102,7 +97,7 @@ pub async fn probe_udp(root_hints: &[SocketAddr]) {
 /// Probe whether recursive resolution works by querying root servers.
 /// Tries up to 3 hints before declaring failure.
 pub async fn probe_recursive(root_hints: &[SocketAddr]) -> bool {
-    let mut probe = DnsPacket::query(next_id(), ".", QueryType::NS);
+    let mut probe = DnsPacket::query(crate::packet::random_id(), ".", QueryType::NS);
     probe.header.recursion_desired = false;
     for hint in root_hints.iter().take(3) {
         if let Ok(resp) = forward_udp(&probe, *hint, Duration::from_secs(3)).await {
@@ -833,7 +828,7 @@ async fn send_query(
     server: SocketAddr,
     srtt: &RwLock<SrttCache>,
 ) -> crate::Result<DnsPacket> {
-    let mut query = DnsPacket::query(next_id(), qname, qtype);
+    let mut query = DnsPacket::query(crate::packet::random_id(), qname, qtype);
     query.header.recursion_desired = false;
     query.edns = Some(crate::packet::EdnsOpt {
         do_bit: true,


### PR DESCRIPTION
## Summary

Off-path spoofing hardening for the plain-UDP upstream paths (recursive + bootstrap). Closes the DNSpooq cache-poisoning class (CVE-2020-25684/85/86) and the residual Kaminsky/SAD-DNS exposure surfaced by the resolver-defense audit.

- **Random transaction IDs.** New `packet::random_id()` draws from `rand_core::OsRng`, replacing the sequential `AtomicU16` counter in `recursive.rs` and the hard-coded `0xBEEF`/`0xBEF0` in the bootstrap resolver. Predictable TXIDs gave an off-path attacker a free 16 bits.
- **On-receipt validation with a recv-loop.** `forward_udp` now owns its socket and loop-receives against a deadline, returning only a datagram that passes `response_matches` (QR=1, our TXID, same qname case-insensitive + qtype). Spoofed, unparseable, and oversized datagrams are discarded until the timeout. The old single `recv()` let the first forged packet win the race; the loop makes the match a filter, not a coin toss.

Recursive and bootstrap were the fully-unchecked paths. Forward-mode's `forward_query_raw` already had a first-2-bytes TXID check via `usable_reply` (no question match, single recv), left as a smaller follow-up.

Scope is default-safe: the shipped DoH-over-TLS default authenticates the upstream, so TXID/port are irrelevant there. The fix matters for recursive mode, a plain-Do53 forward upstream, and the bootstrap resolver.

## Test plan

- `make all` green (fmt + clippy -D warnings + audit + build + 660 lib tests + integration).
- 5 new tests in `forward.rs`: `response_matches` accept / reject (wrong id, name, type, QR=0) / case-insensitivity units, a spoof-race test (wrong-ID datagram sent first, real reply second — asserts the match wins), and a wrong-ID-only timeout.