### PR TITLE
fix(forward): validate the question on plain-UDP replies (RFC 5452)

### DIFF
--- a/src/forward.rs
+++ b/src/forward.rs
@@ -528,6 +528,9 @@ pub async fn forward_query_raw(
     }?;
 
     let resp = usable_reply(wire, resp)?;
+    if matches!(upstream, Upstream::Udp(_)) && !udp_reply_answers_question(wire, &resp) {
+        return Err("plain-UDP upstream answered a different question".into());
+    }
     if !crate::wire::is_truncated(&resp) {
         return Ok(resp);
     }
@@ -542,6 +545,18 @@ pub async fn forward_query_raw(
         return Err("upstream truncated the TCP retry".into());
     }
     Ok(full)
+}
+
+/// Plain-UDP forwarding shares the recursive path's off-path exposure, so it
+/// gets the same RFC 5452 check: `usable_reply` gates id + QR, this adds the
+/// question match. The TLS/HTTPS transports authenticate the peer, so they skip
+/// it. Byte-level because `forward_query_raw` trades in wire, not packets.
+fn udp_reply_answers_question(query_wire: &[u8], resp: &[u8]) -> bool {
+    let parse = |b: &[u8]| {
+        let mut buf = BytePacketBuffer::from_bytes(b);
+        DnsPacket::from_buffer(&mut buf).ok()
+    };
+    matches!((parse(query_wire), parse(resp)), (Some(q), Some(r)) if response_matches(&q, &r))
 }
 
 /// A reply the pipeline can act on: the ID we sent, QR=1, and within
@@ -1190,6 +1205,33 @@ mod tests {
         let edns = asked.edns.expect("OPT present");
         assert_eq!(edns.udp_payload_size, crate::wire::MAX_UPSTREAM_PAYLOAD);
         assert!(edns.do_bit, "DO survives the payload patch");
+    }
+
+    #[tokio::test]
+    async fn forward_udp_refuses_a_reply_for_a_different_question() {
+        // Right id (the stub patches it), well-formed, but its question names
+        // another host — the off-path "answer for a name we didn't ask" shape.
+        let query = make_query();
+        let mut evil = DnsPacket::response_from(&query, ResultCode::NOERROR);
+        evil.questions[0].name = "evil.example".to_string();
+        evil.answers.push(DnsRecord::A {
+            domain: "evil.example".to_string(),
+            addr: "6.6.6.6".parse().unwrap(),
+            ttl: 300,
+        });
+        let addr = crate::testutil::mock_upstream_raw(to_wire(&evil)).await;
+
+        let result = forward_query_raw(
+            &to_wire(&query),
+            &Upstream::Udp(addr),
+            Duration::from_millis(300),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "a reply for another question must be refused"
+        );
     }
 
     #[tokio::test]

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -234,7 +234,7 @@ fn reply_within_budget(full: &[u8], query_wire: &[u8]) -> Vec<u8> {
         .as_ref()
         .map_or(512, |e| e.udp_payload_size as usize);
     if full.len() <= budget {
-        return full.to_vec();
+        return echo_question(full, &query);
     }
 
     let mut tc = DnsPacket::response_from(&query, ResultCode::NOERROR);
@@ -242,6 +242,26 @@ fn reply_within_budget(full: &[u8], query_wire: &[u8]) -> Vec<u8> {
     let mut out = BytePacketBuffer::new();
     tc.write(&mut out).unwrap();
     out.filled().to_vec()
+}
+
+/// Real upstreams echo the query's question; the record-only fixture builders
+/// (`noerror_response`, `a_record_response`) omit it. Graft it back so replies
+/// pass the resolver's RFC 5452 question check, leaving already-questioned or
+/// unparseable fixtures untouched.
+fn echo_question(full: &[u8], query: &DnsPacket) -> Vec<u8> {
+    let mut parse = BytePacketBuffer::from_bytes(full);
+    let Ok(mut resp) = DnsPacket::from_buffer(&mut parse) else {
+        return full.to_vec();
+    };
+    if !resp.questions.is_empty() {
+        return full.to_vec();
+    }
+    resp.questions = query.questions.clone();
+    let mut out = BytePacketBuffer::new();
+    match resp.write(&mut out) {
+        Ok(_) => out.filled().to_vec(),
+        Err(_) => full.to_vec(),
+    }
 }
 
 /// TCP counterpart of `mock_upstream_raw`, bound to the given address —


### PR DESCRIPTION
## Summary

Follow-up to #358, closing the last asymmetry from that PR's review: the recursive path validates an upstream reply's question against what it asked, but plain-UDP forwarding only checked id + QR (`usable_reply`).

- Add the RFC 5452 question match to the `Upstream::Udp` arm of `forward_query_raw`, reusing `response_matches` from #358. An off-path spoof that guessed the txid could otherwise answer for a different name and have it cached against the name we asked.
- The TLS/HTTPS transports (DoH, DoT, ODoH) authenticate the peer, so they skip the check.
- The record-only test builders (`noerror_response`, `a_record_response`) omit the question section; the stub now echoes the query's question the way a real upstream does (`echo_question`), so fixtures satisfy the new check.

Scope is the same as #358: default-safe (the shipped default is DoH-over-TLS), matters for a plain-Do53 forward upstream.

## Test plan

- `make all` green (fmt + clippy -D warnings + audit + build + 662 lib tests + integration).
- New `forward_udp_refuses_a_reply_for_a_different_question`: a well-formed, correct-id reply whose question names another host is refused.
- Existing forwarding/pipeline tests pass unchanged via the `echo_question` fixture fix.