### PR TITLE
fix(docker): copy build.rs into the builder image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to publish, e.g. v0.23.0'
+        required: true
 
 permissions:
   contents: read
@@ -30,8 +35,8 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},value=${{ inputs.version || github.ref_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version || github.ref_name }}
             type=raw,value=latest
 
       - uses: docker/build-push-action@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.97-alpine AS builder
 RUN apk add --no-cache musl-dev cmake make perl
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock build.rs ./
 RUN mkdir src && echo 'fn main() {}' > src/main.rs && echo '' > src/lib.rs
 RUN cargo build --release 2>/dev/null || true
 RUN rm -rf src


### PR DESCRIPTION
The v0.23.0 Docker build failed: https://github.com/razvandimescu/numa/actions/runs/32392614792

```
error: environment variable `OUT_DIR` not defined at compile time  --> src/api.rs:17:18
error[E0425]: cannot find value `LOCALES` in this scope            --> src/api.rs:1164:5
```

The Dockerfile never copied `build.rs`. Harmless while the script only injected `NUMA_BUILD_VERSION` (`lib.rs:63` falls back to `CARGO_PKG_VERSION`), but #360 moved locale embedding into it, so `api.rs`'s `include!(concat!(env!("OUT_DIR"), "/locales.rs"))` has nothing to include without a build script.

Also adds `workflow_dispatch` to the Docker workflow so an image can be rebuilt without cutting a release — needed right now, since `v0.23.0` has no image and `latest` still points at 0.22.0. Retagging would work but re-fires `release.yml` too, which just burns an hour and fails on `cargo publish`.

Verified locally: `docker build` completes, `numa --version` reports 0.23.0, and the locale JSON is embedded in the binary.