### PR TITLE
fix(bench): use real key material in dnssec verify benches

### DIFF
--- a/benches/dnssec.rs
+++ b/benches/dnssec.rs
@@ -1,4 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ring::rand::SystemRandom;
+use ring::signature::{EcdsaKeyPair, Ed25519KeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 
 use numa::dnssec;
 use numa::question::QueryType;
@@ -18,10 +20,6 @@ fn make_rsa_key() -> Vec<u8> {
     key.extend(&[0x01, 0x00, 0x01]); // exponent = 65537
     key.extend(vec![0xFF; 256]); // modulus (256 bytes = 2048 bits)
     key
-}
-
-fn make_ed25519_key() -> Vec<u8> {
-    vec![0xEF; 32]
 }
 
 fn make_dnskey(algorithm: u8, public_key: Vec<u8>) -> DnsRecord {
@@ -101,13 +99,57 @@ fn bench_build_signed_data(c: &mut Criterion) {
     });
 }
 
-fn bench_verify_signature(c: &mut Criterion) {
-    // These will fail verification (keys/sigs are random), but we measure the
-    // crypto overhead — ring still does the full algorithm before returning error.
-    let data = vec![0u8; 128]; // typical signed data size
+/// Throwaway RSA-2048 public key and a PKCS#1 v1.5 SHA-256 signature over the
+/// 128 zero bytes the verify benches sign. Ring cannot generate RSA keys, so
+/// this pair is fixed; the EC algorithms mint a fresh key per run instead.
+const RSA_MODULUS_HEX: &str = "a03ab6f62e05b7403092c526e11c879855208882e9b6911a12125c8d225039f54eb6007d8b08ab026c76ac9f8872b0cac48c6063f09a37571f824dc96949c0b5f4c2a46dcbc0d4f509fbf8d5902266f815172ca3788643d190c223dfa8bc3a4e4ae4c1dd7f34d9bfcc157b3139461f0fb0faf90c16dad80d5fb4e18ed7a0bbafce31b2d954b83b86b03f1a40ebef905e7602b6e1d3380e364e0725685a73a284f960cd86766fb64fdc79648bbfcf3ad489b163ba9ba0b6e91f4437a1e864a2e012ae8d2970ba4c12b13dca82f89955fad4b4739cf50d47202a458c0497c97abad4459c043219b186447cef1785accc874ed94cbc3ce3e89d27226adcc60c3257";
+const RSA_SIG_HEX: &str = "238ac20f4cfd8abf07d29cce55abd23534d30d627e6e3342a613f3618ad5d178db6b512e4b19343ff422b04c7302e7d27880a073cdf50e2294aaede8d4ad07df8163f417b9072615776ef8e44df2270f1e722951b58b2392070842c705b1f8a5ed3670753fa3de62449d3d1a79b3e5a293597abea5eefa053d9117005d47da6ffc4142891e02debfafadef3097baa0ffe1333664dd12f4c6338e3ec572f813f85a59d9034d51518b8e003924c94e2f3e738b119027844449230c0052ff8be8f2cc3e1a9eacde1966d6838b46f91228426a4e3c0014c7ef01ee2afbd3f95ae707babe0c6f3ac0d8151cfb9e4f53ada1b56ab5f772b44611c56fd9fdc07c9ea8dc";
 
-    let rsa_key = make_rsa_key();
-    let rsa_sig = vec![0xAA; 256]; // RSA-2048 signature
+fn unhex(s: &str) -> Vec<u8> {
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+        .collect()
+}
+
+fn real_rsa_key() -> Vec<u8> {
+    let mut key = vec![3u8];
+    key.extend(&[0x01, 0x00, 0x01]);
+    key.extend(unhex(RSA_MODULUS_HEX));
+    key
+}
+
+fn bench_verify_signature(c: &mut Criterion) {
+    // Key material must be valid or the EC paths are rejected at point decode
+    // and the numbers measure parsing, not crypto.
+    let data = vec![0u8; 128];
+    let rng = SystemRandom::new();
+
+    let rsa_key = real_rsa_key();
+    let rsa_sig = unhex(RSA_SIG_HEX);
+
+    let ec_pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng).unwrap();
+    let ec = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, ec_pkcs8.as_ref(), &rng)
+        .unwrap();
+    let ecdsa_key = ec.public_key().as_ref()[1..].to_vec();
+    let ecdsa_sig = ec.sign(&rng, &data).unwrap().as_ref().to_vec();
+
+    let ed_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+    let ed = Ed25519KeyPair::from_pkcs8(ed_pkcs8.as_ref()).unwrap();
+    let ed_key = ed.public_key().as_ref().to_vec();
+    let ed_sig = ed.sign(&data).as_ref().to_vec();
+
+    for (algorithm, key, sig, name) in [
+        (8u8, &rsa_key, &rsa_sig, "rsa_sha256_2048"),
+        (13, &ecdsa_key, &ecdsa_sig, "ecdsa_p256"),
+        (15, &ed_key, &ed_sig, "ed25519"),
+    ] {
+        assert!(
+            dnssec::verify_signature(algorithm, key, &data, sig),
+            "{name} vector must verify, else the bench times the reject path"
+        );
+    }
+
     c.bench_function("verify_rsa_sha256_2048", |b| {
         b.iter(|| {
             dnssec::verify_signature(
@@ -119,8 +161,6 @@ fn bench_verify_signature(c: &mut Criterion) {
         })
     });
 
-    let ecdsa_key = make_ecdsa_key();
-    let ecdsa_sig = make_ecdsa_sig();
     c.bench_function("verify_ecdsa_p256", |b| {
         b.iter(|| {
             dnssec::verify_signature(
@@ -132,8 +172,6 @@ fn bench_verify_signature(c: &mut Criterion) {
         })
     });
 
-    let ed_key = make_ed25519_key();
-    let ed_sig = vec![0xBB; 64];
     c.bench_function("verify_ed25519", |b| {
         b.iter(|| {
             dnssec::verify_signature(


### PR DESCRIPTION
the verify benches fed synthetic keys (`vec![0xAB; 64]`, `vec![0xEF; 32]`) with a
comment saying ring runs the full algorithm before returning an error. it doesn't.
the EC paths bail at point decode, so two of the three numbers were timing the
reject path rather than verification.

| bench | before | after |
|---|---|---|
| `verify_rsa_sha256_2048` | 10.24 µs | 10.25 µs |
| `verify_ecdsa_p256` | 137 ns | 26.15 µs |
| `verify_ed25519` | 3.55 ns | 18.12 µs |

RSA is unchanged. it was the one algorithm always doing real work, since
`0xFF...` is a valid modulus and the modexp runs regardless.

this inverted the ranking. RSA-2048 verify is the cheapest of the three, not the
most expensive, and algo 13 costs 2.5x RSA rather than being 74x faster than it.
algo 13 is where signed zones are heading, so it's the number worth having right.

for scale, `round_trip_cached` in hot_path is 726 ns, so one ECDSA verify is ~36
cached round trips. signature verification is by a wide margin the most expensive
cpu operation in the resolver and the old numbers hid that.

EC keys are minted per run. ring can't generate RSA, so that vector is fixed
(throwaway key, only the public modulus and a signature are in the tree). setup
asserts all three verify, which is what keeps this from silently regressing.

found while looking at what forward-path DNSSEC validation would cost. no
production code changed, so hot_path and throughput are unaffected.

not touched: `bench_key_tag` and `bench_ds_verification` still use the synthetic
`0xFF` modulus. they only hash bytes so the numbers are honest, but they'd be
more representative over the real root KSK.
