### PR TITLE
test(svcb): pin ech SvcParam delivery through the rewrite paths

### DIFF
--- a/src/doh.rs
+++ b/src/doh.rs
@@ -300,6 +300,10 @@ mod tests {
 
     async fn doh_get_response(query: &str) -> Response {
         let ctx = std::sync::Arc::new(crate::testutil::test_ctx().await);
+        doh_get_response_with(query, ctx).await
+    }
+
+    async fn doh_get_response_with(query: &str, ctx: std::sync::Arc<ServerCtx>) -> Response {
         let state = crate::proxy::DohState {
             ctx,
             remote_addr: Some("127.0.0.1:1234".parse().unwrap()),
@@ -349,5 +353,69 @@ mod tests {
         let mut parse = BytePacketBuffer::from_bytes(&body);
         let parsed = DnsPacket::from_buffer(&mut parse).unwrap();
         assert_eq!(parsed.header.rescode, ResultCode::SERVFAIL);
+    }
+
+    /// The byte a browser using Numa-as-DoH actually consumes: an HTTPS RR
+    /// carrying an `ech` SvcParam must leave the DoH endpoint byte-identical,
+    /// including when `filter_aaaa` rewrites the record's ipv6hint.
+    #[tokio::test]
+    async fn doh_serves_https_rr_with_ech_intact() {
+        use crate::question::QueryType;
+        use crate::svcb::{alpn_h3, build_rdata, ech_config_list, ipv6hint_single, ECH_KEY};
+
+        let params = [alpn_h3(), (ECH_KEY, ech_config_list()), ipv6hint_single()];
+        let rdata = build_rdata(1, &["ech", "test"], &params);
+        let filtered = build_rdata(1, &["ech", "test"], &params[..2]);
+
+        let mut cached = DnsPacket::query(0, "ech.test", QueryType::HTTPS);
+        cached.header.response = true;
+        cached.header.rescode = ResultCode::NOERROR;
+        cached.answers.push(DnsRecord::UNKNOWN {
+            domain: "ech.test".to_string(),
+            qtype: QueryType::HTTPS.to_num(),
+            data: rdata.clone(),
+            ttl: 300,
+        });
+
+        let mut buf = BytePacketBuffer::new();
+        DnsPacket::query(0x2222, "ech.test", QueryType::HTTPS)
+            .write(&mut buf)
+            .unwrap();
+        let param = URL_SAFE_NO_PAD.encode(buf.filled());
+
+        for filter_aaaa in [false, true] {
+            let mut ctx = crate::testutil::test_ctx().await;
+            ctx.filter_aaaa = filter_aaaa;
+            ctx.cache
+                .write()
+                .unwrap()
+                .insert("ech.test", QueryType::HTTPS, &cached);
+
+            let resp =
+                doh_get_response_with(&format!("dns={param}"), std::sync::Arc::new(ctx)).await;
+            assert_eq!(resp.status(), StatusCode::OK, "filter_aaaa={filter_aaaa}");
+
+            let body = axum::body::to_bytes(resp.into_body(), MAX_DNS_MSG)
+                .await
+                .unwrap();
+            let mut parse = BytePacketBuffer::from_bytes(&body);
+            let parsed = DnsPacket::from_buffer(&mut parse).unwrap();
+
+            assert_eq!(parsed.answers.len(), 1, "filter_aaaa={filter_aaaa}");
+            match &parsed.answers[0] {
+                DnsRecord::UNKNOWN { qtype, data, .. } => {
+                    assert_eq!(
+                        *qtype,
+                        QueryType::HTTPS.to_num(),
+                        "type 65 must not be downgraded"
+                    );
+                    // Whole-RDATA equality: proves the ech bytes are intact
+                    // *and* that filter_aaaa removed exactly the ipv6hint.
+                    let want = if filter_aaaa { &filtered } else { &rdata };
+                    assert_eq!(data, want, "filter_aaaa={filter_aaaa}");
+                }
+                other => panic!("expected UNKNOWN HTTPS record, got {other:?}"),
+            }
+        }
     }
 }

--- a/src/svcb.rs
+++ b/src/svcb.rs
@@ -186,27 +186,59 @@ pub(crate) fn build_rdata(priority: u16, target: &[&str], params: &[(u16, Vec<u8
     out
 }
 
+/// SvcParamKey = 5 (RFC 9460 §14.3.2, draft-ietf-tls-esni): `ech`.
+#[cfg(test)]
+pub(crate) const ECH_KEY: u16 = 5;
+
+#[cfg(test)]
+pub(crate) fn alpn_h3() -> (u16, Vec<u8>) {
+    // alpn = ["h3"]: one length-prefixed ALPN id
+    (1, vec![0x02, b'h', b'3'])
+}
+
+#[cfg(test)]
+pub(crate) fn ipv6hint_single() -> (u16, Vec<u8>) {
+    // 2606:4700::1
+    (
+        IPV6_HINT_KEY,
+        vec![
+            0x26, 0x06, 0x47, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01,
+        ],
+    )
+}
+
+/// A realistic ECHConfigList (draft-ietf-tls-esni §4): version 0xfe0d, X25519
+/// key config, `public_name` = "cloudflare-ech.com". Opaque to this module —
+/// the point is that these bytes survive an edit untouched.
+#[cfg(test)]
+pub(crate) fn ech_config_list() -> Vec<u8> {
+    let mut contents = vec![0x2a]; // config_id
+    contents.extend_from_slice(&0x0020u16.to_be_bytes()); // DHKEM(X25519, HKDF-SHA256)
+    contents.extend_from_slice(&32u16.to_be_bytes());
+    contents.extend_from_slice(&[0xab; 32]); // public_key
+    contents.extend_from_slice(&4u16.to_be_bytes());
+    contents.extend_from_slice(&[0x00, 0x01, 0x00, 0x01]); // HKDF-SHA256 / AES-128-GCM
+    contents.push(0); // maximum_name_length
+    let public_name = b"cloudflare-ech.com";
+    contents.push(public_name.len() as u8);
+    contents.extend_from_slice(public_name);
+    contents.extend_from_slice(&0u16.to_be_bytes()); // extensions
+
+    let mut config = 0xfe0du16.to_be_bytes().to_vec();
+    config.extend_from_slice(&(contents.len() as u16).to_be_bytes());
+    config.extend_from_slice(&contents);
+
+    let mut list = (config.len() as u16).to_be_bytes().to_vec();
+    list.extend_from_slice(&config);
+    list
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn alpn_h3() -> (u16, Vec<u8>) {
-        // alpn = ["h3"]: one length-prefixed ALPN id
-        (1, vec![0x02, b'h', b'3'])
-    }
-
     fn ipv4hint_single() -> (u16, Vec<u8>) {
         (4, vec![93, 184, 216, 34])
-    }
-
-    fn ipv6hint_single() -> (u16, Vec<u8>) {
-        // 2606:4700::1
-        (
-            6,
-            vec![
-                0x26, 0x06, 0x47, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01,
-            ],
-        )
     }
 
     #[test]
@@ -321,5 +353,44 @@ mod tests {
         // ipv4hint value length 5 is not a multiple of 4.
         let rdata = build_rdata(1, &[], &[(4, vec![1, 2, 3, 4, 5])]);
         assert!(strip_private_hints(&rdata, is_priv).is_none());
+    }
+
+    /// Params in ascending key order, as RFC 9460 §2.2 requires.
+    fn sorted_rdata(params: &[(u16, Vec<u8>)]) -> Vec<u8> {
+        let mut p = params.to_vec();
+        p.sort_by_key(|(k, _)| *k);
+        build_rdata(1, &[], &p)
+    }
+
+    #[test]
+    fn opaque_params_survive_hint_edits() {
+        // `edit_svcparams` copies every non-hint param verbatim, so key 5
+        // (`ech`) is in no way special. The TLV-framing case proves params
+        // are walked by framing rather than scanned for.
+        for (label, key, value) in [
+            ("low key", 0u16, vec![0xde, 0xad]),
+            (
+                "ech mimicking an ipv6hint TLV header",
+                ECH_KEY,
+                vec![0x00, 0x06, 0x00, 0x10, 0xfe, 0x0d],
+            ),
+            ("realistic ECHConfigList", ECH_KEY, ech_config_list()),
+            ("private-use key", 65280, vec![0x01]),
+        ] {
+            let param = (key, value);
+            let with_v6 = sorted_rdata(&[param.clone(), ipv6hint_single()]);
+            assert_eq!(
+                strip_ipv6hint(&with_v6).expect("ipv6hint present → stripped"),
+                sorted_rdata(std::slice::from_ref(&param)),
+                "{label} must survive strip_ipv6hint byte-identical"
+            );
+
+            let with_priv = sorted_rdata(&[ipv4hint(&[PUB4, PRIV4]), param.clone()]);
+            assert_eq!(
+                strip_private_hints(&with_priv, is_priv).expect("private hint → rewritten"),
+                sorted_rdata(&[ipv4hint(&[PUB4]), param]),
+                "{label} must survive strip_private_hints byte-identical"
+            );
+        }
     }
 }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -971,6 +971,36 @@ check "AAAA returns real answers with filter off" \
     ":" \
     "$($DIG google.com AAAA +short | head -1)"
 
+# --- HTTPS RR (type 65) clean delivery ---
+# ECH configs make HTTPS RRs large, and a record dropped at the 512-byte UDP
+# boundary reads to a browser as "this site publishes no ECH". Query as
+# `type65`: dig 9.10.6 on macOS misparses `HTTPS` as a domain name.
+ech_marker() {
+    # dig 9.18 pretty-prints `ech=<base64>`; 9.10.6 emits RFC 3597 hex,
+    # where the ECHConfigList version 0xfe0d is the stable marker.
+    if echo "$1" | tr -d ' \t\n' | grep -qiE 'ech=|fe0d'; then
+        echo present
+    else
+        echo absent
+    fi
+}
+
+ECH_HOST="crypto.cloudflare.com"
+
+if [ "$(ech_marker "$($DIG $ECH_HOST type65 2>&1 || true)")" = "present" ]; then
+    check "HTTPS RR: ech SvcParam delivered over TCP" \
+        "present" \
+        "$(ech_marker "$($DIG $ECH_HOST type65 +tcp 2>&1 || true)")"
+
+    # 512 is the floor Numa clamps to. dig retries over TCP if the answer
+    # comes back truncated, so this covers both the fits and TC=1 cases.
+    check "HTTPS RR: ech survives a 512-byte client buffer" \
+        "present" \
+        "$(ech_marker "$($DIG $ECH_HOST type65 +bufsize=512 2>&1 || true)")"
+else
+    printf "  ${DIM}~ HTTPS RR ech delivery (skipped: no ech SvcParam from upstream)${RESET}\n"
+fi
+
 kill "$NUMA_PID" 2>/dev/null || true
 wait "$NUMA_PID" 2>/dev/null || true
 sleep 1


### PR DESCRIPTION
A resolver that strips or corrupts type 65 silently breaks ECH for every browser already capable of it, and the failure reads to the user as "this site publishes no ECH" rather than as a resolver bug. Caddy 2.10 supplies the ECHConfig; the delivery channel is ours.

No bug here to fix. edit_svcparams copies kept params as a raw byte range instead of re-serializing them, so ech cannot be corrupted by construction, and both rewrite paths are off by default. These land as pins on that property, not as a fix.

Covers the two places HTTPS RDATA is rewritten — strip_ipv6hint via filter_aaaa, strip_private_hints via the rebind filter — with whole-RDATA equality, so a test fails if the ech bytes shift or if a strip removes anything but the hint it targets. One case gives ech a value whose first bytes mimic an ipv6hint TLV header, which passes only if params are walked by framing rather than scanned for.

Adds the byte a browser actually consumes: an end-to-end assertion that the DoH endpoint serves an HTTPS RR with ech intact, under filter_aaaa both off and on. Test helpers move out of svcb's tests module so doh can share them.

The integration check queries crypto.cloudflare.com as type65 — dig 9.10.6 on macOS misparses HTTPS as a domain name — and skips when upstream returns no ech, so it cannot fail on someone else's outage.