### PR TITLE
test(relay): cover a real forward end to end

### DIFF
--- a/src/relay.rs
+++ b/src/relay.rs
@@ -342,4 +342,40 @@ mod tests {
         assert!(!is_valid_hostname("evil.com/../admin"));
         assert!(!is_valid_hostname(&"a".repeat(254)));
     }
+
+    /// The only test that completes a forward: every other relay test asserts
+    /// a rejection, and `forwarded_ok` is checked only as zero. Sealing the
+    /// query needs numa's own HPKE code, so this cannot be a shell probe like
+    /// the other live-network checks.
+    #[tokio::test]
+    #[ignore = "network"]
+    async fn seals_forwards_and_unseals_against_a_real_target() {
+        let (addr, state) = spawn_relay().await;
+        let client = crate::forward::build_https_client();
+        let cache = crate::odoh::OdohConfigCache::new("odoh.crypto.sx".to_string(), client.clone());
+
+        let mut buf = crate::buffer::BytePacketBuffer::new();
+        crate::packet::DnsPacket::query(0xABCD, "example.com", crate::question::QueryType::A)
+            .write(&mut buf)
+            .unwrap();
+
+        let wire = crate::odoh::query_through_relay(
+            buf.filled(),
+            &format!("http://{}/relay", addr),
+            "/dns-query",
+            &client,
+            &cache,
+            Duration::from_secs(20),
+        )
+        .await
+        .expect("ODoH query through the local relay");
+
+        let mut parse = crate::buffer::BytePacketBuffer::from_bytes(&wire);
+        let resp = crate::packet::DnsPacket::from_buffer(&mut parse).unwrap();
+        assert!(
+            !resp.answers.is_empty(),
+            "expected an answer for example.com"
+        );
+        assert_eq!(state.forwarded_ok.load(Ordering::Relaxed), 1);
+    }
 }


### PR DESCRIPTION
## Summary

`forwarded_ok` appears in one assertion in the whole suite, and it asserts zero. Every relay test drives a rejection: bad content type, oversized body, bad targethost, bad targetpath. Nothing ever made the relay reach a target, so the successful path through `handle_relay` → `forward_to_target` had no coverage at all.

This adds one test that seals a query with numa's own HPKE code, POSTs it to a relay spawned in-process, and unseals the answer that comes back from a real ODoH target.

It cannot be a shell probe like `tests/network-probe.sh` or `tests/probe-odoh-ecosystem.sh`, because sealing the query requires the crypto in `odoh.rs`. `#[ignore = "network"]` keeps it out of CI, matching the blocklist format probe in `blocklist.rs`.

Independent of #369 — it exercises `query_through_relay` and `spawn_relay`, both of which predate that branch. The gap is older than the PR that surfaced it.

## Test plan

- `cargo test --lib relay:: -- --ignored` passes against `odoh.crypto.sx`: NOERROR, two A records for example.com, relay counters `total=1 forwarded_ok=1 forwarded_err=0`
- `cargo test --lib` unchanged, 670 passing with 2 ignored
- `cargo fmt --check` clean, `cargo clippy --lib --tests` clean for `relay.rs`