### PR TITLE
Fix Linux path resolution

### DIFF
--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -75,6 +75,16 @@ pub(crate) fn service_config_path() -> Result<String, String> {
     effective_config_path().map(|resolved| resolved.display())
 }
 
+/// The config file a CLI write should land in: what the running daemon
+/// loaded, else the first candidate that exists, else where one would be
+/// created. The bare path, not the `display()` string carrying the note.
+pub fn config_write_target() -> Result<String, String> {
+    let resolved =
+        effective_config_path().map_err(|error| format!("cannot resolve config path: {error}"))?;
+    ensure_writable(Path::new(&resolved.path))?;
+    Ok(resolved.path)
+}
+
 fn effective_config_path() -> Result<EffectiveConfigPath, String> {
     let local = crate::config::load_config(&crate::cli_config_path());
     resolve_effective_config_path(local, query_daemon_config_path)
@@ -316,6 +326,20 @@ mod tests {
             "/local/numa.toml (daemon not reachable at 127.0.0.1:5380; resolved locally; \
              file does not exist yet, defaults apply)"
         );
+    }
+
+    #[test]
+    fn write_target_is_the_bare_path_not_the_note() {
+        let resolved =
+            resolve_effective_config_path(local_config("/local/numa.toml", 5380, false), |_| {
+                Err("daemon not reachable at 127.0.0.1:5380".to_string())
+            })
+            .unwrap();
+
+        // `display()` is for humans; writing to it would create a file
+        // literally named "... (file does not exist yet, defaults apply)".
+        assert_eq!(resolved.path, "/local/numa.toml");
+        assert_ne!(resolved.path, resolved.display());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ pub fn cli_config_path() -> String {
     }
     #[cfg(not(windows))]
     {
-        "numa.toml".to_string()
+        data_dir().join("numa.toml").to_string_lossy().into_owned()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,10 +155,10 @@ fn config_dir_unix() -> std::path::PathBuf {
     daemon_data_dir()
 }
 
-/// Default config path for CLI toggles (`numa lan on`, etc.) and the
-/// Windows service entry. On Windows this matches the SCM's data dir
-/// so toggles update the file the service reads (issue #202). Unix
-/// callers still use the CWD-relative literal `"numa.toml"`.
+/// Seed path for `load_config`, and the Windows service entry, which reads
+/// the data dir the SCM writes (issue #202). The Unix arm must stay
+/// CWD-relative: `load_config` only widens its candidate list for a
+/// relative path. CLI writes go through `config_cli::config_write_target()`.
 pub fn cli_config_path() -> String {
     #[cfg(windows)]
     {
@@ -166,7 +166,7 @@ pub fn cli_config_path() -> String {
     }
     #[cfg(not(windows))]
     {
-        data_dir().join("numa.toml").to_string_lossy().into_owned()
+        "numa.toml".to_string()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,9 +110,6 @@ fn main() -> numa::Result<()> {
         }
         "lan" | "block" | "dnssec" => {
             let sub = std::env::args().nth(2).unwrap_or_default();
-            let config_path = std::env::args()
-                .nth(3)
-                .unwrap_or_else(numa::cli_config_path);
             let enabled = match sub.as_str() {
                 "on" => true,
                 "off" => false,
@@ -120,6 +117,12 @@ fn main() -> numa::Result<()> {
                     eprintln!("Usage: numa {} <on|off> [config-path]", arg1);
                     return Ok(());
                 }
+            };
+            // The daemon knows which file it loaded; a cwd-relative guess
+            // writes a config nothing reads under systemd or launchd (#371).
+            let config_path = match std::env::args().nth(3) {
+                Some(explicit) => explicit,
+                None => numa::config_cli::config_write_target()?,
             };
             let (section, feature_name) = match arg1.as_str() {
                 "lan" => ("lan", "LAN discovery"),


### PR DESCRIPTION
The Linux path resolution for the CLI toggles of DNSSEC was broken. It resolves to "numa.toml" instead of "/var/lib/private/numa/numa.toml". This fixes that resolution.
