### PR TITLE
fix(install): refuse an install that can only crashloop (#299)

### DIFF
--- a/src/system_dns.rs
+++ b/src/system_dns.rs
@@ -112,7 +112,7 @@ const SPARE_PORT: &str = "\n  Just testing? Run numa alongside it on a spare por
      dig @127.0.0.1 -p 5354 example.com\n";
 
 /// Process holding port 53, as far as procfs can tell.
-pub struct Port53Holder {
+pub struct PortHolder {
     pub comm: String,
     pub pid: u32,
     /// systemd unit owning the process cgroup: either the holder's own unit
@@ -121,7 +121,7 @@ pub struct Port53Holder {
     pub unit: Option<String>,
 }
 
-impl Port53Holder {
+impl PortHolder {
     fn is_systemd_resolved(&self) -> bool {
         // /proc/<pid>/comm truncates at 15 bytes: "systemd-resolve".
         self.comm.starts_with("systemd-resolve")
@@ -142,7 +142,7 @@ pub fn try_port53_advisory(bind_addr: &str, err: &std::io::Error) -> Option<Stri
         return None;
     }
     let holder = match err.kind() {
-        std::io::ErrorKind::AddrInUse => port53_holder(),
+        std::io::ErrorKind::AddrInUse => port_holder(53),
         _ => None,
     };
     port53_advisory(bind_addr, err.kind(), holder.as_ref())
@@ -151,7 +151,7 @@ pub fn try_port53_advisory(bind_addr: &str, err: &std::io::Error) -> Option<Stri
 fn port53_advisory(
     bind_addr: &str,
     kind: std::io::ErrorKind,
-    holder: Option<&Port53Holder>,
+    holder: Option<&PortHolder>,
 ) -> Option<String> {
     let (title, body) = match kind {
         std::io::ErrorKind::AddrInUse => (in_use_title(holder), in_use_body(holder)),
@@ -172,7 +172,7 @@ fn port53_advisory(
     ))
 }
 
-fn in_use_title(holder: Option<&Port53Holder>) -> String {
+fn in_use_title(holder: Option<&PortHolder>) -> String {
     let Some(holder) = holder else {
         return "port 53 is already in use".to_string();
     };
@@ -183,7 +183,7 @@ fn in_use_title(holder: Option<&Port53Holder>) -> String {
     }
 }
 
-fn in_use_body(holder: Option<&Port53Holder>) -> String {
+fn in_use_body(holder: Option<&PortHolder>) -> String {
     let Some(holder) = holder else {
         return format!(
             "  Another resolver already owns it. Find out which:\n\n    {WHO_OWNS_53}\n\n  \
@@ -192,12 +192,16 @@ fn in_use_body(holder: Option<&Port53Holder>) -> String {
              will not reconfigure it for you.\n\n    {PORT53_RECIPE_URL}\n"
         );
     };
+    format!("{}{SPARE_PORT}", in_use_remedy(holder))
+}
+
+fn in_use_remedy(holder: &PortHolder) -> String {
     if holder.is_systemd_resolved() {
         // install writes DNSStubListener=no, so this is the one numa can free.
         return "  Numa can free it. Install as the system resolver:\n\n    sudo numa install\n"
             .to_string();
     }
-    let remedy = match (holder.owned_unit(), holder.unit.as_deref()) {
+    match (holder.owned_unit(), holder.unit.as_deref()) {
         (Some(unit), _) => format!(
             "  Numa needs port 53 to be the system resolver, and will not stop or\n  \
              reconfigure another resolver for you. Free the port first:\n\n    \
@@ -213,19 +217,18 @@ fn in_use_body(holder: Option<&Port53Holder>) -> String {
              reconfigure another resolver for you. Stop {} first:\n\n    {PORT53_RECIPE_URL}\n",
             holder.comm
         ),
-    };
-    format!("{remedy}{SPARE_PORT}")
+    }
 }
 
 /// Identify the process on port 53. Reading other users' fds needs root, which
 /// holds on the paths that print advisories (`sudo numa`, `numa install`); the
 /// unprivileged daemon gets `None` and the generic text.
 #[cfg(target_os = "linux")]
-pub fn port53_holder() -> Option<Port53Holder> {
+pub fn port_holder(port: u16) -> Option<PortHolder> {
     let mut inodes = std::collections::HashSet::new();
     for path in ["/proc/net/udp", "/proc/net/udp6"] {
         if let Ok(text) = std::fs::read_to_string(path) {
-            inodes.extend(udp_port_inodes(&text, 53));
+            inodes.extend(udp_port_inodes(&text, port));
         }
     }
     if inodes.is_empty() {
@@ -233,7 +236,7 @@ pub fn port53_holder() -> Option<Port53Holder> {
     }
     let pid = pid_owning_socket(&inodes)?;
     let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
-    Some(Port53Holder {
+    Some(PortHolder {
         comm: comm.trim().to_string(),
         pid,
         unit: std::fs::read_to_string(format!("/proc/{pid}/cgroup"))
@@ -243,7 +246,7 @@ pub fn port53_holder() -> Option<Port53Holder> {
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn port53_holder() -> Option<Port53Holder> {
+pub fn port_holder(_port: u16) -> Option<PortHolder> {
     None
 }
 
@@ -1280,6 +1283,71 @@ fn unsupported_os_err(op: &str) -> String {
     )
 }
 
+/// Refuse an install that can only crashloop.
+///
+/// `systemctl restart` returns 0 for a `Type=simple` unit that dies
+/// milliseconds later, so a busy port otherwise reaches the success banner
+/// with `/etc/resolv.conf` already repointed at a listener that never comes
+/// up. Runs before anything on the system changes (issue #299).
+///
+/// Linux only: identifying the holder is what makes this safe, and macOS
+/// already unloads the daemon when its readiness probe fails.
+#[cfg(target_os = "linux")]
+fn preflight_bind(config_path: &str) -> Result<(), String> {
+    // A running numa owns the port itself — this is a re-install/upgrade.
+    if is_unit_active("numa") {
+        return Ok(());
+    }
+    let config = crate::config::load_config(config_path)
+        .map_err(|e| format!("failed to read config: {e}"))?
+        .config;
+
+    for addr in &config.server.bind_addr {
+        match std::net::UdpSocket::bind(addr) {
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                let port = addr.parse::<SocketAddr>().map(|a| a.port()).unwrap_or(53);
+                let holder = port_holder(port);
+                // systemd-resolved is the one holder install actually frees
+                // (DNSStubListener=no); numa itself means a stale process.
+                if holder
+                    .as_ref()
+                    .is_some_and(|h| h.is_systemd_resolved() || h.comm == "numa")
+                {
+                    continue;
+                }
+                return Err(install_conflict(addr, holder.as_ref()));
+            }
+            _ => continue,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn install_conflict(addr: &str, holder: Option<&PortHolder>) -> String {
+    let port = addr.parse::<SocketAddr>().map(|a| a.port()).unwrap_or(53);
+    let generic =
+        || format!("  Find out what owns it:\n\n    {WHO_OWNS_53}\n\n    {PORT53_RECIPE_URL}\n");
+    // in_use_remedy speaks in terms of port 53, which the advisory path
+    // guarantees but a custom bind_addr does not.
+    let (what, remedy) = match holder {
+        Some(holder) if port == 53 => (
+            format!("{addr} is held by {} (pid {})", holder.comm, holder.pid),
+            in_use_remedy(holder),
+        ),
+        Some(holder) => (
+            format!("{addr} is held by {} (pid {})", holder.comm, holder.pid),
+            generic(),
+        ),
+        None => (format!("{addr} is already in use"), generic()),
+    };
+    let palette = crate::palette::get();
+    format!(
+        "  {}Aborted{}: {what}.\n\n  Nothing was installed and your DNS settings were not changed.\n\n{remedy}\n",
+        palette.warning, palette.reset
+    )
+}
+
 /// Install Numa as a system service that starts on boot and auto-restarts.
 ///
 /// `skip_system_dns = true` registers the service but leaves the host's DNS
@@ -1287,6 +1355,14 @@ fn unsupported_os_err(op: &str) -> String {
 /// operator is responsible for routing traffic to numa themselves — front-end
 /// proxy, browser DoH, etc.
 pub fn install_service(skip_system_dns: bool) -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    if let Err(conflict) = preflight_bind("numa.toml") {
+        // Printed rather than returned: the message is a block, and main
+        // renders a Result error as escaped Debug. Mirrors serve.rs.
+        eprint!("{conflict}");
+        std::process::exit(1);
+    }
+
     #[cfg(target_os = "macos")]
     let result = install_service_macos(skip_system_dns);
     #[cfg(target_os = "linux")]
@@ -1669,9 +1745,9 @@ fn backup_path_linux() -> std::path::PathBuf {
 }
 
 #[cfg(target_os = "linux")]
-fn is_systemd_resolved_active() -> bool {
+fn is_unit_active(unit: &str) -> bool {
     std::process::Command::new("systemctl")
-        .args(["is-active", "--quiet", "systemd-resolved"])
+        .args(["is-active", "--quiet", unit])
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
@@ -1680,7 +1756,7 @@ fn is_systemd_resolved_active() -> bool {
 #[cfg(target_os = "linux")]
 fn install_linux() -> Result<(), String> {
     // Detect systemd-resolved — direct resolv.conf manipulation won't persist
-    if is_systemd_resolved_active() {
+    if is_unit_active("systemd-resolved") {
         let resolved_dir = std::path::Path::new("/etc/systemd/resolved.conf.d");
         std::fs::create_dir_all(resolved_dir)
             .map_err(|e| format!("failed to create {}: {}", resolved_dir.display(), e))?;
@@ -2282,15 +2358,15 @@ mod tests {
         );
     }
 
-    fn holder(comm: &str, unit: Option<&str>) -> Port53Holder {
-        Port53Holder {
+    fn holder(comm: &str, unit: Option<&str>) -> PortHolder {
+        PortHolder {
             comm: comm.to_string(),
             pid: 1234,
             unit: unit.map(str::to_string),
         }
     }
 
-    fn in_use(holder: Option<&Port53Holder>) -> String {
+    fn in_use(holder: Option<&PortHolder>) -> String {
         port53_advisory("0.0.0.0:53", std::io::ErrorKind::AddrInUse, holder)
             .expect("should advise on port 53")
     }
@@ -2348,6 +2424,23 @@ mod tests {
         assert!(msg.contains("Numa can free it"));
         assert!(msg.contains("sudo numa install"));
         assert!(!msg.contains("disable --now"));
+    }
+
+    /// The abort has to say what did *not* happen: from the outside a failed
+    /// install is indistinguishable from a half-applied one.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn install_conflict_states_that_nothing_changed() {
+        let msg = install_conflict(
+            "0.0.0.0:53",
+            Some(&holder("dnsmasq", Some("dnsmasq.service"))),
+        );
+        assert!(msg.contains("held by dnsmasq (pid 1234)"));
+        assert!(msg.contains("Nothing was installed"));
+        assert!(msg.contains("DNS settings were not"));
+        assert!(msg.contains("sudo systemctl disable --now dnsmasq.service"));
+        // Moving numa to a spare port is not a remedy for `numa install`.
+        assert!(!msg.contains("Just testing"));
     }
 
     #[test]

--- a/tests/docker/install-systemd.sh
+++ b/tests/docker/install-systemd.sh
@@ -11,6 +11,9 @@
 #      the CA fingerprint — users' browser-installed CA trust survives.
 #   C. Install from a 0700 source directory stages the binary under
 #      /usr/local/bin/numa and the service starts from there.
+#   D. With dnsmasq holding :53, install aborts before writing the unit or
+#      rewriting resolv.conf, names the holder, and works once it is freed
+#      (issue #299).
 #
 # First run is slow (~5-10 min): image pull + apt + cold cargo build.
 # Subsequent runs reuse cached docker volumes for cargo + target (~30s).
@@ -211,6 +214,61 @@ if [ "${NUMA_INSIDE:-}" = "1" ]; then
     assert_nonroot
     assert_dns_works
 
+    # ---- Scenario D ----
+    # Issue #299: dnsmasq owns :53, so the install can only ever crashloop.
+    # It must abort before touching anything rather than print "Numa is live".
+    printf "\n=== Scenario D: install aborts when another resolver holds port 53 ===\n"
+    reset_state
+    resolv_before=$(cat /etc/resolv.conf)
+    systemctl start dnsmasq.service
+    sleep 1
+    if ! ss -lnup 'sport = :53' | grep -q dnsmasq; then
+        fail "setup: dnsmasq did not take port 53"
+    fi
+
+    "$NUMA" install >/tmp/installD.log 2>&1
+    rc=$?
+
+    if [ "$rc" -ne 0 ]; then
+        pass "install exits nonzero (rc=$rc)"
+    else
+        fail "install reported success while dnsmasq holds :53"
+    fi
+    if grep -q "held by dnsmasq" /tmp/installD.log; then
+        pass "abort names the holder"
+    else
+        fail "abort does not name the holder" "$(tail -5 /tmp/installD.log)"
+    fi
+    if grep -q "Numa is live" /tmp/installD.log; then
+        fail "abort still printed the success banner"
+    else
+        pass "no success banner"
+    fi
+    if [ "$(cat /etc/resolv.conf)" = "$resolv_before" ]; then
+        pass "/etc/resolv.conf untouched"
+    else
+        fail "/etc/resolv.conf was rewritten by an install that could not work"
+    fi
+    if [ -f /etc/systemd/system/numa.service ]; then
+        fail "unit file written despite abort"
+    else
+        pass "no unit file written"
+    fi
+    if grep -q "dnsmasq.service" /tmp/installD.log; then
+        pass "abort suggests disabling the holder's own unit"
+    else
+        fail "abort does not name the unit to disable"
+    fi
+
+    # Freeing the port makes the same command work.
+    systemctl stop dnsmasq.service
+    "$NUMA" install >/tmp/installD2.log 2>&1 || { fail "install failed after freeing :53"; tail -20 /tmp/installD2.log; }
+    wait_active || true
+    assert_dns_works
+
+    reset_state
+    systemctl stop dnsmasq.service 2>/dev/null || true
+
     reset_state
     rm -rf /home/builder
     echo
@@ -241,12 +299,13 @@ RUN apt-get update -qq && apt-get install -y -qq \
       systemd systemd-sysv systemd-resolved \
       ca-certificates curl build-essential \
       pkg-config libssl-dev cmake make perl \
-      dnsutils iproute2 openssl \
+      dnsutils iproute2 openssl dnsmasq \
     && rm -rf /var/lib/apt/lists/* \
     && for u in dev-hugepages.mount sys-fs-fuse-connections.mount \
                 systemd-logind.service getty.target console-getty.service; do \
          systemctl mask $u; \
-       done
+       done \
+    && systemctl disable dnsmasq.service
 STOPSIGNAL SIGRTMIN+3
 CMD ["/lib/systemd/systemd"]
 DOCKERFILE


### PR DESCRIPTION
Closes #299 (second half). Stacked on #382 — review that first; this diff is the two commits after it.

## What was wrong

On a box where dnsmasq owns port 53, `sudo numa install` prints:

```
  Saved /etc/resolv.conf to /root/.numa/original-resolv.conf
  Set /etc/resolv.conf -> nameserver 127.0.0.1
  Service installed and started (auto-starts on boot, restarts if killed)

Numa is live — all DNS on this machine now resolves through it.
```

None of it is true. numa is failing EADDRINUSE under `Restart=always`; `systemctl restart` returns 0 for a `Type=simple` unit that dies milliseconds later, so nothing catches it. With `RestartSec=2` the unit hits systemd's 5-starts-per-10s limit and sits `failed` across reboot.

Severity depends on how the holder is bound:

- dnsmasq on the wildcard or loopback (the NetworkManager default): DNS keeps working through dnsmasq, so the install is a silent no-op wearing a success banner.
- dnsmasq pinned to one interface address: nothing listens on 127.0.0.1 and name resolution fails outright. The installer leaves the machine worse than it found it.

## What this does

Test-bind each `bind_addr` from `data_dir()/numa.toml` (the config the daemon binds with, not the caller's cwd or sudo'd home) at the top of `install_service()`, before the unit file, before `systemctl enable`, before the resolv.conf rewrite.

Proceeds when:
- the port is free
- the holder is `numa.service` itself (re-install or upgrade), by cgroup, so a foreground `sudo numa` still aborts
- systemd-resolved holds it and install will rewrite system DNS (`DNSStubListener=no`); with `--no-system-dns` resolved keeps the port, so that aborts too

Otherwise aborts:

```
  Aborted: 0.0.0.0:53 is held by dnsmasq (pid 4385).

  Nothing was installed and your DNS settings were not changed.

  Numa needs port 53 to be the system resolver, and will not stop or
  reconfigure another resolver for you. Stop dnsmasq first:

    https://github.com/razvandimescu/numa/blob/main/recipes/port-53.md
```

"Nothing was installed and your DNS settings were not changed" is the load-bearing line — from outside the process a failed install is indistinguishable from a half-applied one.

No override flag: there is no configuration in which continuing produces a working install, so a flag would only exist to reach the broken state deliberately.

## Scope

Linux only. macOS already polls the API port and `launchctl bootout`s on failure, so aborting is the existing house policy and Linux was the outlier. Windows installs its NRPT rule and then swallows a start failure into `Ok(())` — same bug class, but the right fix there is extracting the macOS readiness probe into a shared `wait_for_api(port)`, which I'd rather do in its own PR since it also catches config errors, cert failures, and the check-to-start race that a preflight cannot.

## Testing

`tests/docker/install-systemd.sh` gains scenario D (dnsmasq holds :53):

```
=== Scenario D: install aborts when another resolver holds port 53 ===
  PASS: install exits nonzero (rc=1)
  PASS: abort names the holder
  PASS: no success banner
  PASS: /etc/resolv.conf untouched
  PASS: no unit file written
  PASS: abort suggests disabling the holder's own unit
  PASS: DNS resolves on :53 (A record returned)   <- after freeing the port
```

Scenarios A/B/C still pass, which is the regression that mattered: that container runs systemd-resolved, so a preflight that could not tell resolved from dnsmasq would have broken every normal install.

Scenario D also covers `numa install --no-system-dns` with systemd-resolved on :53:

```
  PASS: install --no-system-dns aborts on resolved's stub
```

That case restarts resolved first to work around a bug on main, not introduced here: `numa uninstall` restarts resolved while numa still holds :53, so resolved logs "Turning off local DNS stub support" and never retries. On a stock Ubuntu resolv.conf (127.0.0.53) that leaves DNS dead after uninstall. Separate PR.
