### PR TITLE
fix(bench): unbreak the comparison modes, add tag-baseline tooling

### DIFF
--- a/benches/hot_path.rs
+++ b/benches/hot_path.rs
@@ -1,12 +1,16 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::borrow::Cow;
 use std::net::Ipv4Addr;
 
 use numa::buffer::BytePacketBuffer;
 use numa::cache::DnsCache;
+use numa::ctx::serialize_with_fallback;
 use numa::header::ResultCode;
-use numa::packet::DnsPacket;
+use numa::packet::{DnsPacket, EdnsOpt, DEFAULT_EDNS_PAYLOAD};
 use numa::question::{DnsQuestion, QueryType};
 use numa::record::DnsRecord;
+use numa::stats::Transport;
+use numa::wire::{ensure_do_bit, maximize_payload, MAX_UPSTREAM_PAYLOAD};
 
 fn make_response(domain: &str) -> DnsPacket {
     let mut pkt = DnsPacket::new();
@@ -119,15 +123,7 @@ fn bench_cache_insert(c: &mut Criterion) {
 
 fn bench_round_trip(c: &mut Criterion) {
     // Simulates the cached hot path: parse query → cache hit → serialize response
-    let query_pkt = {
-        let mut q = DnsPacket::new();
-        q.header.id = 0xABCD;
-        q.header.recursion_desired = true;
-        q.questions
-            .push(DnsQuestion::new("example.com".to_string(), QueryType::A));
-        q
-    };
-    let query_wire = to_wire(&query_pkt);
+    let query_wire = to_wire(&make_query("example.com", None));
 
     let response = make_response("example.com");
     let mut cache = DnsCache::new(10_000, 60, 86400);
@@ -198,6 +194,95 @@ fn bench_zone_lookup_miss(c: &mut Criterion) {
     });
 }
 
+fn make_query(domain: &str, edns: Option<EdnsOpt>) -> DnsPacket {
+    let mut pkt = DnsPacket::query(0x1234, domain, QueryType::A);
+    pkt.edns = edns;
+    pkt
+}
+
+fn edns(udp_payload_size: u16, do_bit: bool) -> EdnsOpt {
+    EdnsOpt {
+        udp_payload_size,
+        do_bit,
+        ..EdnsOpt::default()
+    }
+}
+
+/// Clears 512 but stays inside the 4096 buffer, so the UDP budget decides
+/// whether it truncates, not the serializer.
+fn make_large_response(domain: &str) -> DnsPacket {
+    let mut pkt = make_response(domain);
+    pkt.answers.clear();
+    for i in 0..60 {
+        pkt.answers.push(DnsRecord::A {
+            domain: format!("host{i}.{domain}"),
+            addr: Ipv4Addr::new(93, 184, 216, (i % 256) as u8),
+            ttl: 300,
+        });
+    }
+    pkt
+}
+
+/// Both walkers patch a query wire in place or hand back the original.
+type Walker = fn(&[u8]) -> Cow<'_, [u8]>;
+
+fn bench_do_bit_walkers(c: &mut Criterion) {
+    let with_do = to_wire(&make_query(
+        "example.com",
+        Some(edns(DEFAULT_EDNS_PAYLOAD, true)),
+    ));
+    let without_do = to_wire(&make_query(
+        "example.com",
+        Some(edns(DEFAULT_EDNS_PAYLOAD, false)),
+    ));
+    let no_opt = to_wire(&make_query("example.com", None));
+    let maxed = to_wire(&make_query(
+        "example.com",
+        Some(edns(MAX_UPSTREAM_PAYLOAD, true)),
+    ));
+
+    let cases: [(&str, Walker, &[u8]); 5] = [
+        ("ensure_do_bit_borrowed", ensure_do_bit, &with_do),
+        ("ensure_do_bit_patched", ensure_do_bit, &without_do),
+        ("ensure_do_bit_appended", ensure_do_bit, &no_opt),
+        ("maximize_payload_rewritten", maximize_payload, &with_do),
+        ("maximize_payload_borrowed", maximize_payload, &maxed),
+    ];
+    for (name, walk, wire) in cases {
+        c.bench_function(name, |b| b.iter(|| walk(black_box(wire))));
+    }
+}
+
+/// Same response both ways: only the UDP budget separates the arm that
+/// serializes once from the arm that discovers the overflow and builds a TC
+/// packet on top.
+fn bench_serialize_with_fallback(c: &mut Criterion) {
+    let query = make_query("example.com", Some(edns(512, false)));
+    let mut large = make_large_response("example.com");
+    assert!(
+        to_wire(&large).len() > 512,
+        "large response must exceed the budget"
+    );
+
+    for (name, transport) in [
+        ("serialize_udp_over_budget", Transport::Udp),
+        ("serialize_tcp_unbudgeted", Transport::Tcp),
+    ] {
+        c.bench_function(name, |b| {
+            b.iter(|| {
+                serialize_with_fallback(
+                    black_box(&mut large),
+                    black_box(&query),
+                    "example.com",
+                    false,
+                    transport,
+                )
+                .unwrap()
+            })
+        });
+    }
+}
+
 criterion_group!(
     benches,
     bench_buffer_parse,
@@ -209,5 +294,7 @@ criterion_group!(
     bench_round_trip,
     bench_cache_populated_lookup,
     bench_zone_lookup_miss,
+    bench_do_bit_walkers,
+    bench_serialize_with_fallback,
 );
 criterion_main!(benches);

--- a/benches/recursive_compare.rs
+++ b/benches/recursive_compare.rs
@@ -131,6 +131,10 @@ const DOMAINS: &[&str] = &[
 const ROUNDS: usize = 10;
 
 fn main() {
+    // Every path here that touches TLS, and reqwest's client builder even on
+    // plain HTTP, needs a provider installed first.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let arg = |flag: &str| std::env::args().any(|a| a == flag);
 
     let rt = tokio::runtime::Runtime::new().unwrap();
@@ -501,7 +505,6 @@ fn run_dot_comparison(rt: &tokio::runtime::Runtime, iterations: usize) {
     const NUMA_DOT: &str = "127.0.0.1:8530";
     const UNBOUND_DOT: &str = "127.0.0.1:8531";
 
-    let _ = rustls::crypto::ring::default_provider().install_default();
     let tls_config = build_insecure_tls_config();
 
     for (name, addr) in [("Numa", NUMA_DOT), ("Unbound", UNBOUND_DOT)] {

--- a/scripts/bench-baseline.sh
+++ b/scripts/bench-baseline.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Compare the hermetic Criterion benches on the working tree against a released
+# tag, both built and run on this machine. Published numbers from an older run
+# on other hardware are not a regression signal.
+#
+# Usage:
+#   scripts/bench-baseline.sh            # working tree vs the latest tag
+#   scripts/bench-baseline.sh v0.21.0    # ... vs another ref
+#
+# Runs one bench process at a time. The two trees build into separate target
+# dirs, since sharing one makes Cargo reuse a build-script output across
+# checkouts whose build.rs differ. They share only CRITERION_HOME, which is
+# what carries the baseline. Nothing else should be benchmarking meanwhile.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASE_REF="${1:-$(git -C "$ROOT" describe --tags --abbrev=0)}"
+BASE_NAME="${BASE_REF//\//-}"
+# recursive_compare is excluded: it needs a live resolver and a live Unbound.
+BENCHES=(hot_path throughput dnssec)
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/numa-bench-baseline.XXXXXX")"
+export CRITERION_HOME="$ROOT/target/criterion-baseline"
+BASE_TARGET="$ROOT/target/baseline-$BASE_NAME"
+RESULT="$ROOT/target/baseline-vs-$BASE_NAME.log"
+BASE_TREE="$WORK/base"
+
+cleanup() {
+  git -C "$ROOT" worktree remove --force "$BASE_TREE" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+git -C "$ROOT" rev-parse --verify "$BASE_REF^{commit}" >/dev/null
+
+echo "==> baseline $BASE_REF vs working tree ($(git -C "$ROOT" rev-parse --short HEAD))"
+echo "==> criterion data: $CRITERION_HOME"
+
+echo "==> checking out $BASE_REF"
+git -C "$ROOT" worktree add --detach "$BASE_TREE" "$BASE_REF" >/dev/null
+
+BENCH_ARGS=("${BENCHES[@]/#/--bench=}")
+
+echo "==> recording $BASE_REF"
+(cd "$BASE_TREE" && CARGO_TARGET_DIR="$BASE_TARGET" \
+  cargo bench "${BENCH_ARGS[@]}" -- --save-baseline "$BASE_NAME") 2>&1 | tail -3
+
+# Lenient because benches added since the base ref have no baseline to compare
+# against, and strict mode panics on the first one.
+echo "==> comparing working tree"
+(cd "$ROOT" && cargo bench "${BENCH_ARGS[@]}" -- --baseline-lenient "$BASE_NAME") 2>&1 | tee "$RESULT"
+
+echo
+echo "==> regressions vs $BASE_REF"
+# -B6 rather than -B4: a throughput group puts five lines between the bench
+# name and its verdict.
+grep -B6 "Performance has regressed" "$RESULT" | grep -vE "^Benchmarking|^--$|^$" || echo "    none"
+echo
+echo "==> full output: $RESULT"

--- a/scripts/bench-footprint.sh
+++ b/scripts/bench-footprint.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# What a cache entry costs a build, measured from its own /stats. Not a
+# Criterion bench: the number only exists once a resolver has answered real
+# queries.
+#
+# Cache entries are measured in two cohorts, signed and unsigned zones, because
+# DO=1 upstream (#329) only inflates the answers that carry RRSIGs. Averaging
+# the two hides the effect.
+#
+# Usage:
+#   scripts/bench-footprint.sh            # working tree vs the latest tag
+#   scripts/bench-footprint.sh --current  # working tree only
+set -euo pipefail
+
+DNS_PORT=5464
+API_PORT=5391
+
+SIGNED=(ietf.org isc.org iana.org ripe.net nlnetlabs.nl cloudflare.com
+        quad9.net verisign.com internetsociety.org nic.cz fedoraproject.org
+        debian.org icann.org arin.net nist.gov cira.ca paypal.com slack.com)
+UNSIGNED=(kernel.org wikipedia.org facebook.com google.com amazon.com
+          microsoft.com apple.com github.com reddit.com netflix.com youtube.com
+          linkedin.com zoom.us dropbox.com spotify.com ebay.com
+          stackoverflow.com nytimes.com rust-lang.org golang.org python.org
+          nodejs.org)
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT/target}"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/numa-footprint.XXXXXX")"
+BASE_TREE="$WORK/base"
+NUMA_PID=""
+
+if [[ "${1:-}" == "--current" ]]; then
+  BASE_REF=""
+else
+  BASE_REF="${1:-$(git -C "$ROOT" describe --tags --abbrev=0)}"
+  BASE_TARGET="$ROOT/target/baseline-${BASE_REF//\//-}"
+fi
+
+cleanup() {
+  [[ -n "$NUMA_PID" ]] && kill "$NUMA_PID" 2>/dev/null || true
+  git -C "$ROOT" worktree remove --force "$BASE_TREE" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+CONFIG="$WORK/numa.toml"
+cat >"$CONFIG" <<EOF
+[server]
+bind_addr = "127.0.0.1:$DNS_PORT"
+api_port = $API_PORT
+api_bind_addr = "127.0.0.1"
+data_dir = "$WORK/data"
+
+[upstream]
+mode = "forward"
+address = ["https://9.9.9.9/dns-query"]
+timeout_ms = 10000
+
+[blocking]
+enabled = false
+
+[proxy]
+enabled = false
+
+[dot]
+enabled = false
+EOF
+
+start_numa() {
+  "$1" "$CONFIG" >"$WORK/numa.log" 2>&1 &
+  NUMA_PID=$!
+}
+
+stop_numa() {
+  [[ -n "$NUMA_PID" ]] && kill "$NUMA_PID" 2>/dev/null || true
+  wait "$NUMA_PID" 2>/dev/null || true
+  NUMA_PID=""
+}
+
+# serve.rs binds the UDP listeners before it spawns the API, so a healthy API
+# means the resolver is already answering.
+wait_for_api() {
+  for _ in $(seq 1 30); do
+    curl -sf --max-time 1 "http://127.0.0.1:$API_PORT/health" >/dev/null 2>&1 && return 0
+    sleep 1
+  done
+  echo "ERROR: numa API never came up on $API_PORT"
+  tail -20 "$WORK/numa.log"
+  return 1
+}
+
+# entries and cache bytes after resolving one cohort, with the cache flushed
+# first so the two cohorts never share a measurement.
+cohort_bytes() {
+  local label="$1"; shift
+  curl -s --max-time 5 -X DELETE "http://127.0.0.1:$API_PORT/cache" >/dev/null
+  # Serially: a parallel fan-out times some queries out under the 2s budget
+  # and silently measures whichever subset survived.
+  for d in "$@"; do
+    dig @127.0.0.1 -p "$DNS_PORT" +noadflag +time=2 +tries=1 "$d" A >/dev/null 2>&1 || true
+  done
+  curl -s --max-time 5 "http://127.0.0.1:$API_PORT/stats" | python3 -c '
+import json, sys
+s = json.load(sys.stdin)
+n = s["cache"]["entries"]
+b = s["memory"]["cache_bytes"]
+per = b / n if n else 0
+print(f"    {sys.argv[1]:<10} entries={n:<4} cache_bytes={b:<8} per_entry={per:.0f}")
+' "$label"
+}
+
+profile() {
+  local bin="$1" label="$2"
+  # numa prints its version on stderr
+  echo "==> $label: $("$bin" --version 2>&1 | head -1)"
+
+  start_numa "$bin"
+  wait_for_api
+  cohort_bytes unsigned "${UNSIGNED[@]}"
+  cohort_bytes signed "${SIGNED[@]}"
+  stop_numa
+}
+
+echo "==> building working tree"
+(cd "$ROOT" && cargo build --release --bin numa) 2>&1 | tail -2
+profile "$TARGET_DIR/release/numa" "working tree"
+
+if [[ -n "$BASE_REF" ]]; then
+  echo
+  echo "==> building $BASE_REF"
+  git -C "$ROOT" worktree add --detach "$BASE_TREE" "$BASE_REF" >/dev/null
+  (cd "$BASE_TREE" && CARGO_TARGET_DIR="$BASE_TARGET" cargo build --release --bin numa) 2>&1 | tail -2
+  profile "$BASE_TARGET/release/numa" "$BASE_REF"
+fi

--- a/scripts/bench-vs-unbound.sh
+++ b/scripts/bench-vs-unbound.sh
@@ -5,12 +5,20 @@
 # Usage:
 #   scripts/bench-vs-unbound.sh           # warm cache, forwarding mode
 #   scripts/bench-vs-unbound.sh --cold    # unique subdomains, recursive mode
+#
+# One --cold run is not a result. The first of a session has been seen to read
+# 2x slow on the Numa side alone, with Unbound in the same run unaffected, so a
+# single run cannot separate a build from its turn in the order. Re-run any
+# apparent regression, and compare only runs that repeat.
 set -euo pipefail
 
 NUMA_PORT="${NUMA_PORT:-5454}"
 UNBOUND_PORT="${UNBOUND_PORT:-5456}"
 UPSTREAM="${UPSTREAM:-9.9.9.9}"
 UNBOUND_BIN="${UNBOUND_BIN:-/opt/homebrew/sbin/unbound}"
+# Point NUMA_BIN at another build (see bench-baseline.sh's worktree) to bench a
+# release against this tree's Unbound setup without rebuilding.
+NUMA_BIN="${NUMA_BIN:-}"
 
 if [[ "${1:-}" == "--cold" ]]; then
   MODE="cold"
@@ -63,15 +71,18 @@ fi
 
 echo "==> mode: $MODE (numa: $NUMA_TOML)"
 
-echo "==> building numa (release)"
-cargo build --release --bin numa 2>&1 | tail -3
+if [[ -z "$NUMA_BIN" ]]; then
+  echo "==> building numa (release)"
+  cargo build --release --bin numa 2>&1 | tail -3
+  NUMA_BIN="$ROOT/target/release/numa"
+fi
 
 echo "==> starting unbound on 127.0.0.1:$UNBOUND_PORT"
 "$UNBOUND_BIN" -c "$WORK/unbound.conf" -d >"$WORK/unbound.stderr" 2>&1 &
 UNBOUND_PID=$!
 
-echo "==> starting numa-bench on 127.0.0.1:$NUMA_PORT"
-"$ROOT/target/release/numa" "$ROOT/$NUMA_TOML" >"$WORK/numa.log" 2>&1 &
+echo "==> starting numa-bench on 127.0.0.1:$NUMA_PORT ($("$NUMA_BIN" --version 2>&1 | head -1))"
+"$NUMA_BIN" "$ROOT/$NUMA_TOML" >"$WORK/numa.log" 2>&1 &
 NUMA_PID=$!
 
 echo "==> waiting for both servers"


### PR DESCRIPTION
Bench-only. Nothing here touches the shipped binary.

## the fix

Every `--vs-*` mode of `recursive_compare` aborted before running:

```
thread 'main' panicked at reqwest/src/async_impl/client.rs:2484:
No rustls crypto provider is configured.
```

`check_numa_mode` builds a reqwest client, and that panics under
`rustls-no-provider` before the DoT/DoH paths reach their own
`install_default()`. The whole server-comparison suite was unrunnable on main.
Installing once in `main()` covers the plain-HTTP client too, and the
now-redundant install in `run_dot_comparison` goes away.

## new microbenches

`ensure_do_bit`, `maximize_payload` and the client UDP budget are per-query work
added this cycle with nothing measuring them:

| | |
|---|---|
| `ensure_do_bit_borrowed` / `_patched` / `_appended` | 6.8ns / 20.4ns / 17.1ns |
| `maximize_payload_borrowed` / `_rewritten` | 6.9ns / 19.9ns |
| `serialize_udp_over_budget` | 1.737µs |
| `serialize_tcp_unbudgeted` | 1.733µs |

The two serialize cases feed the same oversized response through a UDP budget
and a TCP one, so only the branch differs. Discovering the overflow and building
the TC packet on top costs ~0.2%: the 1.7µs is serializing a large response, not
the second pass. The bench asserts the response really does exceed the budget
first, since one that starts fitting would measure the other arm without
failing.

## scripts

- `bench-baseline.sh` — Criterion micro benches vs a tag, via worktree. Separate
  target dirs per tree (one shared dir makes Cargo reuse a build-script output
  across checkouts whose `build.rs` differ, and the newer tree then fails to
  compile), sharing only `CRITERION_HOME`.
- `bench-footprint.sh` — cache bytes per entry, split into signed and unsigned
  cohorts, read from the resolver's own `/stats`.
- `NUMA_BIN=` on `bench-vs-unbound.sh` — drive any other build against the same
  Unbound without rebuilding.

## what it found on 0.23

No regressions. Alternating v0.16.0 and current, two runs each, they are
indistinguishable on cold recursive: mean 68.2/66.7 vs 68.5/68.5 ms, median
36.5/35.6 vs 36.7/34.9 ms. Warm cached still ties Unbound at 0.1 ms.

DO=1 upstream (#329) costs +32% bytes per cache entry on signed zones
(578 → 761) and nothing on unsigned (538 → 542). Process RSS is unchanged.

Two traps the scripts document. Published numbers from an older machine are not
a regression signal. And one `--cold` run is not a result: the first of a session
read 2x slow on the Numa side alone, with Unbound in the same run unaffected,
which looked exactly like a regression and was not.

