### PR TITLE
fix(install): name the process holding port 53 (#299)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Set as system DNS:
 | Linux | `sudo numa install` | `sudo numa uninstall` |
 | Windows | `numa install` (admin) + reboot | `numa uninstall` (admin) + reboot |
 
+Already running dnsmasq, unbound, or Pi-hole? Port 53 has to be freed first — see [recipes/port-53.md](recipes/port-53.md). systemd-resolved is the exception: `numa install` handles it for you.
+
 On macOS and Linux, numa runs as a system service (launchd/systemd). On Windows, numa auto-starts on login via registry. Windows also binds `127.0.0.2:53` (the built-in Dnscache owns `127.0.0.1:53`) and installs an NRPT rule to route queries to it — so edit `bind_addr`/`api_bind_addr` against `127.0.0.2`, not `127.0.0.1`.
 
 ## Local Services

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -8,6 +8,10 @@ Scenario-driven configs for common Numa deployments. Each recipe is self-contain
 - [dnsdist in front of Numa](dnsdist-front.md) — terminate public TLS externally, keep Numa on loopback.
 - [ODoH upstream with bootstrap pinning](odoh-upstream.md) — oblivious DNS client mode without leaking the relay/target hostnames.
 
+## System integration
+
+- [Freeing port 53](port-53.md) — take the port back from dnsmasq, unbound, named, or Pi-hole, including dnsmasq under NetworkManager.
+
 ## Local network
 
 - [Local DNS records and split DNS](local-dns-records.md) — name your LAN hosts on any domain, answer reverse lookups, hand an internal zone to another resolver.

--- a/recipes/port-53.md
+++ b/recipes/port-53.md
@@ -1,0 +1,86 @@
+# Freeing port 53
+
+Numa binds `0.0.0.0:53` to be the system resolver. On most Linux desktops something already owns that port, and Numa will not stop or reconfigure another resolver for you. This recipe covers the common holders.
+
+Find out which one you have:
+
+```bash
+sudo ss -lnup 'sport = :53'     # Linux
+sudo lsof -nP -iUDP:53          # macOS
+```
+
+Numa names the holder itself when it fails to bind, including the systemd unit that started it.
+
+## systemd-resolved
+
+The only case Numa handles for you. `sudo numa install` writes `/etc/systemd/resolved.conf.d/numa.conf` with `DNSStubListener=no`, restarts resolved, and takes the port. Nothing to do here.
+
+## dnsmasq, standalone
+
+```bash
+sudo systemctl disable --now dnsmasq.service
+sudo numa install
+```
+
+## dnsmasq, started by NetworkManager
+
+The case in [issue #299](https://github.com/razvandimescu/numa/issues/299). `systemctl disable dnsmasq` does not help and neither does killing the process: NetworkManager runs its own dnsmasq instance and restarts it. Turn off NetworkManager's DNS cache instead.
+
+Check whether this is your setup:
+
+```bash
+grep -r '^dns=' /etc/NetworkManager/    # dns=dnsmasq means NetworkManager owns it
+```
+
+Then:
+
+```bash
+sudo tee /etc/NetworkManager/conf.d/00-numa.conf >/dev/null <<'EOF'
+[main]
+dns=none
+EOF
+
+sudo systemctl restart NetworkManager
+sudo numa install
+```
+
+`dns=none` stops NetworkManager from spawning dnsmasq and from managing `/etc/resolv.conf`, leaving `numa install` free to point it at 127.0.0.1. To keep NetworkManager in charge of resolv.conf instead, use `dns=default` and pin the connection's DNS so DHCP does not overwrite it:
+
+```bash
+nmcli con mod "<connection>" ipv4.dns 127.0.0.1 ipv4.ignore-auto-dns yes
+```
+
+To undo: `sudo rm /etc/NetworkManager/conf.d/00-numa.conf && sudo systemctl restart NetworkManager`.
+
+## unbound, named, pihole-FTL
+
+Same shape as standalone dnsmasq. Stop the service, then install:
+
+```bash
+sudo systemctl disable --now unbound.service     # or named.service, pihole-FTL.service
+sudo numa install
+```
+
+Pi-hole is worth a moment's thought before you disable it: Numa's `[blocking]` section covers the same ground, so this is a replacement rather than a coexistence.
+
+## Running alongside, without taking port 53
+
+For testing, or when the existing resolver has to stay, put Numa on a spare port:
+
+```bash
+numa config edit    # [server] bind_addr = "127.0.0.1:5354"
+numa
+dig @127.0.0.1 -p 5354 example.com
+```
+
+Nothing else on the machine will use it until you point clients at that address, and `numa install` is not involved.
+
+## Verifying
+
+```bash
+sudo numa install
+numa service status     # active (running), not activating (auto-restart) or failed
+dig @127.0.0.1 example.com
+```
+
+If `numa service status` shows the service restarting in a loop, port 53 is still held. `journalctl -u numa -n 20` prints the same advisory with the holder named.

--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -92,22 +92,75 @@ pub fn discover_system_dns() -> SystemDnsInfo {
     }
 }
 
+const PORT53_RECIPE_URL: &str =
+    "https://github.com/razvandimescu/numa/blob/main/recipes/port-53.md";
+
+#[cfg(target_os = "linux")]
+const WHO_OWNS_53: &str = "sudo ss -lnup 'sport = :53'";
+#[cfg(windows)]
+const WHO_OWNS_53: &str = "netstat -ano -p UDP | findstr :53";
+#[cfg(not(any(target_os = "linux", windows)))]
+const WHO_OWNS_53: &str = "sudo lsof -nP -iUDP:53";
+
+#[cfg(windows)]
+const ELEVATE: &str = "  Port 53 is privileged. Run numa from an Administrator prompt.";
+#[cfg(not(windows))]
+const ELEVATE: &str = "  Port 53 is privileged. Run:\n\n    sudo numa";
+
+const SPARE_PORT: &str = "\n  Just testing? Run numa alongside it on a spare port:\n\n    \
+     numa config edit    # [server] bind_addr = \"127.0.0.1:5354\"\n    numa\n    \
+     dig @127.0.0.1 -p 5354 example.com\n";
+
+/// Process holding port 53, as far as procfs can tell.
+pub struct Port53Holder {
+    pub comm: String,
+    pub pid: u32,
+    /// systemd unit owning the process cgroup: either the holder's own unit
+    /// (`dnsmasq.service`) or a supervisor that spawned it
+    /// (`NetworkManager.service`), which is why `owned_unit` re-checks.
+    pub unit: Option<String>,
+}
+
+impl Port53Holder {
+    fn is_systemd_resolved(&self) -> bool {
+        // /proc/<pid>/comm truncates at 15 bytes: "systemd-resolve".
+        self.comm.starts_with("systemd-resolve")
+    }
+
+    /// The unit only when the holder *is* that unit. Telling someone to
+    /// disable the supervisor that spawned it is worse advice than none.
+    fn owned_unit(&self) -> Option<&str> {
+        let unit = self.unit.as_deref()?;
+        (unit.strip_suffix(".service")? == self.comm).then_some(unit)
+    }
+}
+
 /// Advisory for port-53 bind failures (EADDRINUSE or EACCES); `None`
 /// if not applicable so the caller can fall back to the raw error.
 pub fn try_port53_advisory(bind_addr: &str, err: &std::io::Error) -> Option<String> {
     if !is_port_53(bind_addr) {
         return None;
     }
-    let (title, cause) = match err.kind() {
-        std::io::ErrorKind::AddrInUse => (
-            "port 53 is already in use",
-            "Another process is already bound to port 53. On Linux this is\n  \
-             typically systemd-resolved; on Windows, the DNS Client service.",
-        ),
+    let holder = match err.kind() {
+        std::io::ErrorKind::AddrInUse => port53_holder(),
+        _ => None,
+    };
+    port53_advisory(bind_addr, err.kind(), holder.as_ref())
+}
+
+fn port53_advisory(
+    bind_addr: &str,
+    kind: std::io::ErrorKind,
+    holder: Option<&Port53Holder>,
+) -> Option<String> {
+    let (title, body) = match kind {
+        std::io::ErrorKind::AddrInUse => (in_use_title(holder), in_use_body(holder)),
         std::io::ErrorKind::PermissionDenied => (
-            "permission denied",
-            "Port 53 is privileged — binding it requires root on Linux/macOS\n  \
-             or Administrator on Windows.",
+            "permission denied".to_string(),
+            format!(
+                "{ELEVATE}\n\n  Or run unprivileged on a spare port:\n\n    \
+                 numa config edit    # [server] bind_addr = \"127.0.0.1:5354\"\n"
+            ),
         ),
         _ => return None,
     };
@@ -115,30 +168,141 @@ pub fn try_port53_advisory(bind_addr: &str, err: &std::io::Error) -> Option<Stri
     let o = palette.brand_bold;
     let r = palette.reset;
     Some(format!(
-        "
-{o}Numa{r} — cannot bind to {bind_addr}: {title}.
-
-  {cause}
-
-  Fix — pick one:
-
-    1. Install Numa as the system resolver (frees port 53):
-
-         sudo numa install       (on Windows, run as Administrator)
-
-    2. Run on a non-privileged port for testing.
-       Create {} with:
-
-         [server]
-         bind_addr = \"127.0.0.1:5354\"
-         api_port  = 5380
-
-       Then run:  numa
-       Test with: dig @127.0.0.1 -p 5354 example.com
-
-",
-        crate::suggested_config_path().display()
+        "\n{o}Numa{r} — cannot bind to {bind_addr}: {title}.\n\n{body}\n"
     ))
+}
+
+fn in_use_title(holder: Option<&Port53Holder>) -> String {
+    let Some(holder) = holder else {
+        return "port 53 is already in use".to_string();
+    };
+    let held = format!("port 53 is held by {} (pid {})", holder.comm, holder.pid);
+    match holder.unit.as_deref() {
+        Some(unit) if holder.owned_unit().is_none() => format!("{held},\nstarted by {unit}"),
+        _ => held,
+    }
+}
+
+fn in_use_body(holder: Option<&Port53Holder>) -> String {
+    let Some(holder) = holder else {
+        return format!(
+            "  Another resolver already owns it. Find out which:\n\n    {WHO_OWNS_53}\n\n  \
+             If it is systemd-resolved, sudo numa install frees it. Anything else\n  \
+             (dnsmasq, unbound, named, pihole-FTL) has to be stopped first. Numa\n  \
+             will not reconfigure it for you.\n\n    {PORT53_RECIPE_URL}\n"
+        );
+    };
+    if holder.is_systemd_resolved() {
+        // install writes DNSStubListener=no, so this is the one numa can free.
+        return "  Numa can free it. Install as the system resolver:\n\n    sudo numa install\n"
+            .to_string();
+    }
+    let remedy = match (holder.owned_unit(), holder.unit.as_deref()) {
+        (Some(unit), _) => format!(
+            "  Numa needs port 53 to be the system resolver, and will not stop or\n  \
+             reconfigure another resolver for you. Free the port first:\n\n    \
+             sudo systemctl disable --now {unit}\n    sudo numa install\n"
+        ),
+        (None, Some(unit)) => format!(
+            "  Killing {} will not free the port. {unit} restarts it. Stop that\n  \
+             service, or tell it not to run a DNS cache:\n\n    {PORT53_RECIPE_URL}\n",
+            holder.comm
+        ),
+        (None, None) => format!(
+            "  Numa needs port 53 to be the system resolver, and will not stop or\n  \
+             reconfigure another resolver for you. Stop {} first:\n\n    {PORT53_RECIPE_URL}\n",
+            holder.comm
+        ),
+    };
+    format!("{remedy}{SPARE_PORT}")
+}
+
+/// Identify the process on port 53. Reading other users' fds needs root, which
+/// holds on the paths that print advisories (`sudo numa`, `numa install`); the
+/// unprivileged daemon gets `None` and the generic text.
+#[cfg(target_os = "linux")]
+pub fn port53_holder() -> Option<Port53Holder> {
+    let mut inodes = std::collections::HashSet::new();
+    for path in ["/proc/net/udp", "/proc/net/udp6"] {
+        if let Ok(text) = std::fs::read_to_string(path) {
+            inodes.extend(udp_port_inodes(&text, 53));
+        }
+    }
+    if inodes.is_empty() {
+        return None;
+    }
+    let pid = pid_owning_socket(&inodes)?;
+    let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
+    Some(Port53Holder {
+        comm: comm.trim().to_string(),
+        pid,
+        unit: std::fs::read_to_string(format!("/proc/{pid}/cgroup"))
+            .ok()
+            .and_then(|cgroup| systemd_unit_from_cgroup(&cgroup)),
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn port53_holder() -> Option<Port53Holder> {
+    None
+}
+
+/// Socket inodes bound to `port`, from `/proc/net/udp{,6}`: field 1 is
+/// `<hex addr>:<hex port>`, field 9 the inode.
+#[cfg(any(target_os = "linux", test))]
+fn udp_port_inodes(proc_net_udp: &str, port: u16) -> std::collections::HashSet<u64> {
+    proc_net_udp
+        .lines()
+        .skip(1)
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            let local = fields.nth(1)?;
+            if u16::from_str_radix(local.rsplit(':').next()?, 16).ok()? != port {
+                return None;
+            }
+            fields.nth(7)?.parse().ok()
+        })
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn pid_owning_socket(inodes: &std::collections::HashSet<u64>) -> Option<u32> {
+    let targets: std::collections::HashSet<String> = inodes
+        .iter()
+        .map(|inode| format!("socket:[{inode}]"))
+        .collect();
+    for entry in std::fs::read_dir("/proc").ok()?.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|n| n.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let Ok(fds) = std::fs::read_dir(entry.path().join("fd")) else {
+            continue;
+        };
+        for fd in fds.flatten() {
+            if std::fs::read_link(fd.path())
+                .is_ok_and(|link| targets.contains(link.to_string_lossy().as_ref()))
+            {
+                return Some(pid);
+            }
+        }
+    }
+    None
+}
+
+/// Last `*.service` segment of a cgroup path: `0::/system.slice/dnsmasq.service`
+/// on v2, `1:name=systemd:/system.slice/dnsmasq.service` on v1.
+#[cfg(any(target_os = "linux", test))]
+fn systemd_unit_from_cgroup(cgroup: &str) -> Option<String> {
+    cgroup
+        .lines()
+        .filter_map(|line| line.rsplit(':').next())
+        .flat_map(|path| path.split('/'))
+        .rfind(|segment| segment.ends_with(".service"))
+        .map(str::to_string)
 }
 
 fn is_port_53(bind_addr: &str) -> bool {
@@ -2118,24 +2282,106 @@ mod tests {
         );
     }
 
+    fn holder(comm: &str, unit: Option<&str>) -> Port53Holder {
+        Port53Holder {
+            comm: comm.to_string(),
+            pid: 1234,
+            unit: unit.map(str::to_string),
+        }
+    }
+
+    fn in_use(holder: Option<&Port53Holder>) -> String {
+        port53_advisory("0.0.0.0:53", std::io::ErrorKind::AddrInUse, holder)
+            .expect("should advise on port 53")
+    }
+
     #[test]
     fn try_port53_advisory_addr_in_use() {
         let err = std::io::Error::from(std::io::ErrorKind::AddrInUse);
         let msg = try_port53_advisory("0.0.0.0:53", &err).expect("should advise on port 53");
         assert!(msg.contains("cannot bind to"));
+    }
+
+    #[test]
+    fn port53_advisory_unknown_holder_does_not_guess() {
+        let msg = in_use(None);
         assert!(msg.contains("already in use"));
-        assert!(msg.contains("numa install"));
-        assert!(msg.contains("bind_addr"));
+        assert!(msg.contains(WHO_OWNS_53));
+        assert!(msg.contains(PORT53_RECIPE_URL));
+        assert!(!msg.contains("typically systemd-resolved"));
+    }
+
+    #[test]
+    fn port53_advisory_names_holder_and_its_unit() {
+        let msg = in_use(Some(&holder("dnsmasq", Some("dnsmasq.service"))));
+        assert!(msg.contains("held by dnsmasq (pid 1234)"));
+        assert!(msg.contains("sudo systemctl disable --now dnsmasq.service"));
+        assert!(msg.contains("numa config edit"));
+    }
+
+    /// The #299 case: killing the holder is futile, and disabling the
+    /// supervisor is not advice numa should give.
+    #[test]
+    fn port53_advisory_defers_to_recipe_for_supervised_holder() {
+        let msg = in_use(Some(&holder("dnsmasq", Some("NetworkManager.service"))));
+        assert!(msg.contains("started by NetworkManager.service"));
+        assert!(msg.contains("NetworkManager.service restarts it"));
+        assert!(msg.contains(PORT53_RECIPE_URL));
+        assert!(!msg.contains("disable --now"));
+    }
+
+    #[test]
+    fn port53_advisory_unsupervised_holder_gets_no_systemctl_advice() {
+        let msg = in_use(Some(&holder("unbound", None)));
+        assert!(msg.contains("held by unbound (pid 1234)"));
+        assert!(msg.contains("Stop unbound first"));
+        assert!(!msg.contains("systemctl"));
+    }
+
+    /// comm is truncated to 15 bytes, so the match is on the prefix.
+    #[test]
+    fn port53_advisory_offers_install_only_for_systemd_resolved() {
+        let msg = in_use(Some(&holder(
+            "systemd-resolve",
+            Some("systemd-resolved.service"),
+        )));
+        assert!(msg.contains("Numa can free it"));
+        assert!(msg.contains("sudo numa install"));
+        assert!(!msg.contains("disable --now"));
     }
 
     #[test]
     fn try_port53_advisory_permission_denied() {
         let err = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
         let msg = try_port53_advisory("0.0.0.0:53", &err).expect("should advise on port 53");
-        assert!(msg.contains("cannot bind to"));
         assert!(msg.contains("permission denied"));
-        assert!(msg.contains("numa install"));
-        assert!(msg.contains("bind_addr"));
+        assert!(msg.contains(ELEVATE));
+        assert!(!msg.contains("numa install"));
+    }
+
+    #[test]
+    fn udp_port_inodes_matches_only_the_wanted_port() {
+        let proc_net_udp = "\
+  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+  982: 3500007F:0035 00000000:0000 07 00000000:00000000 00:00000000  00000000   101        0 27503
+  983: 00000000:0044 00000000:0000 07 00000000:00000000 00:00000000  00000000     0        0 19422
+";
+        let inodes = udp_port_inodes(proc_net_udp, 53);
+        assert_eq!(inodes, std::collections::HashSet::from([27503]));
+    }
+
+    #[test]
+    fn systemd_unit_from_cgroup_reads_both_hierarchies() {
+        assert_eq!(
+            systemd_unit_from_cgroup("0::/system.slice/dnsmasq.service\n").as_deref(),
+            Some("dnsmasq.service")
+        );
+        assert_eq!(
+            systemd_unit_from_cgroup("1:name=systemd:/system.slice/NetworkManager.service\n")
+                .as_deref(),
+            Some("NetworkManager.service")
+        );
+        assert!(systemd_unit_from_cgroup("0::/user.slice/session-3.scope\n").is_none());
     }
 
     #[test]

--- a/tests/docker/smoke-port53.sh
+++ b/tests/docker/smoke-port53.sh
@@ -7,10 +7,14 @@
 # 0.0.0.0:53). Verifies:
 #   - process exits with code 1
 #   - stderr contains the advisory ("cannot bind to")
-#   - stderr contains both fix suggestions ("numa install", "bind_addr")
+#   - the advisory names the holder it found in procfs, rather than
+#     guessing systemd-resolved (issue #299)
+#   - it does not claim `numa install` frees a port numa cannot free
+#   - it still offers the spare-port alternative and the recipe link
 #
 # This is the end-to-end test for the fix in:
-#   src/main.rs — AddrInUse match arm → eprint advisory + process::exit(1)
+#   src/system_dns.rs — port53_holder() + port53_advisory()
+#   src/serve.rs      — bind_udp_listeners() → eprint advisory + exit(1)
 #
 # No systemd-resolved needed — the conflict is simulated by a Python
 # UDP socket held open before numa starts.
@@ -116,16 +120,31 @@ else
     fail "advisory printed to stderr" "stderr did not contain 'cannot bind to'"
 fi
 
-if echo "$OUTPUT" | grep -q "numa install"; then
-    pass "advisory offers 'sudo numa install'"
+if echo "$OUTPUT" | grep -q "held by python3"; then
+    pass "advisory names the holder process"
 else
-    fail "advisory offers 'sudo numa install'" "not found in output"
+    fail "advisory names the holder process" "'held by python3' not found in output"
+fi
+
+# numa install cannot free a port held by anything but systemd-resolved,
+# so offering it here is the misinformation issue #299 reported.
+if echo "$OUTPUT" | grep -q "numa install"; then
+    fail "advisory does not offer 'numa install' for a holder it cannot free" \
+         "output still suggests numa install"
+else
+    pass "advisory does not offer 'numa install' for a holder it cannot free"
 fi
 
 if echo "$OUTPUT" | grep -q "bind_addr"; then
     pass "advisory offers non-privileged port alternative"
 else
     fail "advisory offers non-privileged port alternative" "'bind_addr' not found in output"
+fi
+
+if echo "$OUTPUT" | grep -q "recipes/port-53.md"; then
+    pass "advisory links the port-53 recipe"
+else
+    fail "advisory links the port-53 recipe" "recipe URL not found in output"
 fi
 
 echo


### PR DESCRIPTION
Closes #299 (first half).

## What was wrong

The port-53 advisory guessed the holder. On the reporter's machine it was dnsmasq under NetworkManager, and both remedies the message offered were wrong for it:

- `sudo numa install` cannot free port 53 from anything except systemd-resolved.
- "create `/root/.config/numa/numa.toml`" points at a path `load_config` never reaches once `/var/lib/numa/numa.toml` exists, i.e. on any machine that ran install.

He killed dnsmasq, NetworkManager restarted it, and a stranger's three-step recipe got "Too complex."

## What this does

Resolve the holder from procfs (`/proc/net/udp{,6}` inode → `/proc/*/fd` → `comm`, plus the cgroup's `*.service` segment) and pick the remedy from it:

| Holder | Remedy |
|---|---|
| systemd-resolved | `sudo numa install` (it genuinely frees the port) |
| its own unit (`dnsmasq.service`) | `systemctl disable --now dnsmasq.service` |
| spawned by another unit (NetworkManager) | says killing it will not help, links the recipe |
| unknown / non-Linux | how to find out, no guessing |

`systemctl disable` is only ever suggested when the unit stem matches `comm`, so numa never tells anyone to disable NetworkManager.

Before:

```
Numa — cannot bind to 0.0.0.0:53: port 53 is already in use.

  Another process is already bound to port 53. On Linux this is
  typically systemd-resolved; on Windows, the DNS Client service.
```

After, same machine:

```
Numa — cannot bind to 0.0.0.0:53: port 53 is held by dnsmasq (pid 3627).

  Numa needs port 53 to be the system resolver, and will not stop or
  reconfigure another resolver for you. Stop dnsmasq first:

    https://github.com/razvandimescu/numa/blob/main/recipes/port-53.md
```

Also fixes the EACCES branch, which never mentioned `sudo numa` — the actual answer when you hit it.

Adds `recipes/port-53.md` covering systemd-resolved, standalone dnsmasq, dnsmasq under NetworkManager, unbound/named/pihole-FTL, and running alongside on a spare port.

## Notes

- Detection needs root to read another user's fds. That holds on the two paths that print advisories (`sudo numa`, `sudo numa install`); the `DynamicUser=yes` daemon gets `None` and the generic text.
- Docker's default caps drop `CAP_SYS_PTRACE`, so detection degrades inside plain containers when the holder runs as a different user. Real root is unaffected.

## Testing

- New inline tests: procfs parsers from fixtures, one per advisory branch. The parser is a pure `&str` function so no procfs is needed.
- `tests/docker/smoke-port53.sh` extended: asserts the holder is named, that `numa install` is *not* offered for a holder numa cannot free, and that the recipe is linked. Passes.
- Verified end to end against real dnsmasq 2.90 in a Debian container: correct pid, correct branch.

Install still reports success while crashlooping on a busy port. That is the other half of #299 and lands in a follow-up PR on top of this one.