### PR TITLE
fix(serve): handle SIGTERM and SIGINT so containers can stop numa

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod relay;
 pub mod serve;
 pub mod service_store;
 pub mod setup_phone;
+pub mod shutdown;
 pub mod srtt;
 pub mod stats;
 pub mod svcb;

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -80,7 +80,10 @@ pub async fn run(addr: SocketAddr) -> Result<()> {
     let app = build_app(RelayState::new());
     let listener = TcpListener::bind(addr).await?;
     info!("ODoH relay listening on {}", addr);
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(crate::shutdown::signal())
+        .await?;
+    info!("relay stopped");
     Ok(())
 }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -257,8 +257,13 @@ pub async fn run(config_path: String) -> crate::Result<()> {
             udp_serve_loop(&ctx, socket, pp.as_ref()).await
         }));
     }
-    let (first, _, _) = futures::future::select_all(handles).await;
-    first?
+    tokio::select! {
+        (first, _, _) = futures::future::select_all(handles) => first?,
+        () = crate::shutdown::signal() => {
+            info!("shutting down");
+            Ok(())
+        }
+    }
 }
 
 /// First port-53 bind failure routes through `try_port53_advisory` so the

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -1,0 +1,27 @@
+//! Termination signals. As PID 1 (containers) the kernel drops signals whose
+//! disposition is still the default, so an explicit handler is what makes
+//! `docker stop` and Ctrl-C work at all (issue #367).
+
+/// Resolves on SIGINT or SIGTERM (Ctrl-C only on Windows).
+pub async fn signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal as unix_signal, SignalKind};
+        let mut term = match unix_signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!("cannot listen for SIGTERM: {}", e);
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = term.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -187,6 +187,23 @@ CONF
         "0" \
         "$ERRORS"
 
+    echo ""
+    echo "=== Shutdown ==="
+
+    # SIGTERM must be handled, not merely the default disposition: as PID 1 in
+    # a container the kernel drops signals with a default handler (issue #367).
+    kill -TERM "$NUMA_PID" 2>/dev/null || true
+    SHUTDOWN_RC=""
+    for _ in 1 2 3 4 5; do
+        if ! kill -0 "$NUMA_PID" 2>/dev/null; then
+            SHUTDOWN_RC=0
+            wait "$NUMA_PID" 2>/dev/null || SHUTDOWN_RC=$?
+            break
+        fi
+        sleep 1
+    done
+    check "Exits cleanly on SIGTERM" "^0$" "${SHUTDOWN_RC:-timeout}"
+
     kill "$NUMA_PID" 2>/dev/null || true
     wait "$NUMA_PID" 2>/dev/null || true
     sleep 1


### PR DESCRIPTION
Closes #367.

numa installed no signal handlers at all. Outside a container that goes unnoticed — the default disposition terminates the process. As PID 1 the kernel drops signals whose disposition is still the default, so `docker run` + Ctrl-C and `docker stop` did nothing and the container had to be force-killed.

- `src/shutdown.rs`: one future that resolves on SIGINT or SIGTERM (Ctrl-C only on Windows).
- `serve.rs`: the UDP `select_all` now races that signal and returns `Ok(())`.
- `relay.rs`: same via axum's `with_graceful_shutdown`, so `numa relay` in a container stops too.
- `tests/integration.sh`: the shared teardown sends SIGTERM explicitly and asserts the process exits within 5s with status 0, instead of `kill; wait || true` swallowing it.

Fixing the binary rather than documenting `--init`, so existing `docker run` commands keep working.

Verified in a container, which is the case the issue is about. numa is PID 1 in both (exec-form ENTRYPOINT). On 44fb4d5 `docker stop -t 10` hangs the full timeout and the container is SIGKILLed (exit 137); on this branch it returns in under a second with exit 0, and `docker kill -s INT` exits 0 as well. `cargo test` 665 passed, `SUITES=1 tests/integration.sh` 19/19.
